### PR TITLE
Add Travis-CI tests for testing SW counter measures against HW level fault injection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,51 @@ matrix:
   include:
     - os: linux
       language: minimal
-      env: TEST=fih-tests
+      env: BUILD_TYPE=RELEASE SKIP_SIZE=2,4,6,8,10 TEST=fih-tests DAMAGE_TYPE=SIGNATURE
+
+    - os: linux
+      language: minimal
+      env: BUILD_TYPE=RELEASE SKIP_SIZE=2,4,6,8,10 FIH_LEVEL=LOW TEST=fih-tests DAMAGE_TYPE=SIGNATURE
+
+    - os: linux
+      language: minimal
+      env: BUILD_TYPE=RELEASE SKIP_SIZE=2,4,6,8,10 FIH_LEVEL=MEDIUM TEST=fih-tests DAMAGE_TYPE=SIGNATURE
+
+    - os: linux
+      language: minimal
+      env: BUILD_TYPE=MINSIZEREL SKIP_SIZE=2,4,6 TEST=fih-tests DAMAGE_TYPE=SIGNATURE
+
+    - os: linux
+      language: minimal
+      env: BUILD_TYPE=MINSIZEREL SKIP_SIZE=2,4,6 FIH_LEVEL=LOW TEST=fih-tests DAMAGE_TYPE=SIGNATURE
+
+    - os: linux
+      language: minimal
+      env: BUILD_TYPE=MINSIZEREL SKIP_SIZE=2,4,6 FIH_LEVEL=MEDIUM TEST=fih-tests DAMAGE_TYPE=SIGNATURE
+
+    - os: linux
+      language: minimal
+      env: BUILD_TYPE=MINSIZEREL SKIP_SIZE=8,10 TEST=fih-tests DAMAGE_TYPE=SIGNATURE
+
+    - os: linux
+      language: minimal
+      env: BUILD_TYPE=MINSIZEREL SKIP_SIZE=8,10 FIH_LEVEL=LOW TEST=fih-tests DAMAGE_TYPE=SIGNATURE
+
+    - os: linux
+      language: minimal
+      env: BUILD_TYPE=MINSIZEREL SKIP_SIZE=8,10 FIH_LEVEL=MEDIUM TEST=fih-tests DAMAGE_TYPE=SIGNATURE
+
+    ## Corrupt image hash is not tested as it is in the unprotected TLV section
+    ## and is easy to calculate a valid hash for a changed image
+    #- os: linux
+    #  language: minimal
+    #  env: BUILD_TYPE=MINSIZEREL SKIP_SIZE=2,4,6 TEST=fih-tests DAMAGE_TYPE=IMAGE_HASH
+
+    ## Max profile is not tested as it requires HW entropy source which is not
+    ## present in the QEMU system being used for the tests.
+    #- os: linux
+    #  language: minimal
+    #  env: FIH_LEVEL=MAX TEST=fih-tests
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+# Travis configuration. Run FI hardening tests.
+
+language: minimal
+
+services:
+  - docker
+
+matrix:
+  include:
+    - os: linux
+      language: minimal
+      env: TEST=fih-tests
+
+before_install:
+  - |
+    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+      ./ci/check-signed-off-by.sh
+      if [ $? -ne 0 ]; then
+        exit 1
+      fi
+    fi
+
+install:
+  - ./ci/${TEST}_install.sh
+
+script:
+  - ./ci/${TEST}_run.sh
+
+notifications:
+  slack:
+    rooms:
+      - secure: "Tg9ZvJfb6e4QSEsxUvwW2MIqbuNRxD4nAOkgs8eopj/fRtqN6Zk06NVSeMmYcZunDFJXUSzYANBsF98OtaaUlm4WVt2T0ZFBJZrOYfIv18/zXCjYa04sDxur57F1ZYTYKyRpdUkfzPd/rGE4jKLQNcia+r/BTQbJkcZbXeg5/6cUeMP1so8/o0oMhSQP+GH0fLbyLzx3VPE8zu6+j2fCFC7R3idxtfO9VtsKlubfi3HgPgXTs+DEAAA8aoOku2esjFSFXTtdUFGz90YzyShZvtMcRg3Grp9+PZAsJwWk4eKSonKCO0DScfPUlMZbJcV7VsmyTxYKLLsGRZae6ZBH+XLfx5XeqgtgCor3FYx2dUXYfV9y8VvERDdossB0gZ/V2OUGePctDefiORytV6dMa7X3AfSdosgs/tjG4kbf+PMaVULzwF6dd3CdsxdClSl68UQPWA6wC2TEyo1EQea8jgZU6heLustZaQZhBkFkr/6j75XeGBjPw2fgVRkgg/OnTOYmo7N8181wOU+xORIEO1BtYmgRpc0cgpm4H9457diSHG1D2SoNy4tiQPCW2enN00QNGK5pZSL/FGA/ReUcALgAW0QcOljjU2bUSGPxo/VAi5ZyljWgVAGQ5qHJ4jgdfPf7VJUzCVH64G1S5+0gZPpO6vvvPdZtqeXrfBZMOBw="
+    on_success: always

--- a/ci/fih-tests_install.sh
+++ b/ci/fih-tests_install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -x
+
+# Copyright (c) 2020 Arm Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# get mcuboot root; assumes running script is stored under REPO_DIR/ci/
+REPO_DIR=$(dirname $(dirname $(realpath $0)))
+pushd $(mktemp -d)
+
+# copy mcuboot so that it is part of the docker build context
+cp -r $REPO_DIR .
+cp -r $REPO_DIR/ci/fih_test_docker/execute_test.sh .
+cp -r $REPO_DIR/ci/fih_test_docker/Dockerfile .
+./mcuboot/ci/fih_test_docker/build.sh
+popd

