### PR TITLE
WIP: Conversion

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -158,7 +158,7 @@ boot_trailer_sz(uint8_t min_write_sz)
 #endif
            /* swap_type + copy_done + image_ok + swap_size */
            BOOT_MAX_ALIGN * 4                     +
-           BOOT_MAGIC_SZ;
+           (uint32_t)BOOT_MAGIC_SZ;
 }
 
 int
@@ -190,7 +190,7 @@ boot_status_off(const struct flash_area *fap)
 static inline uint32_t
 boot_magic_off(const struct flash_area *fap)
 {
-    return fap->fa_size - BOOT_MAGIC_SZ;
+    return fap->fa_size - (uint32_t)BOOT_MAGIC_SZ;
 }
 
 static inline uint32_t
@@ -242,7 +242,7 @@ boot_read_swap_state(const struct flash_area *fap,
     if (rc == 1) {
         state->magic = BOOT_MAGIC_UNSET;
     } else {
-        state->magic = boot_magic_decode(magic);
+        state->magic = (uint8_t)boot_magic_decode(magic);
     }
 
     off = boot_swap_info_off(fap);
@@ -269,7 +269,7 @@ boot_read_swap_state(const struct flash_area *fap,
     if (rc == 1) {
         state->copy_done = BOOT_FLAG_UNSET;
     } else {
-        state->copy_done = boot_flag_decode(state->copy_done);
+        state->copy_done = (uint8_t)boot_flag_decode(state->copy_done);
     }
 
     off = boot_image_ok_off(fap);
@@ -281,7 +281,7 @@ boot_read_swap_state(const struct flash_area *fap,
     if (rc == 1) {
         state->image_ok = BOOT_FLAG_UNSET;
     } else {
-        state->image_ok = boot_flag_decode(state->image_ok);
+        state->image_ok = (uint8_t)boot_flag_decode(state->image_ok);
     }
 
     return 0;
@@ -296,7 +296,7 @@ boot_read_swap_state_by_id(int flash_area_id, struct boot_swap_state *state)
     const struct flash_area *fap;
     int rc;
 
-    rc = flash_area_open(flash_area_id, &fap);
+    rc = flash_area_open((uint8_t)flash_area_id, &fap);
     if (rc != 0) {
         return BOOT_EFLASH;
     }

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -159,7 +159,7 @@ _Static_assert(BOOT_IMAGE_NUMBER > 0, "Invalid value for BOOT_IMAGE_NUMBER");
 #define BOOT_SET_SWAP_INFO(swap_info, image, type)  {                          \
                                                     assert((image) < 0xF);     \
                                                     assert((type)  < 0xF);     \
-                                                    (swap_info) = (image) << 4 \
+                                                    (swap_info) = (uint8_t)((image) << 4) \
                                                                 | (type);      \
                                                     }
 
@@ -282,7 +282,7 @@ static inline bool boot_u16_safe_add(uint16_t *dest, uint16_t a, uint16_t b)
     if (tmp > UINT16_MAX) {
         return false;
     } else {
-        *dest = tmp;
+        *dest = (uint16_t)tmp;
         return true;
     }
 }

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -104,7 +104,7 @@ key_unwrap(uint8_t *wrapped, uint8_t *enckey)
                 B[k] = A[k];
                 B[8 + k] = enckey[((i-1) * 8) + k];
             }
-            B[7] ^= 2 * j + i;
+            B[7] ^= (uint8_t)(2 * j + i);
             if (tc_aes_decrypt((uint8_t *)&B, (uint8_t *)&B, &aes) == 0) {
                 return -1;
             }
