### PR TITLE
Port mcuboot to Mbed-OS

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -1,0 +1,17 @@
+boot/boot_serial/*
+boot/mynewt/*
+boot/zephyr/*
+boot/cypress/*
+ci/*
+docs/*
+ptest/*
+samples/*
+scripts/*
+sim/*
+testplan/*
+ext/cddl_gen/*
+ext/fiat/*
+ext/mbedtls/*
+ext/mbedtls-asn1/*
+ext/nrf/*
+ext/tinycrypt/tests/*

--- a/boot/mbed/app_enc_keys.c
+++ b/boot/mbed/app_enc_keys.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020 Embedded Planet
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#include <bootutil/sign_key.h>
+#include <mcuboot_config/mcuboot_config.h>
+
+#if defined(MCUBOOT_SIGN_RSA)
+#define HAVE_KEYS
+extern const unsigned char rsa_pub_key[];
+extern unsigned int rsa_pub_key_len;
+#elif defined(MCUBOOT_SIGN_EC256)
+#define HAVE_KEYS
+extern const unsigned char ecdsa_pub_key[];
+extern unsigned int ecdsa_pub_key_len;
+#elif defined(MCUBOOT_SIGN_ED25519)
+#define HAVE_KEYS
+extern const unsigned char ed25519_pub_key[];
+extern unsigned int ed25519_pub_key_len;
+#else
+#error "No public key available for given signing algorithm."
+#endif
+
+/*
+ * Note: Keys for both signing and encryption must be provided by the application.
+ * mcuboot's imgtool utility can be used to generate these keys and convert them into compatible C code.
+ * See imgtool's documentation, specifically the section: "Incorporating the public key into the code" which can be found here:
+ * https://github.com/JuulLabs-OSS/mcuboot/blob/master/docs/imgtool.md#incorporating-the-public-key-into-the-code
+ */
+#if defined(HAVE_KEYS)
+const struct bootutil_key bootutil_keys[] = {
+    {
+#if defined(MCUBOOT_SIGN_RSA)
+        .key = rsa_pub_key,
+        .len = &rsa_pub_key_len,
+#elif defined(MCUBOOT_SIGN_EC256)
+        .key = ecdsa_pub_key,
+        .len = &ecdsa_pub_key_len,
+#elif defined(MCUBOOT_SIGN_ED25519)
+        .key = ed25519_pub_key,
+        .len = &ed25519_pub_key_len,
+#endif
+    },
+};
+const int bootutil_key_cnt = 1;
+
+#if defined(MCUBOOT_ENCRYPT_RSA)
+
+extern const unsigned char enc_priv_key[];
+extern const unsigned int enc_priv_key_len;
+
+const struct bootutil_key bootutil_enc_key = {
+    .key = enc_priv_key,
+    .len = &enc_priv_key_len,
+};
+#elif defined(MCUBOOT_ENCRYPT_KW)
+#error "Encrypted images with AES-KW is not implemented yet."
+#endif
+
+#endif