--- a/ci/fih-tests_run.sh
+++ b/ci/fih-tests_run.sh
@@ -16,4 +16,4 @@
 
 set -e
 
-docker run mcuboot/fih-test /bin/sh -c '/root/execute_test.sh'
+docker run mcuboot/fih-test /bin/sh -c '/root/execute_test.sh $0 $1 $2' 2,4,6,8,10 RELEASE SIGNATURE

--- a/ci/fih-tests_run.sh
+++ b/ci/fih-tests_run.sh
@@ -16,4 +16,8 @@
 
 set -e
 
-docker run mcuboot/fih-test /bin/sh -c '/root/execute_test.sh $0 $1 $2' 2,4,6,8,10 RELEASE SIGNATURE
+if test -z "$FIH_LEVEL"; then
+    docker run mcuboot/fih-test /bin/sh -c '/root/execute_test.sh $0 $1 $2' $SKIP_SIZE $BUILD_TYPE $DAMAGE_TYPE
+else
+    docker run mcuboot/fih-test /bin/sh -c '/root/execute_test.sh $0 $1 $2 $3' $SKIP_SIZE $BUILD_TYPE $DAMAGE_TYPE $FIH_LEVEL
+fi

--- a/ci/fih-tests_run.sh
+++ b/ci/fih-tests_run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -x
+
+# Copyright (c) 2020 Arm Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+docker run mcuboot/fih-test /bin/sh -c '/root/execute_test.sh'

--- a/ci/fih_test_docker/Dockerfile
+++ b/ci/fih_test_docker/Dockerfile
@@ -1,0 +1,51 @@
+# Copyright (c) 2020 Arm Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:focal
+
+# get dependencies for retrieving and building TF-M with MCUBoot, and QEMU.
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" \
+    apt-get install -y \
+    cmake \
+    curl \
+    gcc-arm-none-eabi \
+    gdb-multiarch \
+    git \
+    libncurses5 \
+    python3 \
+    python3-pip \
+    qemu-system-arm
+
+RUN \
+    # installing python packages
+    python3 -m pip install \
+        imgtool==1.6.0 \
+        Jinja2==2.10 \
+        PyYAML==3.12 \
+        pyasn1==0.1.9
+
+# Clone TF-M and dependencies
+RUN mkdir -p /root/work/tfm &&\
+    cd /root/work/tfm  &&\
+    git clone https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git -b TF-Mv1.2-RC1 &&\
+    mkdir mcuboot
+
+# Copy the test execution script to the image
+COPY execute_test.sh /root
+# copy the MCUBoot under test to the image
+COPY mcuboot /root/work/tfm/mcuboot
+
+# run the command
+CMD ["bash"]

--- a/ci/fih_test_docker/build.sh
+++ b/ci/fih_test_docker/build.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Copyright (c) 2020 Arm Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+trap cleanup_exit INT TERM EXIT
+
+cleanup_exit()
+{
+  rm -f *.list *.key
+}
+
+export LANG=C
+
+image=mcuboot/fih-test
+docker build --pull --tag=$image .
+echo $image > .docker-tag