@@ -116,7 +116,7 @@ key_unwrap(uint8_t *wrapped, uint8_t *enckey)
     }
 
     for (i = 0, k = 0; i < 8; i++) {
-        k |= A[i] ^ 0xa6;
+        k |= (int8_t)(A[i] ^ 0xa6);
     }
     if (k) {
         return -1;
@@ -233,7 +233,7 @@ boot_enc_load(struct enc_key_data *enc_state, int image_index,
     if (rc < 0) {
         return rc;
     }
-    slot = rc;
+    slot = (uint8_t)rc;
 
     /* Already loaded... */
     if (enc_state[slot].valid) {

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -279,7 +279,7 @@ bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
             if (rc) {
                 return rc;
             }
-            key_id = bootutil_find_key(buf, len);
+            key_id = bootutil_find_key(buf, (uint8_t)len);
             /*
              * The key may not be found, which is acceptable.  There
              * can be multiple signatures, each preceded by a key.
@@ -297,7 +297,7 @@ bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
             if (rc) {
                 return -1;
             }
-            rc = bootutil_verify_sig(hash, sizeof(hash), buf, len, key_id);
+            rc = bootutil_verify_sig(hash, sizeof(hash), buf, len, (uint8_t)key_id);
             if (rc == 0) {
                 valid_signature = 1;
             }

--- a/boot/bootutil/src/tlv.c
+++ b/boot/bootutil/src/tlv.c
@@ -71,7 +71,7 @@ bootutil_tlv_iter_begin(struct image_tlv_iter *it, const struct image_header *hd
     it->prot_end = off_ + it->hdr->ih_protect_tlv_size;
     it->tlv_end = off_ + it->hdr->ih_protect_tlv_size + info.it_tlv_tot;
     // position on first TLV
-    it->tlv_off = off_ + sizeof(info);
+    it->tlv_off = off_ + (uint32_t)sizeof(info);
     return 0;
 }
 
@@ -100,7 +100,7 @@ bootutil_tlv_iter_next(struct image_tlv_iter *it, uint32_t *off, uint16_t *len,
 
     while (it->tlv_off < it->tlv_end) {
         if (it->hdr->ih_protect_tlv_size > 0 && it->tlv_off == it->prot_end) {
-            it->tlv_off += sizeof(struct image_tlv_info);
+            it->tlv_off += (uint32_t)sizeof(struct image_tlv_info);
         }
 
         rc = flash_area_read(it->fap, it->tlv_off, &tlv, sizeof tlv);
@@ -117,13 +117,13 @@ bootutil_tlv_iter_next(struct image_tlv_iter *it, uint32_t *off, uint16_t *len,
             if (type != NULL) {
                 *type = tlv.it_type;
             }
-            *off = it->tlv_off + sizeof(tlv);
+            *off = it->tlv_off + (uint32_t)sizeof(tlv);
             *len = tlv.it_len;
-            it->tlv_off += sizeof(tlv) + tlv.it_len;
+            it->tlv_off += (uint32_t)sizeof(tlv) + tlv.it_len;
             return 0;
         }
 
-        it->tlv_off += sizeof(tlv) + tlv.it_len;
+        it->tlv_off += (uint32_t)sizeof(tlv) + tlv.it_len;
     }
 
     return 1;

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -22,6 +22,7 @@ fn main() {
     let multiimage = env::var("CARGO_FEATURE_MULTIIMAGE").is_ok();
 
     let mut conf = cc::Build::new();
+    let mut cryptconf = cc::Build::new();
     conf.define("__BOOTSIM__", None);
     conf.define("MCUBOOT_HAVE_LOGGING", None);
     conf.define("MCUBOOT_USE_FLASH_AREA_GET_SECTORS", None);
@@ -57,51 +58,56 @@ fn main() {
         conf.define("MCUBOOT_USE_MBED_TLS", None);
 
         conf.include("../../ext/mbedtls/include");
-        conf.file("../../ext/mbedtls/library/sha256.c");
+        cryptconf.include("../../ext/mbedtls/include");
+        cryptconf.file("../../ext/mbedtls/library/sha256.c");
         conf.file("csupport/keys.c");
 
-        conf.file("../../ext/mbedtls/library/rsa.c");
-        conf.file("../../ext/mbedtls/library/bignum.c");
-        conf.file("../../ext/mbedtls/library/platform.c");
-        conf.file("../../ext/mbedtls/library/platform_util.c");
-        conf.file("../../ext/mbedtls/library/asn1parse.c");
+        cryptconf.file("../../ext/mbedtls/library/rsa.c");
+        cryptconf.file("../../ext/mbedtls/library/bignum.c");
+        cryptconf.file("../../ext/mbedtls/library/platform.c");
+        cryptconf.file("../../ext/mbedtls/library/platform_util.c");
+        cryptconf.file("../../ext/mbedtls/library/asn1parse.c");
     } else if sig_ecdsa {
         conf.define("MCUBOOT_SIGN_EC256", None);
         conf.define("MCUBOOT_USE_TINYCRYPT", None);
 
         if !enc_kw {
             conf.include("../../ext/mbedtls-asn1/include");
+            cryptconf.include("../../ext/mbedtls-asn1/include");
         }
         conf.include("../../ext/tinycrypt/lib/include");
+        cryptconf.include("../../ext/tinycrypt/lib/include");
 
         conf.file("csupport/keys.c");
 
-        conf.file("../../ext/tinycrypt/lib/source/utils.c");
-        conf.file("../../ext/tinycrypt/lib/source/sha256.c");
-        conf.file("../../ext/tinycrypt/lib/source/ecc.c");
-        conf.file("../../ext/tinycrypt/lib/source/ecc_dsa.c");
-        conf.file("../../ext/tinycrypt/lib/source/ecc_platform_specific.c");
+        cryptconf.file("../../ext/tinycrypt/lib/source/utils.c");
+        cryptconf.file("../../ext/tinycrypt/lib/source/sha256.c");
+        cryptconf.file("../../ext/tinycrypt/lib/source/ecc.c");
+        cryptconf.file("../../ext/tinycrypt/lib/source/ecc_dsa.c");
+        cryptconf.file("../../ext/tinycrypt/lib/source/ecc_platform_specific.c");
 
-        conf.file("../../ext/mbedtls-asn1/src/platform_util.c");
-        conf.file("../../ext/mbedtls-asn1/src/asn1parse.c");
+        cryptconf.file("../../ext/mbedtls-asn1/src/platform_util.c");
+        cryptconf.file("../../ext/mbedtls-asn1/src/asn1parse.c");
     } else if sig_ed25519 {
         conf.define("MCUBOOT_SIGN_ED25519", None);
         conf.define("MCUBOOT_USE_MBED_TLS", None);
 
         conf.include("../../ext/mbedtls/include");
-        conf.file("../../ext/mbedtls/library/sha256.c");
-        conf.file("../../ext/mbedtls/library/sha512.c");
+        cryptconf.include("../../ext/mbedtls/include");
+        cryptconf.file("../../ext/mbedtls/library/sha256.c");
+        cryptconf.file("../../ext/mbedtls/library/sha512.c");
         conf.file("csupport/keys.c");
-        conf.file("../../ext/fiat/src/curve25519.c");
-        conf.file("../../ext/mbedtls/library/platform.c");
-        conf.file("../../ext/mbedtls/library/platform_util.c");
-        conf.file("../../ext/mbedtls/library/asn1parse.c");
+        cryptconf.file("../../ext/fiat/src/curve25519.c");
+        cryptconf.file("../../ext/mbedtls/library/platform.c");
+        cryptconf.file("../../ext/mbedtls/library/platform_util.c");
+        cryptconf.file("../../ext/mbedtls/library/asn1parse.c");
     } else {
         // Neither signature type, only verify sha256. The default
         // configuration file bundled with mbedTLS is sufficient.
         conf.define("MCUBOOT_USE_MBED_TLS", None);
         conf.include("../../ext/mbedtls/include");
-        conf.file("../../ext/mbedtls/library/sha256.c");
+        cryptconf.include("../../ext/mbedtls/include");
+        cryptconf.file("../../ext/mbedtls/library/sha256.c");
     }
 
     if overwrite_only {
@@ -118,17 +124,18 @@ fn main() {
         conf.file("csupport/keys.c");
 
         conf.include("../../ext/mbedtls/include");
-        conf.file("../../ext/mbedtls/library/sha256.c");
+        cryptconf.include("../../ext/mbedtls/include");
+        cryptconf.file("../../ext/mbedtls/library/sha256.c");
 
-        conf.file("../../ext/mbedtls/library/platform.c");
-        conf.file("../../ext/mbedtls/library/platform_util.c");
-        conf.file("../../ext/mbedtls/library/rsa.c");
-        conf.file("../../ext/mbedtls/library/rsa_internal.c");
-        conf.file("../../ext/mbedtls/library/md.c");
-        conf.file("../../ext/mbedtls/library/md_wrap.c");
-        conf.file("../../ext/mbedtls/library/aes.c");
-        conf.file("../../ext/mbedtls/library/bignum.c");
-        conf.file("../../ext/mbedtls/library/asn1parse.c");
+        cryptconf.file("../../ext/mbedtls/library/platform.c");
+        cryptconf.file("../../ext/mbedtls/library/platform_util.c");
+        cryptconf.file("../../ext/mbedtls/library/rsa.c");
+        cryptconf.file("../../ext/mbedtls/library/rsa_internal.c");
+        cryptconf.file("../../ext/mbedtls/library/md.c");
+        cryptconf.file("../../ext/mbedtls/library/md_wrap.c");
+        cryptconf.file("../../ext/mbedtls/library/aes.c");
+        cryptconf.file("../../ext/mbedtls/library/bignum.c");
+        cryptconf.file("../../ext/mbedtls/library/asn1parse.c");
     }
 
     if enc_kw {
@@ -139,27 +146,29 @@ fn main() {
         conf.file("csupport/keys.c");
 
         if sig_rsa || sig_rsa3072 {
-            conf.file("../../ext/mbedtls/library/sha256.c");
+            cryptconf.file("../../ext/mbedtls/library/sha256.c");
         }
 
         /* Simulator uses Mbed-TLS to wrap keys */
         conf.include("../../ext/mbedtls/include");
-        conf.file("../../ext/mbedtls/library/platform.c");
-        conf.file("../../ext/mbedtls/library/platform_util.c");
-        conf.file("../../ext/mbedtls/library/nist_kw.c");
-        conf.file("../../ext/mbedtls/library/cipher.c");
-        conf.file("../../ext/mbedtls/library/cipher_wrap.c");
-        conf.file("../../ext/mbedtls/library/aes.c");
+        cryptconf.include("../../ext/mbedtls/include");
+        cryptconf.file("../../ext/mbedtls/library/platform.c");
+        cryptconf.file("../../ext/mbedtls/library/platform_util.c");
+        cryptconf.file("../../ext/mbedtls/library/nist_kw.c");
+        cryptconf.file("../../ext/mbedtls/library/cipher.c");
+        cryptconf.file("../../ext/mbedtls/library/cipher_wrap.c");
+        cryptconf.file("../../ext/mbedtls/library/aes.c");
 
         if sig_ecdsa {
             conf.define("MCUBOOT_USE_TINYCRYPT", None);
 
             conf.include("../../ext/tinycrypt/lib/include");
+            cryptconf.include("../../ext/tinycrypt/lib/include");
 
-            conf.file("../../ext/tinycrypt/lib/source/utils.c");
-            conf.file("../../ext/tinycrypt/lib/source/sha256.c");
-            conf.file("../../ext/tinycrypt/lib/source/aes_encrypt.c");
-            conf.file("../../ext/tinycrypt/lib/source/aes_decrypt.c");
+            cryptconf.file("../../ext/tinycrypt/lib/source/utils.c");
+            cryptconf.file("../../ext/tinycrypt/lib/source/sha256.c");
+            cryptconf.file("../../ext/tinycrypt/lib/source/aes_encrypt.c");
+            cryptconf.file("../../ext/tinycrypt/lib/source/aes_decrypt.c");
         }
 
         if sig_ed25519 {
@@ -168,15 +177,15 @@ fn main() {
     }
 
     if sig_rsa && enc_kw {
-        conf.define("MBEDTLS_CONFIG_FILE", Some("<config-rsa-kw.h>"));
+        cryptconf.define("MBEDTLS_CONFIG_FILE", Some("<config-rsa-kw.h>"));
     } else if sig_rsa || sig_rsa3072 || enc_rsa {
-        conf.define("MBEDTLS_CONFIG_FILE", Some("<config-rsa.h>"));
+        cryptconf.define("MBEDTLS_CONFIG_FILE", Some("<config-rsa.h>"));
     } else if sig_ecdsa && !enc_kw {
-        conf.define("MBEDTLS_CONFIG_FILE", Some("<config-asn1.h>"));
+        cryptconf.define("MBEDTLS_CONFIG_FILE", Some("<config-asn1.h>"));
     } else if sig_ed25519 {
-        conf.define("MBEDTLS_CONFIG_FILE", Some("<config-ed25519.h>"));
+        cryptconf.define("MBEDTLS_CONFIG_FILE", Some("<config-ed25519.h>"));
     } else if enc_kw {
-        conf.define("MBEDTLS_CONFIG_FILE", Some("<config-kw.h>"));
+        cryptconf.define("MBEDTLS_CONFIG_FILE", Some("<config-kw.h>"));
     }
 
     conf.file("../../boot/bootutil/src/image_validate.c");
@@ -195,7 +204,9 @@ fn main() {
     conf.include("../../boot/bootutil/include");
     conf.include("csupport");
     conf.include("../../boot/zephyr/include");
+    cryptconf.include("../../boot/zephyr/include");
     conf.debug(true);
+    cryptconf.debug(true);
     conf.flag("-Wall");
     conf.flag("-Werror");
 
@@ -203,7 +214,9 @@ fn main() {
     // It has incomplete std=c11 and std=c99 support but std=c99 was checked
     // to build correctly so leaving it here to updated in the future...
     conf.flag("-std=c99");
+    cryptconf.flag("-std=c99");
 
+    cryptconf.compile("libcrypt.a");
     conf.compile("libbootutil.a");
 
     walk_dir("../../boot").unwrap();

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -208,6 +208,8 @@ fn main() {
     conf.debug(true);
     cryptconf.debug(true);
     conf.flag("-Wall");
+    conf.flag("-Wconversion");
+    conf.flag("-Wno-sign-conversion");
     conf.flag("-Werror");
 
     // FIXME: travis-ci still uses gcc 4.8.4 which defaults to std=gnu90.


### PR DESCRIPTION
Demonstrate areas with unsafe implicit integer conversions. This enables `-Wconversion` (but also `-Wno-sign-conversion`) to warn about implicit integer conversions that can lose data. The patch also "fixes" these by adding casts. Casts aren't the correct answer to most of these, but this change does show us which variables and types need to be thought about.

A bigger change is to remove the `-Wno-sign-conversion` to show cases where there are implicit changes in the signedness of values.