--- a/boot/mbed/include/flash_map_backend/flash_map_backend.h
+++ b/boot/mbed/include/flash_map_backend/flash_map_backend.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2015 Runtime Inc
+ * Copyright (c) 2020 Embedded Planet
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the Licens
+ */
+
+#ifndef H_UTIL_FLASH_MAP_
+#define H_UTIL_FLASH_MAP_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ *
+ * Provides abstraction of flash regions for type of use.
+ * I.e. dude where's my image?
+ *
+ * System will contain a map which contains flash areas. Every
+ * region will contain flash identifier, offset within flash and length.
+ *
+ * 1. This system map could be in a file within filesystem (Initializer
+ * must know/figure out where the filesystem is at).
+ * 2. Map could be at fixed location for project (compiled to code)
+ * 3. Map could be at specific place in flash (put in place at mfg time).
+ *
+ * Note that the map you use must be valid for BSP it's for,
+ * match the linker scripts when platform executes from flash,
+ * and match the target offset specified in download script.
+ */
+#include <inttypes.h>
+
+/**
+ * @brief Structure describing an area on a flash device.
+ *
+ * Multiple flash devices may be available in the system, each of
+ * which may have its own areas. For this reason, flash areas track
+ * which flash device they are part of.
+ */
+struct flash_area {
+    /**
+     * This flash area's ID; unique in the system.
+     */
+    uint8_t fa_id;
+
+    /**
+     * ID of the flash device this area is a part of.
+     */
+    uint8_t fa_device_id;
+
+    uint16_t pad16;
+
+    /**
+     * This area's offset, relative to the beginning of its flash
+     * device's storage.
+     */
+    uint32_t fa_off;
+
+    /**
+     * This area's size, in bytes.
+     */
+    uint32_t fa_size;
+};
+
+/**
+ * @brief Structure describing a sector within a flash area.
+ *
+ * Each sector has an offset relative to the start of its flash area
+ * (NOT relative to the start of its flash device), and a size. A
+ * flash area may contain sectors with different sizes.
+ */
+struct flash_sector {
+    /**
+     * Offset of this sector, from the start of its flash area (not device).
+     */
+    uint32_t fs_off;
+
+    /**
+     * Size of this sector, in bytes.
+     */
+    uint32_t fs_size;
+};
+
+/*
+ * Start using flash area.
+ */
+int flash_area_open(uint8_t id, const struct flash_area ** fapp);
+
+void flash_area_close(const struct flash_area * fap);
+
+/*
+ * Read/write/erase. Offset is relative from beginning of flash area.
+ */
+int flash_area_read(const struct flash_area * fap, uint32_t off, void *dst,
+  uint32_t len);
+int flash_area_write(const struct flash_area * fap, uint32_t off, const void *src,
+  uint32_t len);
+int flash_area_erase(const struct flash_area * fap, uint32_t off, uint32_t len);
+
+/*
+ * Alignment restriction for flash writes.
+ */
+uint8_t flash_area_align(const struct flash_area * fap);
+
+/*
+ * What is value is read from erased flash bytes.
+ */
+uint8_t flash_area_erased_val(const struct flash_area * fap);
+
+/*
+ * Given flash area ID, return info about sectors within the area.
+ */
+int flash_area_get_sectors(int fa_id, uint32_t *count,
+  struct flash_sector *sectors);
+
+
+int flash_area_id_from_image_slot(int slot);
+int flash_area_id_from_multi_image_slot(int image_index, int slot);
+
+
+int flash_area_id_to_image_slot(int area_id);
+/**
+ * Converts the specified flash area ID and image index (in multi-image setup)
+ * to an image slot index.
+ *
+ * Returns image slot index (0 or 1), or -1 if ID doesn't correspond to an image
+ * slot.
+ */
+int flash_area_id_to_multi_image_slot(int image_index, int area_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H_UTIL_FLASH_MAP_ */

--- a/boot/mbed/include/flash_map_backend/secondary_bd.h
+++ b/boot/mbed/include/flash_map_backend/secondary_bd.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 Embedded Planet
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the Licens
+ *
+ * Created on: Jul 30, 2020
+ * Author: gdbeckstein
+ */
+
+#ifndef MCUBOOT_BOOT_MBED_INCLUDE_FLASH_MAP_BACKEND_SECONDARY_BD_H_
+#define MCUBOOT_BOOT_MBED_INCLUDE_FLASH_MAP_BACKEND_SECONDARY_BD_H_
+
+#include "blockdevice/BlockDevice.h"
+
+/**
+ * This is implemented as a weak function and may be redefined
+ * by the application. The default case is to return the
+ * BlockDevice object returned by BlockDevice::get_default_instance();
+ *
+ * @retval secondary_bd Secondary BlockDevice where update candidates are stored
+ */
+mbed::BlockDevice* get_secondary_bd(void);
+
+#endif /* MCUBOOT_BOOT_MBED_INCLUDE_FLASH_MAP_BACKEND_SECONDARY_BD_H_ */

--- a/boot/mbed/include/mcuboot_config/mcuboot_assert.h
+++ b/boot/mbed/include/mcuboot_config/mcuboot_assert.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2018 Open Source Foundries Limited
+ *
+ * Copyright (c) 2020 Embedded Planet
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the Licens
+ */
+
+#include "platform/mbed_assert.h"

--- a/boot/mbed/include/mcuboot_config/mcuboot_config.h
+++ b/boot/mbed/include/mcuboot_config/mcuboot_config.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2018 Open Source Foundries Limited
+ * Copyright (c) 2019-2020 Arm Limited
+ * Copyright (c) 2019-2020 Linaro Limited
+ * Copyright (c) 2020 Embedded Planet
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __MCUBOOT_CONFIG_H__
+#define __MCUBOOT_CONFIG_H__
+
+/*
+ * For available configurations and their explanations,
+ * see mbed_lib.json.
+ */
+
+#define SIGNATURE_TYPE_RSA      0
+#define SIGNATURE_TYPE_EC256    1
+#define SIGNATURE_TYPE_ED25519  2
+
+/*
+ * Signature algorithm
+ */
+#if (MCUBOOT_SIGNATURE_ALGORITHM == SIGNATURE_TYPE_RSA)
+#define MCUBOOT_SIGN_RSA
+#  if (MCUBOOT_RSA_SIGNATURE_LENGTH != 2048 && \
+       MCUBOOT_RSA_SIGNATURE_LENGTH != 3072)
+#    error "Invalid RSA key size (must be 2048 or 3072)"
+#  else
+#    define MCUBOOT_SIGN_RSA_LEN MCUBOOT_RSA_SIGNATURE_LENGTH
+#  endif
+#elif (MCUBOOT_SIGNATURE_ALGORITHM == SIGNATURE_TYPE_EC256)
+#define MCUBOOT_SIGN_EC256
+#elif (MCUBOOT_SIGNATURE_ALGORITHM == SIGNATURE_TYPE_ED25519)
+#define MCUBOOT_SIGN_ED25519
+#endif
+
+/*
+ * Crypto backend
+ */
+#define MBEDTLS     0
+#define TINYCRYPT   1
+
+#if (MCUBOOT_CRYPTO_BACKEND == MBEDTLS)
+#define MCUBOOT_USE_MBED_TLS
+#elif (MCUBOOT_CRYPTO_BACKEND == TINYCRYPT)
+/**
+ * XXX TinyCrypt is currently only supported in GCC builds
+ * See https://github.com/mcu-tools/mcuboot/pull/791#discussion_r515050672 for more information.
+ */
+#if !defined(__GNUC__)
+#error TinyCrypt is currently only supported in GCC builds for Mbed-OS.
+#endif
+#define MCUBOOT_USE_TINYCRYPT
+#endif
+
+/*
+ * Only one image (two slots) supported for now
+ */
+#define MCUBOOT_IMAGE_NUMBER 1
+
+/*
+ * Encrypted Images
+ */
+#if defined(MCUBOOT_ENCRYPT_RSA) || defined(MCUBOOT_ENCRYPT_EC256) || defined(MCUBOOT_ENCRYPT_X25519)
+#define MCUBOOT_ENC_IMAGES
+#endif
+
+/*
+ * Enabling this option uses newer flash map APIs. This saves RAM and
+ * avoids deprecated API usage.
+ */
+#define MCUBOOT_USE_FLASH_AREA_GET_SECTORS
+
+/*
+ * No watchdog integration for now
+ */
+#define MCUBOOT_WATCHDOG_FEED()                 \
+    do {                                        \
+    } while (0)
+
+
+#endif /* __MCUBOOT_CONFIG_H__ */