--- a/ci/fih_test_docker/damage_image.py
+++ b/ci/fih_test_docker/damage_image.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2020 Arm Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import struct
+import sys
+
+from imgtool.image import (IMAGE_HEADER_SIZE, IMAGE_MAGIC,
+                           TLV_INFO_MAGIC, TLV_PROT_INFO_MAGIC, TLV_VALUES)
+from shutil import copyfile
+
+
+def get_tlv_type_string(tlv_type):
+    tlvs = {v: f"IMAGE_TLV_{k}" for k, v in TLV_VALUES.items()}
+    return tlvs.get(tlv_type, "UNKNOWN({:d})".format(tlv_type))
+
+
+class ImageHeader:
+
+    def __init__(self):
+        self.ih_magic = 0
+        self.ih_load_addr = 0
+        self.ih_hdr_size = 0
+        self.ih_protect_tlv_size = 0
+        self.ih_img_size = 0
+        self.ih_flags = 0
+        self.iv_major = 0
+        self.iv_minor = 0
+        self.iv_revision = 0
+        self.iv_build_num = 0
+        self._pad1 = 0
+
+    @staticmethod
+    def read_from_binary(in_file):
+        h = ImageHeader()
+
+        (h.ih_magic, h.ih_load_addr, h.ih_hdr_size, h.ih_protect_tlv_size, h.ih_img_size,
+            h.ih_flags, h.iv_major, h.iv_minor, h.iv_revision, h.iv_build_num, h._pad1
+         ) = struct.unpack('<IIHHIIBBHII', in_file.read(IMAGE_HEADER_SIZE))
+        return h
+
+    def __repr__(self):
+        return "\n".join([
+            "    ih_magic = 0x{:X}".format(self.ih_magic),
+            "    ih_load_addr = " + str(self.ih_load_addr),
+            "    ih_hdr_size = " + str(self.ih_hdr_size),
+            "    ih_protect_tlv_size = " + str(self.ih_protect_tlv_size),
+            "    ih_img_size = " + str(self.ih_img_size),
+            "    ih_flags = " + str(self.ih_flags),
+            "    iv_major = " + str(self.iv_major),
+            "    iv_minor = " + str(self.iv_minor),
+            "    iv_revision = " + str(self.iv_revision),
+            "    iv_build_num = " + str(self.iv_build_num),
+            "    _pad1 = " + str(self._pad1)])
+
+
+class ImageTLVInfo:
+    def __init__(self):
+        self.format_string = '<HH'
+
+        self.it_magic = 0
+        self.it_tlv_tot = 0
+
+    @staticmethod
+    def read_from_binary(in_file):
+        i = ImageTLVInfo()
+
+        (i.it_magic, i.it_tlv_tot) = struct.unpack('<HH', in_file.read(4))
+        return i
+
+    def __repr__(self):
+        return "\n".join([
+            "    it_magic = 0x{:X}".format(self.it_magic),
+            "    it_tlv_tot = " + str(self.it_tlv_tot)])
+
+    def __len__(self):
+        return struct.calcsize(self.format_string)
+
+
+class ImageTLV:
+    def __init__(self):
+        self.it_value = 0
+        self.it_type = 0
+        self.it_len = 0
+
+    @staticmethod
+    def read_from_binary(in_file):
+        tlv = ImageTLV()
+        (tlv.it_type, _, tlv.it_len) = struct.unpack('<BBH', in_file.read(4))
+        (tlv.it_value) = struct.unpack('<{:d}s'.format(tlv.it_len), in_file.read(tlv.it_len))
+        return tlv
+
+    def __len__(self):
+        round_to = 1
+        return int((4 + self.it_len + round_to - 1) // round_to) * round_to
+
+
+def get_arguments():
+    parser = argparse.ArgumentParser(description='Corrupt an MCUBoot image')
+    parser.add_argument("-i", "--in-file", required=True, help='The input image to be corrupted (read only)')
+    parser.add_argument("-o", "--out-file", required=True, help='the corrupted image')
+    parser.add_argument('-a', '--image-hash',
+                        default=False,
+                        action="store_true",
+                        required=False,
+                        help='Corrupt the image hash')
+    parser.add_argument('-s', '--signature',
+                        default=False,
+                        action="store_true",
+                        required=False,
+                        help='Corrupt the signature of the image')
+    return parser.parse_args()
+
+
+def damage_tlv(image_offset, tlv_off, tlv, out_file_content):
+    damage_offset = image_offset + tlv_off + 4
+    logging.info("        Damaging TLV at offset 0x{:X}...".format(damage_offset))
+    value = bytearray(tlv.it_value[0])
+    value[0] = (value[0] + 1) % 256
+    out_file_content[damage_offset] = value[0]
+
+
+def is_valid_signature(tlv):
+    return tlv.it_type == TLV_VALUES['RSA2048'] or tlv.it_type == TLV_VALUES['RSA3072']
+
+
+def damage_image(args, in_file, out_file_content, image_offset):
+    in_file.seek(image_offset, 0)
+
+    # Find the Image header
+    image_header = ImageHeader.read_from_binary(in_file)
+    if image_header.ih_magic != IMAGE_MAGIC:
+        raise Exception("Invalid magic in image_header: 0x{:X} instead of 0x{:X}".format(image_header.ih_magic, IMAGE_MAGIC))
+
+    # Find the TLV header
+    tlv_info_offset = image_header.ih_hdr_size + image_header.ih_img_size
+    in_file.seek(image_offset + tlv_info_offset, 0)
+
+    tlv_info = ImageTLVInfo.read_from_binary(in_file)
+    if tlv_info.it_magic == TLV_PROT_INFO_MAGIC:
+        logging.debug("Protected TLV found at offset 0x{:X}".format(tlv_info_offset))
+        if image_header.ih_protect_tlv_size != tlv_info.it_tlv_tot:
+            raise Exception("Invalid prot TLV len ({:d} vs. {:d})".format(image_header.ih_protect_tlv_size, tlv_info.it_tlv_tot))
+
+        # seek to unprotected TLV
+        tlv_info_offset += tlv_info.it_tlv_tot
+        in_file.seek(image_offset + tlv_info_offset)
+        tlv_info = ImageTLVInfo.read_from_binary(in_file)
+
+    else:
+        if image_header.ih_protect_tlv_size != 0:
+            raise Exception("No prot TLV was found.")
+
+    logging.debug("Unprotected TLV found at offset 0x{:X}".format(tlv_info_offset))
+    if tlv_info.it_magic != TLV_INFO_MAGIC:
+        raise Exception("Invalid magic in tlv info: 0x{:X} instead of 0x{:X}".format(tlv_info.it_magic, TLV_INFO_MAGIC))
+
+    tlv_off = tlv_info_offset + len(ImageTLVInfo())
+    tlv_end = tlv_info_offset + tlv_info.it_tlv_tot
+
+    # iterate over the TLV entries
+    while tlv_off < tlv_end:
+        in_file.seek(image_offset + tlv_off, 0)
+        tlv = ImageTLV.read_from_binary(in_file)
+
+        logging.debug("    tlv {:24s} len = {:4d}, len = {:4d}".format(get_tlv_type_string(tlv.it_type), tlv.it_len, len(tlv)))
+
+        if is_valid_signature(tlv) and args.signature:
+            damage_tlv(image_offset, tlv_off, tlv, out_file_content)
+        elif tlv.it_type == TLV_VALUES['SHA256'] and args.image_hash:
+            damage_tlv(image_offset, tlv_off, tlv, out_file_content)
+
+        tlv_off += len(tlv)
+
+
+def main():
+    args = get_arguments()
+
+    logging.debug("The script was started")
+
+    copyfile(args.in_file, args.out_file)
+    in_file = open(args.in_file, 'rb')
+
+    out_file_content = bytearray(in_file.read())
+
+    damage_image(args, in_file, out_file_content, 0)
+
+    in_file.close()
+
+    file_to_damage = open(args.out_file, 'wb')
+    file_to_damage.write(out_file_content)
+    file_to_damage.close()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format='%(levelname)5s: %(message)s',
+                        level=logging.DEBUG, stream=sys.stdout)
+
+    main()

