### PR TITLE
Introduce utility function to retrieve primary application version.

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -62,6 +62,8 @@ extern "C" {
 #define BOOT_MAX_ALIGN          8
 
 struct image_header;
+struct image_version;
+
 /**
  * A response object provided by the boot loader code; indicates where to jump
  * to execute the main image.
@@ -102,6 +104,8 @@ int boot_swap_type(void);
 
 int boot_set_pending(int permanent);
 int boot_set_confirmed(void);
+
+int boot_get_current_version(struct image_version *version);
 
 #define SPLIT_GO_OK                 (0)
 #define SPLIT_GO_NON_MATCHING       (-1)

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -837,3 +837,30 @@ done:
     flash_area_close(fap);
     return rc;
 }
+
+/**
+ * Populates the version information of the
+ * currently installed primary application
+ *
+ * @param[in] version Destination version structure buffer
+ * @return 0 on success; nonzero on failure.
+ */
+int boot_get_current_version(struct image_version *version)
+{
+    struct boot_loader_state state;
+    struct boot_status status;
+    struct image_header hdr;
+    int rc;
+
+    assert(version != NULL);
+
+    rc = boot_read_image_header(&state, 0, &hdr, &status);
+    if (rc != 0) {
+        return rc;
+    }
+
+    /** Copy the header's version struct over into the caller-supplied buffer */
+    memcpy(version, &hdr.ih_ver, sizeof(struct image_version));
+
+    return 0;
+}


### PR DESCRIPTION
This commit introduces a utility function that allows the application to retrieve the version number stored in the application header info for the primary slot.

Signed-off-by: George Beckstein <becksteing@embeddedplanet.com>

Wasn't sure if this functionality was already available from mcuboot's APIs, but I did not find it when I looked.