--- a/boot/mbed/include/mcuboot_config/mcuboot_logging.h
+++ b/boot/mbed/include/mcuboot_config/mcuboot_logging.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2015 Runtime Inc
+ * Copyright (c) 2020 Cypress Semiconductor Corporation
+ * Copyright (c) 2020 Embedded Planet
+ * Copyright (c) 2020 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the Licens.
+ */
+
+#ifndef __MCUBOOT_LOGGING_H__
+#define __MCUBOOT_LOGGING_H__
+
+#define MCUBOOT_LOG_LEVEL_OFF      0
+#define MCUBOOT_LOG_LEVEL_ERROR    1
+#define MCUBOOT_LOG_LEVEL_WARNING  2
+#define MCUBOOT_LOG_LEVEL_INFO     3
+#define MCUBOOT_LOG_LEVEL_DEBUG    4
+
+/*
+ * The compiled log level determines the maximum level that can be
+ * printed.
+ */
+#ifndef MCUBOOT_LOG_LEVEL
+#define MCUBOOT_LOG_LEVEL MCUBOOT_LOG_LEVEL_OFF
+#endif
+
+#if MCUBOOT_LOG_LEVEL == MCUBOOT_LOG_LEVEL_OFF
+#define MBED_CONF_MBED_TRACE_ENABLE 0
+#else
+#define MBED_CONF_MBED_TRACE_ENABLE 1
+#define MCUBOOT_HAVE_LOGGING
+#endif
+
+#if MCUBOOT_LOG_LEVEL == MCUBOOT_LOG_LEVEL_ERROR
+#define MBED_TRACE_MAX_LEVEL TRACE_LEVEL_ERROR
+#elif MCUBOOT_LOG_LEVEL == MCUBOOT_LOG_LEVEL_WARNING
+#define MBED_TRACE_MAX_LEVEL TRACE_LEVEL_WARN
+#elif MCUBOOT_LOG_LEVEL == MCUBOOT_LOG_LEVEL_INFO
+#define MBED_TRACE_MAX_LEVEL TRACE_LEVEL_INFO
+#elif MCUBOOT_LOG_LEVEL == MCUBOOT_LOG_LEVEL_DEBUG
+#define MBED_TRACE_MAX_LEVEL TRACE_LEVEL_DEBUG
+#endif
+
+#define TRACE_GROUP "MCUb"
+#include "mbed_trace.h"
+
+#define MCUBOOT_LOG_MODULE_DECLARE(domain)  /* ignore */
+#define MCUBOOT_LOG_MODULE_REGISTER(domain) /* ignore */
+
+#if MCUBOOT_LOG_LEVEL >= MCUBOOT_LOG_LEVEL_ERROR
+#define MCUBOOT_LOG_ERR tr_error
+#else
+#define MCUBOOT_LOG_ERR(...) IGNORE(__VA_ARGS__)
+#endif
+
+#if MCUBOOT_LOG_LEVEL >= MCUBOOT_LOG_LEVEL_WARNING
+#define MCUBOOT_LOG_WRN tr_warn
+#else
+#define MCUBOOT_LOG_WRN(...) IGNORE(__VA_ARGS__)
+#endif
+
+#if MCUBOOT_LOG_LEVEL >= MCUBOOT_LOG_LEVEL_INFO
+#define MCUBOOT_LOG_INF tr_info
+#else
+#define MCUBOOT_LOG_INF(...) IGNORE(__VA_ARGS__)
+#endif
+
+#if MCUBOOT_LOG_LEVEL >= MCUBOOT_LOG_LEVEL_DEBUG
+#define MCUBOOT_LOG_DBG tr_debug
+#else
+#define MCUBOOT_LOG_DBG(...) IGNORE(__VA_ARGS__)
+#endif
+
+#endif /* __MCUBOOT_LOGGING_H__ */