--- a/ci/fih_test_docker/execute_test.sh
+++ b/ci/fih_test_docker/execute_test.sh
@@ -63,5 +63,4 @@ echo "    - FIH_LEVEL: $FIH_LEVEL"
 echo "    - SKIP_SIZE: $SKIP_SIZE"
 echo "    - DAMAGE_TYPE: $DAMAGE_TYPE"
 
-# TODO: Create human readable output
-cat fih_test_output.yaml
+python3 $MCUBOOT_PATH/ci/fih_test_docker/generate_test_report.py fih_test_output.yaml

--- a/ci/fih_test_docker/execute_test.sh
+++ b/ci/fih_test_docker/execute_test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -x
+
+# Copyright (c) 2020 Arm Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+WORKING_DIRECTORY=/root/work/tfm
+MCUBOOT_PATH=$WORKING_DIRECTORY/mcuboot
+
+TFM_DIR=/root/work/tfm/trusted-firmware-m
+TFM_BUILD_DIR=$TFM_DIR/build
+MCUBOOT_AXF=install/outputs/MPS2/AN521/bl2.axf
+SIGNED_TFM_BIN=install/outputs/MPS2/AN521/tfm_s_ns_signed.bin
+QEMU_LOG_FILE=qemu.log
+QEMU_PID_FILE=qemu_pid.txt
+
+source ~/.bashrc
+
+# build TF-M with MCUBoot
+mkdir -p $TFM_BUILD_DIR
+cd $TFM_DIR
+cmake -B $TFM_BUILD_DIR \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DTFM_TOOLCHAIN_FILE=toolchain_GNUARM.cmake \
+    -DTFM_PLATFORM=mps2/an521 \
+    -DTEST_NS=ON \
+    -DTEST_S=ON \
+    -DTFM_PSA_API=ON \
+    -DMCUBOOT_PATH=$MCUBOOT_PATH \
+    -DMCUBOOT_LOG_LEVEL=INFO \
+    .
+cd $TFM_BUILD_DIR
+make -j install
+
+# Run MCUBoot and TF-M in QEMU
+/usr/bin/qemu-system-arm \
+    -M mps2-an521 \
+    -kernel $MCUBOOT_AXF \
+    -device loader,file=$SIGNED_TFM_BIN,addr=0x10080000 \
+    -chardev file,id=char0,path=$QEMU_LOG_FILE \
+    -serial chardev:char0 \
+    -display none \
+    -pidfile $QEMU_PID_FILE \
+    -daemonize
+
+sleep 7
+
+cat $QEMU_LOG_FILE

--- a/ci/fih_test_docker/fi_make_manifest.sh
+++ b/ci/fih_test_docker/fi_make_manifest.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright (c) 2020 Arm Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+OBJDUMP=arm-none-eabi-objdump
+GDB=gdb-multiarch
+
+# Check if the ELF file specified is compatible
+if test $# -eq 0 || ! file $1 | grep "ELF" | grep "ARM" | grep "32" &>/dev/null; then
+    echo "Incompatible file: $1" 1>&2
+    exit 1
+fi
+
+# Extract the full path
+AXF_PATH=$(realpath $1)
+#Dump all objects that have a name containing FIH_LABEL
+ADDRESSES=$($OBJDUMP $AXF_PATH -t | grep "FIH_LABEL")
+# strip all data except "address, label_name"
+ADDRESSES=$(echo "$ADDRESSES" | sed "s/\([[:xdigit:]]*\).*\(FIH_LABEL_FIH_CALL_[a-zA-Z]*\)_.*/0x\1, \2/g")
+# Sort by address in ascending order
+ADDRESSES=$(echo "$ADDRESSES" | sort)
+# In the case that there is a START followed by another START take the first one
+ADDRESSES=$(echo "$ADDRESSES" | sed "N;s/\(.*START.*\)\n\(.*START.*\)/\1/;P;D")
+# Same for END except take the second one
+ADDRESSES=$(echo "$ADDRESSES" | sed "N;s/\(.*END.*\)\n\(.*END.*\)/\2/;P;D")
+
+# Output in CSV format with a label
+echo "Address, Type"
+echo "$ADDRESSES"

