### PR TITLE
Remove mbed-os library file

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/mbed-os/#2f87d59c7f2eed226ff82df72d2724b0ac122177


### PR DESCRIPTION
This commit reverts the addition of an `mbed-os.lib` file introduced with the Mbed-OS port (d82afbfaa839f2d4b86b883fc570f4955a9bec0e). 

Mbed-OS build tools use .lib files to pull in additional dependencies automatically with a single command. The intended usage of mcuboot with mbed-os is to clone mcuboot _next to_ mbed-os, rather than mbed-os inside mcuboot.

Signed-off-by: George Beckstein <becksteing@embeddedplanet.com>