--- a/boot/mbed/include/os/os_malloc.h
+++ b/boot/mbed/include/os/os_malloc.h
@@ -1,0 +1,1 @@
+/** Not required for Mbed -- malloc calls are retargeted by the platform */

--- a/boot/mbed/include/sysflash/sysflash.h
+++ b/boot/mbed/include/sysflash/sysflash.h
@@ -1,0 +1,14 @@
+/* Manual version of auto-generated version. */
+
+#ifndef __SYSFLASH_H__
+#define __SYSFLASH_H__
+
+#define PRIMARY_ID      0
+#define SECONDARY_ID    1
+#define SCRATCH_ID      2
+
+#define FLASH_AREA_IMAGE_PRIMARY(x)    PRIMARY_ID
+#define FLASH_AREA_IMAGE_SECONDARY(x)  SECONDARY_ID
+#define FLASH_AREA_IMAGE_SCRATCH       SCRATCH_ID
+
+#endif /* __SYSFLASH_H__ */

--- a/boot/mbed/mbed_lib.json
+++ b/boot/mbed/mbed_lib.json
@@ -1,0 +1,165 @@
+{
+    "name": "mcuboot",
+    "config": {
+        "bootloader-build": {
+            "help": "Build the bootloader, in addition to the MCUboot library.",
+            "macro_name": "MCUBOOT_BOOTLOADER_BUILD",
+            "accepted_values": [true, false],
+            "value": true
+        },
+        "primary-slot-address": {
+            "help": "Start address of the primary (bootable) image slot. Target-dependent, please set on a per-target basis.",
+            "macro_name": "MCUBOOT_PRIMARY_SLOT_START_ADDR",
+            "required": true
+        },
+        "slot-size": {
+            "help": "Size of the primary (bootable) image slot, in bytes. Target-dependent, please set on a per-target basis.",
+            "macro_name": "MCUBOOT_SLOT_SIZE",
+            "required": true
+        },
+        "scratch-address": {
+            "help": "Start address of the scratch area. If needed, please set on a per-target basis.",
+            "macro_name": "MCUBOOT_SCRATCH_START_ADDR"
+        },
+        "scratch-size": {
+            "help": "Size of the scratch area, in bytes. If needed, please set on a per-target basis.",
+            "macro_name": "MCUBOOT_SCRATCH_SIZE"
+        },
+        "header-size": {
+            "help": "Header size, in bytes, prepended to the bootable application image. Should be one or multiple times the sector size.",
+            "macro_name": "MCUBOOT_HEADER_SIZE",
+            "required": true,
+            "value": 4096
+        },
+        "validate-primary-slot": {
+            "help": "Always check the signature of the image in the primary slot before booting, even if no upgrade was performed. This is recommended if the boot time penalty is acceptable.",
+            "macro_name": "MCUBOOT_VALIDATE_PRIMARY_SLOT",
+            "accepted_values": [true, null],
+            "value": true
+        },
+        "signature-algorithm": {
+            "help": "The algorithm used for digital signing.",
+            "macro_name": "MCUBOOT_SIGNATURE_ALGORITHM",
+            "required": true,
+            "accepted_values": ["SIGNATURE_TYPE_RSA", "SIGNATURE_TYPE_EC256", "SIGNATURE_TYPE_ED25519"],
+            "value": "SIGNATURE_TYPE_RSA"
+        },
+        "rsa-signature-length": {
+            "help": "If RSA is used for signature algorithm, this specifies the length.",
+            "macro_name": "MCUBOOT_RSA_SIGNATURE_LENGTH",
+            "required": true,
+            "accepted_values": [2048, 3072],
+            "value": 2048
+        },
+        "crypto-backend": {
+            "help": "The crypto library backend. NOTE: TinyCrypt is currently only supported with GCC for Mbed-OS builds.",
+            "macro_name": "MCUBOOT_CRYPTO_BACKEND",
+            "required": true,
+            "accepted_values": ["MBEDTLS", "TINYCRYPT"],
+            "value": "MBEDTLS"
+        },
+        "overwrite-only": {
+            "help": "The default is to support A/B image swapping with rollback. A simpler code path, which only supports overwriting the existing image with the update image, is also available. (null to disable)",
+            "macro_name": "MCUBOOT_OVERWRITE_ONLY",
+            "accepted_values": [true, null],
+            "value": null
+        },
+        "overwrite-only-fast": {
+            "help": "Only erase and overwrite those primary slot sectors needed to install the new image, rather than the entire image slot.",
+            "macro_name": "MCUBOOT_OVERWRITE_ONLY_FAST",
+            "accepted_values": [true, null],
+            "value": null
+        },
+        "log-level": {
+            "help": "Verbosity of MCUboot logging.",
+            "macro_name": "MCUBOOT_LOG_LEVEL",
+            "accepted_values": ["MCUBOOT_LOG_LEVEL_OFF", "MCUBOOT_LOG_LEVEL_ERROR", "MCUBOOT_LOG_LEVEL_WARN", "MCUBOOT_LOG_LEVEL_INFO", "MCUBOOT_LOG_LEVEL_DEBUG"],
+            "value": "MCUBOOT_LOG_LEVEL_OFF"
+        },
+        "log-bootloader-only": {
+            "help": "Exclude non-bootloader logs from Mbed OS (e.g. underlying storage).",
+            "macro_name": "MCUBOOT_LOG_BOOTLOADER_ONLY",
+            "accepted_values": [true, false],
+            "value": true
+        },
+        "max-img-sectors": {
+            "help": "Maximum number of flash sectors per image slot. Target-dependent, please set on a per-target basis.",
+            "macro_name": "MCUBOOT_MAX_IMG_SECTORS",
+            "required": true
+        },
+        "read-granularity": {
+            "help": "Granularity of read operations, in bytes. Enables a workaround if your block device does not support reading a single byte at a time. If this is used, it should be at least the value of your specific <blockdevice>->get_read_size() result.",
+            "macro_name": "MCUBOOT_READ_GRANULARITY",
+            "value": null
+        },
+        "hardware-key": {
+            "help": "Use hardware key (NOT TESTED)",
+            "macro_name": "MCUBOOT_HW_KEY",
+            "accepted_values": [true, null],
+            "value": null
+        },
+        "boot-swap-move": {
+            "help": "Boot swap using move (NOT TESTED)",
+            "macro_name": "MCUBOOT_SWAP_USING_MOVE",
+            "accepted_values": [true, null],
+            "value": null
+        },
+        "updateable-image-number": {
+            "help": "Updateable image number (NOT TESTED)",
+            "macro_name": "MCUBOOT_IMAGE_NUMBER"
+        },
+        "MCUBOOT_SWAP_SAVE_ENCTLV": {
+            "help": "Swap save enctlv (NOT TESTED)",
+            "macro_name": "MCUBOOT_IMAGE_NUMBER",
+            "value": null
+        },
+        "encrypt-rsa": {
+            "help": "Encrypt images using RSA (NOT TESTED)",
+            "macro_name": "MCUBOOT_ENCRYPT_RSA",
+            "accepted_values": [true, null],
+            "value": null
+        },
+        "encrypt-ec256": {
+            "help": "Encrypt images using EC256 (NOT TESTED)",
+            "macro_name": "MCUBOOT_ENCRYPT_EC256",
+            "accepted_values": [true, null],
+            "value": null
+        },
+        "encrypt-x25519": {
+            "help": "Encrypt images using X25519 (NOT TESTED)",
+            "macro_name":  "MCUBOOT_ENCRYPT_X25519",
+            "accepted_values": [true, null],
+            "value": null
+        },
+        "bootstrap": {
+            "help": "Bootstrap (NOT TESTED)",
+            "macro_name": "MCUBOOT_BOOTSTRAP",
+            "value": null
+        },
+        "use-bench": {
+            "help": "Use bench (NOT TESTED)",
+            "macro_name": "MCUBOOT_USE_BENCH",
+            "value": null
+        },
+        "downgrade-prevention": {
+            "help": "Prevent downgrades (NOT TESTED)",
+            "macro_name": "MCUBOOT_DOWNGRADE_PREVENTION",
+            "value": null
+        },
+        "hw-rollback-protection": {
+            "help": "Hardware rollback protection (NOT TESTED)",
+            "macro_name": "MCUBOOT_HW_ROLLBACK_PROT",
+            "value": null
+        },
+        "measured-boot": {
+            "help": "Measured boot (NOT TESTED)",
+            "macro_name": "MCUBOOT_MEASURED_BOOT",
+            "value": null
+        },
+        "share-data": {
+            "help": "Share data (NOT TESTED)",
+            "macro_name": "MCUBOOT_DATA_SHARING",
+            "value": null
+        }
+    }
+}