--- a/ci/fih_test_docker/fi_tester_gdb.sh
+++ b/ci/fih_test_docker/fi_tester_gdb.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+
+# Copyright (c) 2020 Arm Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function skip_instruction {
+
+    local SKIP_ADDRESS=$1
+    local SKIP_SIZE=$2
+
+    # Parse the ASM instruction from the address using gdb
+    INSTR=$($GDB $AXF_FILE --batch -ex "disassemble $SKIP_ADDRESS" | grep "^ *$SKIP_ADDRESS" | sed "s/.*:[ \t]*\(.*\)$/\1/g")
+    # Parse the C line from the address using gdb
+    LINE=$($GDB $AXF_FILE --batch -ex "info line *$SKIP_ADDRESS" | sed "s/Line \([0-9]*\).*\"\(.*\)\".*/\2:\1/g")
+
+    # Sometimes an address is in the middle of a 4 byte instruction. In that case
+    # don't run the test
+    if test "$INSTR" == ""; then
+        return
+    fi
+
+    # Print out the meta-info about the test, in YAML
+    echo "- skip_test:"
+    echo "    addr: $SKIP_ADDRESS"
+    echo "    asm:  \"$INSTR\""
+    echo "    line: \"$LINE\""
+    echo "    skip: $SKIP_SIZE"
+    # echo -ne "$SKIP_ADDRESS | $INSTR...\t"
+
+    cat >commands.gdb <<EOF
+target remote localhost: 1234
+b *$SKIP_ADDRESS
+continue&
+eval "shell sleep 0.5"
+interrupt
+if \$pc == $SKIP_ADDRESS
+    echo "Stopped at breakpoint"
+else
+    echo "Failed to stop at breakpoint"
+end
+echo "PC before increase:"
+print \$pc
+set \$pc += $SKIP_SIZE
+echo "PC after increase:"
+print \$pc
+detach
+eval "shell sleep 0.5"
+EOF
+
+    echo -n '.' 1>&2
+
+    # start qemu, dump the serial output to $QEMU_LOG_FILE
+    QEMU_LOG_FILE=qemu.log
+    QEMU_PID_FILE=qemu_pid.txt
+    rm -f $QEMU_PID_FILE $QEMU_LOG_FILE
+    /usr/bin/qemu-system-arm \
+        -M mps2-an521 \
+        -s -S \
+        -kernel $IMAGE_DIR/bl2.axf \
+        -device loader,file=$IMAGE_DIR/tfm_s_ns_signed.bin,addr=0x10080000 \
+        -chardev file,id=char0,path=$QEMU_LOG_FILE \
+        -serial chardev:char0 \
+        -display none \
+        -pidfile $QEMU_PID_FILE \
+        -daemonize
+
+    # start qemu, skip the instruction, and continue execution
+    $GDB < ./commands.gdb &>gdb_out.txt
+
+    # kill qemu
+    kill -9 `cat $QEMU_PID_FILE`
+
+    # If "Secure image initializing" is seen the TFM booted, which means that a skip
+    # managed to defeat the signature check. Write out whether the image booted or
+    # not to the log in YAML
+    if cat $QEMU_LOG_FILE | grep -i "Starting bootloader" &>/dev/null; then
+        # bootloader started successfully
+        if cat gdb_out.txt | grep -i "Stopped at breakpoint" &>/dev/null; then
+            # The target was stopped at the desired address
+            if cat $QEMU_LOG_FILE | grep -i "Secure image initializing" &>/dev/null; then
+                echo "    test_exec_ok: True"
+                echo "    skipped: True"
+                echo "    boot: True"
+
+                #print the address that was skipped, and some context to the console
+                echo "" 1>&2
+                echo "Boot success: address: $SKIP_ADDRESS skipped: $SKIP_SIZE" 1>&2
+                arm-none-eabi-objdump -d $IMAGE_DIR/bl2.axf --start-address=$SKIP_ADDRESS -S | tail -n +7 | head -n 14 1>&2
+                echo "" 1>&2
+                echo "" 1>&2
+            else
+                LAST_LINE=`tail -n 1 $QEMU_LOG_FILE | tr -dc '[:print:]'`
+                echo "    test_exec_ok: True"
+                echo "    skipped: True"
+                echo "    boot: False"
+                echo "    last_line: '$LAST_LINE' "
+            fi
+        else
+            # The target was not stopped at the desired address.
+            # The most probable reason is that the instruction for that address is
+            # on a call path that is not taken in this run (e.g. error handling)
+            if cat $QEMU_LOG_FILE | grep -i "Secure image initializing" &>/dev/null; then
+                # The image booted, although it shouldn't happen as the test is to
+                # be run with a corrupt image.
+                echo "    test_exec_ok: False"
+                echo "    test_exec_fail_reason: \"No instructions were skipped (e.g. branch was not executed), but booted successfully\""
+            else
+                # the execution didn't stop at the address (e.g. the instruction
+                # is on a branch that is not taken)
+                echo "    test_exec_ok: True"
+                echo "    skipped: False"
+            fi
+        fi
+    else
+        # failed before the first printout
+        echo "    test_exec_ok: True"
+        echo "    skipped: True"
+        echo "    boot: False"
+        echo "    last_line: 'N/A' "
+    fi
+}
+
+# Inform how the script is used
+usage() {
+    echo "$0 <image_dir> <start_addr> [<end_addr>] [(-s | --skip) <skip_len>]"
+}
+
+#defaults
+SKIP=2
+BIN_DIR=$(pwd)/install/outputs/MPS2/AN521
+AXF_FILE=$BIN_DIR/bl2.axf
+GDB=gdb-multiarch
+BOOTLOADER=true
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -s|--skip)
+        SKIP="$2"
+        shift
+        shift
+        ;;
+        -h|--help)
+        usage
+        exit 0
+        ;;
+        *)
+        if test -z "$IMAGE_DIR"; then
+            IMAGE_DIR=$1
+        elif test -z "$START"; then
+            START=$1
+        elif test -z "$END"; then
+            END=$1
+        else
+            usage
+            exit 1
+        fi
+        shift
+        ;;
+    esac
+done
+
+# Check that image directory, start and end address have been supplied
+if test -z "$IMAGE_DIR"; then
+    usage
+    exit 2
+fi
+
+if test -z "$START"; then
+    usage
+    exit 2
+fi
+
+if test -z "$END"; then
+    END=$START
+fi
+
+if test -z "$SKIP"; then
+    SKIP='2'
+fi
+
+# Create the start-end address range (step 2)
+ADDRS=$(printf '0x%x\n' $(seq "$START" 2 "$END"))
+
+# For each address run the skip_instruction function on it
+for ADDR in $ADDRS; do
+    skip_instruction $ADDR $SKIP
+done

