### PR TITLE
Mbed-OS patches - temporarily disable TinyCrypt backend

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -15,3 +15,5 @@ ext/mbedtls/*
 ext/mbedtls-asn1/*
 ext/nrf/*
 ext/tinycrypt/tests/*
+ext/tinycrypt/*
+ext/tinycrypt-sha512/*

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Instructions for different operating systems can be found here:
 - [Zephyr](docs/readme-zephyr.md)
 - [Mynewt](docs/readme-mynewt.md)
 - [RIOT](docs/readme-riot.md)
+- [Mbed-OS](docs/readme-mbed.md)
 - [Simulator](sim/README.rst)
 
 ## Roadmap

--- a/boot/mbed/include/mcuboot_config/mcuboot_config.h
+++ b/boot/mbed/include/mcuboot_config/mcuboot_config.h
@@ -46,12 +46,10 @@
 #define MCUBOOT_USE_MBED_TLS
 #elif (MCUBOOT_CRYPTO_BACKEND == TINYCRYPT)
 /**
- * XXX TinyCrypt is currently only supported in GCC builds
- * See https://github.com/mcu-tools/mcuboot/pull/791#discussion_r515050672 for more information.
+ * XXX TinyCrypt is currently not supported by Mbed-OS due to build conflicts.
+ * See https://github.com/AGlass0fMilk/mbed-mcuboot-blinky/issues/2
  */
-#if !defined(__GNUC__)
-#error TinyCrypt is currently only supported in GCC builds for Mbed-OS.
-#endif
+#error TinyCrypt is currently not supported by Mbed-OS due to build conflicts.
 #define MCUBOOT_USE_TINYCRYPT
 #endif
 


### PR DESCRIPTION
This PR introduces a few patch changes to the Mbed-OS port including:

- Add a link to the Mbed-OS readme from the respository's main README.
- Temporarily disable building with the TinyCrypt backend for Mbed-OS builds

An explanation of the TinyCrypt change:

TinyCrypt uses a modified version of micro-ecc. Another version of micro-ecc is also used by the Mbed Cordio BLE stack. When building mcuboot for a target with BLE enabled, this causes multiple-defined symbol errors during linking. Due to the nature of Mbed's current build system, it is difficult to fix this.

Mbed will soon release a more flexible cmake-based build system that will make it possible to exclude these TinyCrypt files from an application build that may also link Cordio BLE sources.

Until then, this commit temporarily disables the use of TinyCrypt with Mbed-OS and excludes its sources from the build to avoid this build error. 

See AGlass0fMilk/mbed-mcuboot-blinky#2 for more details.