--- a/boot/mbed/mcuboot_main.cpp
+++ b/boot/mbed/mcuboot_main.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020 Embedded Planet
+ * Copyright (c) 2020 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#if MCUBOOT_BOOTLOADER_BUILD
+
+#include <stdlib.h>
+#include "bootutil/bootutil.h"
+#include "bootutil/image.h"
+#include "hal/serial_api.h"
+#include "mbed_application.h"
+
+#if (MCUBOOT_CRYPTO_BACKEND == MBEDTLS)
+#include "mbedtls/platform.h"
+#elif (MCUBOOT_CRYPTO_BACKEND == TINYCRYPT)
+#include "tinycrypt/ecc.h"
+#endif
+
+#define MBED_TRACE_MAX_LEVEL TRACE_LEVEL_DEBUG
+#define TRACE_GROUP "BL"
+#include "mbed-trace/mbed_trace.h"
+
+#if (MCUBOOT_CRYPTO_BACKEND == TINYCRYPT)
+/* XXX add this global definition for linking only
+ * TinyCrypt is used for signature verification and ECIES using secp256r1 and AES encryption;
+ * RNG is not required. So here we provide a stub.
+ * See https://github.com/mcu-tools/mcuboot/pull/791#discussion_r514480098
+ */
+
+extern "C" {
+int default_CSPRNG(uint8_t *dest, unsigned int size) { return 0; }
+}
+#endif
+
+int main()
+{
+    int rc;
+
+    mbed_trace_init();
+#if MCUBOOT_LOG_BOOTLOADER_ONLY
+    mbed_trace_include_filters_set("MCUb,BL");
+#endif
+
+    tr_info("Starting MCUboot");
+    
+#if (MCUBOOT_CRYPTO_BACKEND == MBEDTLS)
+    // Initialize mbedtls crypto for use by MCUboot
+    mbedtls_platform_context unused_ctx;
+    rc = mbedtls_platform_setup(&unused_ctx);
+    if(rc != 0) {
+        tr_error("Failed to setup Mbed TLS, error: %d", rc);
+        exit(rc);
+    }
+#elif (MCUBOOT_CRYPTO_BACKEND == TINYCRYPT)
+    uECC_set_rng(0);
+#endif
+
+    struct boot_rsp rsp;
+    rc = boot_go(&rsp);
+    if(rc != 0) {
+        tr_error("Failed to locate firmware image, error: %d", rc);
+        exit(rc);
+    }
+
+    uint32_t address = rsp.br_image_off + rsp.br_hdr->ih_hdr_size;
+
+    // Workaround: The extra \n ensures the last trace gets flushed
+    // before mbed_start_application() destroys the stack and jumps
+    // to the application
+    tr_info("Booting firmware image at 0x%x\n", address);
+
+    // Run the application in the primary slot
+    // Add header size offset to calculate the actual start address of application
+    mbed_start_application(address);
+}
+
+#endif // MCUBOOT_BOOTLOADER_BUILD