--- a/ci/fih_test_docker/generate_test_report.py
+++ b/ci/fih_test_docker/generate_test_report.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2020 Arm Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import yaml
+import collections
+
+CATEGORIES = {
+        'TOTAL': 'Total tests run',
+        'SUCCESS': 'Tests executed successfully',
+        'FAILED': 'Tests failed to execute successfully',
+        # the execution never reached the address
+        'ADDRES_NOEXEC': 'Address was not executed',
+        # The address was successfully skipped by the debugger
+        'SKIPPED': 'Address was skipped',
+        'NO_BOOT': 'System not booted (desired behaviour)',
+        'BOOT': 'System booted (undesired behaviour)'
+}
+
+
+def print_results(results):
+    test_stats = collections.Counter()
+    failed_boot_last_lines = collections.Counter()
+    exec_fail_reasons = collections.Counter()
+
+    for test in results:
+        test = test["skip_test"]
+
+        test_stats.update([CATEGORIES['TOTAL']])
+
+        if test["test_exec_ok"]:
+            test_stats.update([CATEGORIES['SUCCESS']])
+
+            if "skipped" in test.keys() and not test["skipped"]:
+                # The debugger didn't stop at this address
+                test_stats.update([CATEGORIES['ADDRES_NOEXEC']])
+                continue
+
+            if test["boot"]:
+                test_stats.update([CATEGORIES['BOOT']])
+                continue
+
+            failed_boot_last_lines.update([test["last_line"]])
+        else:
+            exec_fail_reasons.update([test["test_exec_fail_reason"]])
+
+    print("{:s}: {:d}.".format(CATEGORIES['TOTAL'], test_stats[CATEGORIES['TOTAL']]))
+    print("{:s} ({:d}):".format(CATEGORIES['SUCCESS'], test_stats[CATEGORIES['SUCCESS']]))
+    print("    {:s}: ({:d}):".format(CATEGORIES['ADDRES_NOEXEC'], test_stats[CATEGORIES['ADDRES_NOEXEC']]))
+    test_with_skip = test_stats[CATEGORIES['SUCCESS']] - test_stats[CATEGORIES['ADDRES_NOEXEC']]
+    print("    {:s}: ({:d}):".format(CATEGORIES['SKIPPED'], test_with_skip))
+    print("    {:s} ({:d}):".format(CATEGORIES['NO_BOOT'], test_with_skip - test_stats[CATEGORIES['BOOT']]))
+    for last_line in failed_boot_last_lines.keys():
+        print("        last line: {:s} ({:d})".format(last_line, failed_boot_last_lines[last_line]))
+    print("    {:s} ({:d})".format(CATEGORIES['BOOT'], test_stats[CATEGORIES['BOOT']]))
+    print("{:s} ({:d}):".format(CATEGORIES['FAILED'], test_stats[CATEGORIES['TOTAL']] - test_stats[CATEGORIES['SUCCESS']]))
+    for reason in exec_fail_reasons.keys():
+        print("    {:s} ({:d})".format(reason, exec_fail_reasons[reason]))
+
+
+def main():
+    parser = argparse.ArgumentParser(description='''Process a FIH test output yaml file, and output a human readable report''')
+    parser.add_argument('filename', help='yaml file to process')
+
+    args = parser.parse_args()
+
+    with open(args.filename) as output_yaml_file:
+        results = yaml.safe_load(output_yaml_file)
+
+        if results:
+            print_results(results)
+        else:
+            print("Failed to parse output yaml file.")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/fih_test_docker/run_fi_test.sh
+++ b/ci/fih_test_docker/run_fi_test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Copyright (c) 2020 Arm Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Get the dir this is running in and the dir the script is in.
+PWD=$(pwd)
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )
+
+# PAD is the amount of extra instructions that should be tested on each side of
+# the critical region
+PAD=6
+
+MCUBOOT_AXF=$1
+SKIP_SIZES=$2
+DAMAGE_TYPE=$3
+
+# Take an image and make it unbootable. This is done by replacing one of the
+# strings in the image with a different string. This causes the signature check
+# to fail
+function damage_image
+{
+    IMAGEDIR=$(dirname $MCUBOOT_AXF)
+    local IMAGE_NAME=tfm_s_ns_signed.bin
+    local BACKUP_IMAGE_NAME=tfm_s_ns_signed.bin.orig
+    local IMAGE=$IMAGEDIR/$IMAGE_NAME
+    mv $IMAGE $IMAGEDIR/$BACKUP_IMAGE_NAME
+
+    if [ "$DAMAGE_TYPE" = "SIGNATURE" ]; then
+        DAMAGE_PARAM="--signature"
+    elif [ "$DAMAGE_TYPE" = "IMAGE_HASH" ]; then
+        DAMAGE_PARAM="--image-hash"
+    else
+        echo "Failed to damage image $IMAGE with param $DAMAGE_TYPE" 1>&2
+        exit -1
+    fi
+
+    # TODO: damage image here
+    cp $IMAGEDIR/$BACKUP_IMAGE_NAME $IMAGE
+}
+
+function run_test
+{
+    local SKIP_SIZE=$1
+
+    $DIR/fi_make_manifest.sh $MCUBOOT_AXF > $PWD/fih_manifest.csv
+
+    # Load the CSV FI manifest file, and output in START, END lines. Effectively
+    # join START and END lines together with a comma seperator.
+    REGIONS=$(sed "N;s/\(0x[[:xdigit:]]*\).*START\n\(0x[[:xdigit:]]*\).*END.*/\1,\2/g;P;D" $PWD/fih_manifest.csv)
+    # Ignore the first line, which includes the CSV header
+    REGIONS=$(echo "$REGIONS" | tail -n+2)
+
+    for REGION in $REGIONS; do
+        #Split the START,END pairs into the two variables
+        START=$(echo $REGION | cut -d"," -f 1)
+        END=$(echo $REGION | cut -d"," -f 2)
+
+        # Apply padding, converting back to hex
+        START=$(printf "0x%X" $((START - PAD)))
+        END=$(printf "0x%X" $((END + PAD)))
+
+        # Invoke the fi tester script
+        $DIR/fi_tester_gdb.sh $IMAGEDIR $START $END --skip $SKIP_SIZE
+    done
+}
+
+damage_image $MCUBOOT_AXF
+# Run the run_test function with each skip length between min and max in turn.
+
+IFS=', ' read -r -a sizes <<< "$SKIP_SIZES"
+for size in "${sizes[@]}"; do
+    echo "Run tests with skip size $size" 1>&2
+    run_test $size
+done

