### PR TITLE
[DNM] boot: zephyr: remove flash erased val functions

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -108,31 +108,3 @@ int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
 
     return rc;
 }
-
-#define ERASED_VAL 0xff
-uint8_t flash_area_erased_val(const struct flash_area *fap)
-{
-    (void)fap;
-    return ERASED_VAL;
-}
-
-int flash_area_read_is_empty(const struct flash_area *fa, uint32_t off,
-        void *dst, uint32_t len)
-{
-    uint8_t i;
-    uint8_t *u8dst;
-    int rc;
-
-    rc = flash_area_read(fa, off, dst, len);
-    if (rc) {
-        return -1;
-    }
-
-    for (i = 0, u8dst = (uint8_t *)dst; i < len; i++) {
-        if (u8dst[i] != ERASED_VAL) {
-            return 0;
-        }
-    }
-
-    return 1;
-}

--- a/boot/zephyr/include/flash_map_backend/flash_map_backend.h
+++ b/boot/zephyr/include/flash_map_backend/flash_map_backend.h
@@ -76,20 +76,6 @@ int flash_area_id_to_multi_image_slot(int image_index, int area_id);
  */
 int flash_area_sector_from_off(off_t off, struct flash_sector *sector);
 
-/*
- * Returns the value expected to be read when accessing any erased
- * flash byte.
- */
-uint8_t flash_area_erased_val(const struct flash_area *fap);
-
-/*
- * Reads len bytes from off, and checks if the read data is erased.
- *
- * Returns 1 if erased, 0 if non-erased, and -1 on failure.
- */
-int flash_area_read_is_empty(const struct flash_area *fa, uint32_t off,
-        void *dst, uint32_t len);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Functions that were used to get the erased value from the flash device driver were removed on this commit, because a correct implementation is being added to Zephyr which correctly queries the flash driver.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/28519