--- a/boot/mbed/src/flash_map_backend.cpp
+++ b/boot/mbed/src/flash_map_backend.cpp
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2020 Embedded Planet
+ * Copyright (c) 2020 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#include <assert.h>
+#include <cstring>
+#include "flash_map_backend/flash_map_backend.h"
+#include "flash_map_backend/secondary_bd.h"
+#include "sysflash/sysflash.h"
+
+#include "blockdevice/BlockDevice.h"
+#include "FlashIAP/FlashIAPBlockDevice.h"
+
+#include "mcuboot_config/mcuboot_logging.h"
+
+#define FLASH_DEVICE_INTERNAL_FLASH 0
+#define FLASH_AREAS 3
+
+/** Application defined secondary block device */
+mbed::BlockDevice* mcuboot_secondary_bd = get_secondary_bd();
+
+/** Internal application block device */
+static FlashIAPBlockDevice mcuboot_primary_bd(MCUBOOT_PRIMARY_SLOT_START_ADDR, MCUBOOT_SLOT_SIZE);
+
+#ifndef MCUBOOT_OVERWRITE_ONLY
+/** Scratch space is at the end of internal flash, after the main application */
+static FlashIAPBlockDevice mcuboot_scratch_bd(MCUBOOT_SCRATCH_START_ADDR, MCUBOOT_SCRATCH_SIZE);
+#endif
+
+static mbed::BlockDevice* flash_map_bd[FLASH_AREAS] = {
+        (mbed::BlockDevice*) &mcuboot_primary_bd,       /** Primary (loadable) image area */
+        mcuboot_secondary_bd,                           /** Secondary (update candidate) image area */
+#ifndef MCUBOOT_OVERWRITE_ONLY
+        (mbed::BlockDevice*) &mcuboot_scratch_bd        /** Scratch space for swapping images */
+#else
+        nullptr
+#endif
+};
+
+static struct flash_area flash_areas[FLASH_AREAS];
+
+int flash_area_open(uint8_t id, const struct flash_area** fapp) {
+
+    *fapp = &flash_areas[id];
+    struct flash_area* fap = (struct flash_area*)*fapp;
+
+    // The offset of the slot is from the beginning of the flash device.
+    switch (id) {
+        case PRIMARY_ID:
+            fap->fa_off = MCUBOOT_PRIMARY_SLOT_START_ADDR;
+            break;
+        case SECONDARY_ID:
+            // The offset of the secondary slot is not currently used.
+            fap->fa_off = 0;
+            break;
+#ifndef MCUBOOT_OVERWRITE_ONLY
+        case SCRATCH_ID:
+            fap->fa_off = MCUBOOT_SCRATCH_START_ADDR;
+            break;
+#endif
+        default:
+            MCUBOOT_LOG_ERR("flash_area_open, unknown id %d", id);
+            return -1;
+    }
+
+    fap->fa_id = id;
+    fap->fa_device_id = 0; // not relevant
+
+    mbed::BlockDevice* bd = flash_map_bd[id];
+    fap->fa_size = (uint32_t) bd->size();
+    return bd->init();
+}
+
+void flash_area_close(const struct flash_area* fap) {
+    mbed::BlockDevice* bd = flash_map_bd[fap->fa_id];
+    bd->deinit();
+}
+
+/*
+ * Read/write/erase. Offset is relative from beginning of flash area.
+ */
+int flash_area_read(const struct flash_area* fap, uint32_t off, void* dst, uint32_t len) {
+    mbed::BlockDevice* bd = flash_map_bd[fap->fa_id];
+
+    // Note: The address must be aligned to bd->get_read_size(). If MCUBOOT_READ_GRANULARITY
+    // is defined, the length does not need to be aligned.
+#ifdef MCUBOOT_READ_GRANULARITY
+    uint32_t read_size = bd->get_read_size();
+    if (read_size == 0) {
+        MCUBOOT_LOG_ERR("Invalid read size: must be non-zero");
+        return -1;
+    }
+    if (MCUBOOT_READ_GRANULARITY < read_size) {
+        MCUBOOT_LOG_ERR("Please increase MCUBOOT_READ_GRANULARITY (currently %u) to be at least %u",
+                    MCUBOOT_READ_GRANULARITY, read_size);
+        return -1;
+    }
+
+    uint32_t remainder = len % read_size;
+    len -= remainder;
+    if (len != 0) {
+#endif
+        if (!bd->is_valid_read(off, len)) {
+            MCUBOOT_LOG_ERR("Invalid read: fa_id %d offset 0x%x len 0x%x", fap->fa_id, off, len);
+            return -1;
+        }
+        else {
+            int ret = bd->read(dst, off, len);
+            if (ret != 0) {
+                MCUBOOT_LOG_ERR("Read failed: fa_id %d offset 0x%x len 0x%x", fap->fa_id, off, len);
+                return ret;
+            }
+        }
+#ifdef MCUBOOT_READ_GRANULARITY
+    }
+
+    if (remainder) {
+        if (!bd->is_valid_read(off + len, read_size)) {
+            MCUBOOT_LOG_ERR("Invalid read: fa_id %d offset 0x%x len 0x%x", fap->fa_id, off + len, read_size);
+            return -1;
+        }
+        else {
+            uint8_t buffer[MCUBOOT_READ_GRANULARITY];
+            int ret = bd->read(buffer, off + len, read_size);
+            if (ret != 0) {
+                MCUBOOT_LOG_ERR("Read failed: %d", ret);
+                return ret;
+            }
+            memcpy((uint8_t *)dst + len, buffer, remainder);
+        }
+    }
+#endif
+
+    return 0;
+}
+
+int flash_area_write(const struct flash_area* fap, uint32_t off, const void* src, uint32_t len) {
+    mbed::BlockDevice* bd = flash_map_bd[fap->fa_id];
+    return bd->program(src, off, len);
+}
+
+int flash_area_erase(const struct flash_area* fap, uint32_t off, uint32_t len) {
+    mbed::BlockDevice* bd = flash_map_bd[fap->fa_id];
+    return bd->erase(off, len);
+}
+
+uint8_t flash_area_align(const struct flash_area* fap) {
+    mbed::BlockDevice* bd = flash_map_bd[fap->fa_id];
+    return bd->get_program_size();
+}
+
+uint8_t flash_area_erased_val(const struct flash_area* fap) {
+    mbed::BlockDevice* bd = flash_map_bd[fap->fa_id];
+    return bd->get_erase_value();
+}
+
+int flash_area_get_sectors(int fa_id, uint32_t* count, struct flash_sector* sectors) {
+    mbed::BlockDevice* bd = flash_map_bd[fa_id];
+
+    // Loop through sectors and collect information on them
+    bd_addr_t offset = 0;
+    *count = 0;
+    while (*count < MCUBOOT_MAX_IMG_SECTORS && bd->is_valid_read(offset, bd->get_read_size())) {
+
+        sectors[*count].fs_off = offset;
+        bd_size_t erase_size = bd->get_erase_size(offset);
+        sectors[*count].fs_size = erase_size;
+
+        offset += erase_size;
+        *count += 1;
+    }
+
+    return 0;
+}
+
+int flash_area_id_from_image_slot(int slot) {
+    return slot;
+}
+
+int flash_area_id_to_image_slot(int area_id) {
+    return area_id;
+}
+
+/**
+ * Multi images support not implemented yet
+ */
+int flash_area_id_from_multi_image_slot(int image_index, int slot)
+{
+    assert(image_index == 0);
+    return slot;
+}
+
+int flash_area_id_to_multi_image_slot(int image_index, int area_id)
+{
+    assert(image_index == 0);
+    return area_id;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ target with a complete port planned.
   - [Zephyr](readme-zephyr.md)
   - [Mynewt](readme-mynewt.md)
   - [RIOT](readme-riot.md)
+  - [Mbed-OS](readme-mbed.md)
 - [Patch submission](SubmittingPatches.md) - information
   on how to contribute to mcuboot
 - Testing
@@ -58,6 +59,7 @@ For more information in the source, here are some pointers:
 - [boot/boot\_serial](https://github.com/JuulLabs-OSS/mcuboot/tree/master/boot/boot_serial): Support for serial upgrade within the bootloader itself.
 - [boot/zephyr](https://github.com/JuulLabs-OSS/mcuboot/tree/master/boot/zephyr): Port of the bootloader to Zephyr
 - [boot/mynewt](https://github.com/JuulLabs-OSS/mcuboot/tree/master/boot/mynewt): Mynewt bootloader app
+- [boot/mbed](https://github.com/JuulLabs-OSS/mcuboot/tree/master/boot/mbed): Port of the bootloader to Mbed-OS
 - [imgtool](https://github.com/JuulLabs-OSS/mcuboot/tree/master/scripts/imgtool.py): A tool to securely sign firmware images for booting by MCUboot.
 - [sim](https://github.com/JuulLabs-OSS/mcuboot/tree/master/sim): A bootloader simulator for testing and regression
 

--- a/docs/readme-mbed.md
+++ b/docs/readme-mbed.md
@@ -1,0 +1,41 @@
+# MCUboot port for Mbed OS
+
+This is an MCUboot port for Mbed OS.
+
+## Using MCUboot
+
+Note: The following is a general overview. It does not cover MCUboot or Mbed OS basics.
+
+See https://github.com/AGlass0fMilk/mbed-mcuboot-demo as a detailed example.
+
+### Basic configurations
+
+To use MCUboot, you need to create an Mbed OS project with the following configurations:
+* `"mcuboot.primary-slot-address"`: address of the primary slot in the internal flash
+* `"mcuboot.slot-size"`: size of an image slot (only one image, two slots are currently supported)
+* `"mcuboot.max-img-sectors"`: maximum number of sectors, should be at least the number of sectors in each slot
+* `"target.restrict_size"`: the maximum size of the bootloader, such that it does not overlap with the primary slot
+
+More configurations such as signing algorithm, slot swapping, etc. can be found in [mbed_lib.json](https://github.com/JuulLabs-OSS/mcuboot/tree/master/boot/mbed/mbed_lib.json). Please note that certain features are not currently supported.
+
+### Providing a secondary slot
+
+You need to provide an instance of `mbed::BlockDevice` as the secondary slot. It can be any types of internal or external storage provided that:
+* Its size equals the `"mcuboot.slot-size"` you have set
+* Its minimum supported read and write sizes (granularities) are _no larger than_ 16 byte, which MCUboot's read/write operations are aligned to. If the read size is larger than _one byte_, you need to set `"mcuboot.read-granularity"` to the read size of the storage - this buffers smaller read operations.
+
+In order for MCUboot to access your secondary slot, the interface to implement is
+```cpp
+mbed::BlockDevice* get_secondary_bd(void);
+```
+which should return an uninitialized instance of BlockDevice.
+
+### Building the bootloader
+
+To build a bootloader based on MCUboot, make sure `"mcuboot.bootloader-build"` is `true` (already the default) and you have provided configurations and a secondary slot BlockDevice as explained above.
+
+### Building a user application
+
+To build a user application, set `"mcuboot.bootloader-build"` to `false` so MCUboot is built as a _library only_ without a bootloader application. This is useful if your user application needs to confirm the current image with `boot_set_confirmed()` after an update, or set a new image in the secondary slot as pending with `boot_set_pending()` in order to trigger an update upon reboot.
+
+As your application starts in the primary slots (instead of the beginning of the whole flash), you need to set the start address (`"target.mbed_app_start"`) to be equal to `"mcuboot.primary-slot-address"` + `"mcuboot.header-size"` of your bootloader. And its size (`"target.mbed_app_size"`) must be no larger than `"mcuboot.slot-size"` - `"mcuboot.header-size"`, and some space must be left for the image trailer too (see [this](design.md#image-trailer)).

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/mbed-os/#2f87d59c7f2eed226ff82df72d2724b0ac122177


### PR DESCRIPTION
This PR introduces support for Mbed-OS with mcuboot. You can find demos of [a bootloader here](https://github.com/AGlass0fMilk/mbed-mcuboot-demo) and [a bootable application](https://github.com/AGlass0fMilk/mbed-mcuboot-blinky) here.