--- a/ci/fih_test_docker/run_fi_test.sh
+++ b/ci/fih_test_docker/run_fi_test.sh
@@ -48,8 +48,7 @@ function damage_image
         exit -1
     fi
 
-    # TODO: damage image here
-    cp $IMAGEDIR/$BACKUP_IMAGE_NAME $IMAGE
+    python3 $DIR/damage_image.py -i $IMAGEDIR/$BACKUP_IMAGE_NAME -o $IMAGE $DAMAGE_PARAM 1>&2
 }
 
 function run_test

--- a/docs/design.md
+++ b/docs/design.md
@@ -1159,3 +1159,130 @@ this, the target must provide a definition for the `boot_save_shared_data()`
 function which is declared in `boot/bootutil/include/bootutil/boot_record.h`.
 The `boot_add_data_to_shared_area()` function can be used for adding new TLV
 entries to the shared data area.
+
+## [Testing in CI](#testing-in-ci)
+
+### [Testing Fault Injection Hardening (FIH)](#testing-fih)
+
+The CI currently tests the Fault Injection Hardening feature of MCUboot by
+executing instruction skip during execution, and looking at whether a corrupted
+image was booted by the bootloader or not.
+
+The main idea is that instruction skipping can be automated by scripting a
+debugger to automatically execute the following steps:
+
+- Set breakpoint at specified address.
+- Continue execution.
+- On breakpoint hit increase the Program Counter.
+- Continue execution.
+- Detach from target after a timeout reached.
+
+Whether or not the corrupted image was booted or not can be decided by looking
+for certain entries in the log.
+
+As MCUboot is deployed on a microcontroller, testing FI would not make much
+sense in the simulator environment running on a host machine with different
+architecture than the MCU's, as the degree of hardening depends on compiler
+behavior. For example, (a bit counterintuitively) the code produced by gcc
+with `-O0` optimisation is more resilient against FI attacks than the code
+generated with `-O3` or `-Os` optimizations.
+
+To run on a desired architecture in the CI, the tests need to be executed on an
+emulator (as real devices are not available in the CI environment). For this
+implementation QEMU is selected.
+
+For the tests MCUboot needs a set of drivers and an implementation of a main
+function. For the purpose of this test Trusted-Firmware-M has been selected as
+it supports Armv8-M platforms that are also emulated by QEMU.
+
+The tests run in a docker container inside the CI VMs, to make it more easy to
+deploy build and test environment (QEMU, compilers, interpreters). The CI VMs
+seems to be using quite old Ubuntu (16.04).
+
+The sequence of the testing is the following (pseudo code):
+
+```sh
+fn main()
+  # Implemented in ci/fih-tests_install.sh
+  generate_docker_image(Dockerfile)
+
+  # See details below. Implemented in ci/fih-tests_run.sh.
+  # Calling the function with different parameters is done by Travis CI based on
+  # the values provided in the .travis.yaml
+  start_docker_image(skip_sizes, build_type, damage_type, fih_level)
+
+fn start_docker_image(skip_sizes, build_type, damage_type, fih_level)
+  # implemented in ci/fih_test_docker/execute_test.sh
+  compile_mcuboot(build_type)
+
+  # implemented in ci/fih_test_docker/damage_image.py
+  damage_image(damage_type)
+
+  # implemented in ci/fih_test_docker/run_fi_test.sh
+  ranges = generate_address_ranges()
+  for s in skip_sizes
+    for r in ranges
+      do_skip_in_qemu(s, r) # See details below
+  evaluate_logs()
+
+fn do_skip_in_qemu(size, range)
+  for a in r
+    run_qemu(a, size)  # See details below
+
+# this part is implemented in ci/fih_test_docker/fi_tester_gdb.sh
+fn run_qemu(a, size)
+  script = create_debugger_script(a, size)
+  start_qemu_in_bacground() # logs serial out to a file
+  gdb_attach_to_qemu(script)
+  kill_qemu()
+
+  # This checks the debugger and the quemu logs, and decides whether the tets
+  # was executed successfully, and whether the image is booted or not. Then
+  # emits a yaml fragment on the standard out to be processed by the caller
+  # script
+  evaluate_run(qemu_log_file)
+```
+
+Further notes:
+
+- The image is corrupted by changing its signature.
+- MCUBOOT_FIH_PROFILE_MAX is not tested as it requires TRNG, and the AN521
+platform has no support for it. However this profile adds the random
+execution delay to the code, so should not affect the instruction skip results
+too much, because break point is placed at exact address. But in practice this
+makes harder the accurate timing of the attack.
+- The test cases defined in .travis.yml always return `passed`, if they were
+executed successfully. A yaml file is created during test execution with the
+details of the test execution results. A summary of the collected results is
+printed in the log at the end of the test.
+
+An advantage of having the tests running in a docker image is that it is
+possible to run the tests on a local machine that has git and docker, without
+installing any additional software.
+
+So, running the test on the host looks like the following (The commands below
+are issued from the MCUboot source directory):
+
+```sh
+$ ./ci/fih-tests_install.sh
+$ FIH_LEVEL=MCUBOOT_FIH_PROFILE_MEDIUM BUILD_TYPE=RELEASE SKIP_SIZE=2 \
+    DAMAGE_TYPE=SIGNATURE ./ci/fih-tests_run.sh
+```
+On the travis CI the environment variables in the last command are set based on
+the configs provided in the `.travis.yaml`
+
+This starts the tests, however the shell that it is running in is not
+interactive, it is not possible to examine the results of the test run. To have
+an interactive shell where the results can be examined, the following can be
+done:
+
+- The docker image needs to be built with `ci/fih-tests_install.sh` as described
+  above.
+- Start the docker image with the following command:
+  `docker run -i -t mcuboot/fih-test`.
+- Execute the test with a command similar to the following:
+  `/root/execute_test.sh 8 RELEASE SIGNATURE MEDIUM`. After the test finishes,
+  the shell returns, and it is possible to investigate the results. It is also
+  possible to stop the test with _Ctrl+c_. The parameters to the
+  `execute_test.sh` are `SKIP_SIZE`, `BUILD_TYPE`, `DAMAGE_TYPE`, `FIH_LEVEL` in
+  order.


### PR DESCRIPTION
The tests investigate the behaviour of MCUBoot in case of instruction skip. The idea behind the test implementation is to create a set of scripts that execute the following:
- Run in MCUBoot in QEMU with a corrupted image.
- Attach a debugger to QEMU, and stop execution of MCUBoot.
- Modify the PC register by adding a predefined value to it
- Continue the execution
- Check whether the image booted successfully.
- As it would be unrealistic to test with skipping all the instructions, the test is limited to the instructions that are hardened in MCUboot. The FIH_* macros define symbols in the code at the beginning and the end of the hardening code, and the address of those symbols are extracted by the test scripts.

To Achieve this, the pull requests consists of the following additions to the CI directory:
- A Dockerfile, that describes an image that can compile MCUBoot with TF-M, and can run it in QEMU.
- Scripts that run on the Travis test slave to build the docker image and compile MCUBoot with TF-M, and corrupt the boot image. Note: the image is corrupted by changing the signature of the image.
- Scripts that execute the instruction skip tests based on the parameters passed into the test environment from the .travis.yml file.
- A python script that creates a short summary of the test results based on the yaml file emitted by the test scripts.

Below are some statistics based on test results:

Release build (-O3):
```
+------------------------------+-----------------+----------------------+------------------------+
|                              | MCUBoot         | Number of skip tests | Successful boots with  |
|                              | Image Size      | executed             | corrupted image        |
+==============================+=================+======================+========================+
| MCUBOOT_FIH_PROFILE_NONE     | FLASH:  25.1 kB |         480          |         35             |
|                              | RAM:    25.4 kB |                      |                        |
+------------------------------+-----------------+----------------------+------------------------+
| MCUBOOT_FIH_PROFILE_LOW      | FLASH:  25.5 kB |         770          |         19             |
|                              | RAM:    25.4 kB |                      |                        |
+------------------------------+-----------------+----------------------+------------------------+
| MCUBOOT_FIH_PROFILE_MEDIUM   | FLASH:  27.8 kB |        1145          |          9             |
|                              | RAM:    25.4 kB |                      |                        |
+------------------------------+-----------------+----------------------+------------------------+
```

MinSizeRel build (-Os):
```
+------------------------------+-----------------+----------------------+------------------------+
|                              | MCUBoot         | Number of skip tests | Successful boots with  |
|                              | Image Size      | executed             | corrupted image        |
+==============================+=================+======================+========================+
| MCUBOOT_FIH_PROFILE_NONE     | FLASH:  24.3 kB |          540         |           35           |
|                              | RAM:    25.4 kB |                      |                        |
+------------------------------+-----------------+----------------------+------------------------+
| MCUBOOT_FIH_PROFILE_LOW      | FLASH:  24.7 kB |          840         |           24           |
|                              | RAM:    25.4 kB |                      |                        |
+------------------------------+-----------------+----------------------+------------------------+
| MCUBOOT_FIH_PROFILE_MEDIUM   | FLASH:  27.0 kB |         1220         |           12           |
|                              | RAM:    25.4 kB |                      |                        |
+------------------------------+-----------------+----------------------+------------------------+
```

Note: MCUBOOT_FIH_PROFILE_MAX is not tested as it requires RNG, and the AN521 platform in TF-M has no support for it. However this profile adds the random execution delay to the code, so should not affect the instruction skip results too much.

The tests executed by Travis for this pull request can be looked at to see the tests in operation.

Note: the test cases defined in .travis.yml always return passed, if they were executed successfully.
