### PR TITLE
Crypto fixes after last refactoring

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/aes_ctr.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_ctr.h
@@ -96,31 +96,9 @@ static inline int bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx, const 
 
 static int _bootutil_aes_ctr_crypt(bootutil_aes_ctr_context *ctx, uint8_t *counter, const uint8_t *in, uint32_t inlen, uint32_t blk_off, uint8_t *out)
 {
-    uint8_t buf[16];
-    uint32_t buflen;
     int rc;
-    if (blk_off == 0) {
-        rc = tc_ctr_mode(out, inlen, in, inlen, counter, ctx);
-        if (rc != TC_CRYPTO_SUCCESS) {
-            return -1;
-        }
-    } else if (blk_off < 16) {
-        buflen = ((inlen + blk_off <= 16) ? inlen : (16 - blk_off));
-        inlen -= buflen;
-        memcpy(&buf[blk_off], &in[0], buflen);
-        rc = tc_ctr_mode(buf, 16, buf, 16, counter, ctx);
-        if (rc != TC_CRYPTO_SUCCESS) {
-            return -1;
-        }
-        memcpy(&out[0], &buf[blk_off], buflen);
-        memset(&buf[0], 0, 16);
-        if (inlen > 0) {
-            rc = tc_ctr_mode(&out[buflen], inlen, &in[buflen], inlen, counter, ctx);
-        }
-        if (rc != TC_CRYPTO_SUCCESS) {
-            return -1;
-        }
-    } else {
+    rc = tc_ctr_mode(out, inlen, in, inlen, counter, &blk_off, ctx);
+    if (rc != TC_CRYPTO_SUCCESS) {
         return -1;
     }
     return 0;

--- a/boot/bootutil/include/bootutil/crypto/aes_ctr.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_ctr.h
@@ -62,19 +62,13 @@ static inline int bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx, const 
 static inline int bootutil_aes_ctr_encrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter, const uint8_t *m, uint32_t mlen, size_t blk_off, uint8_t *c)
 {
     uint8_t stream_block[BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE];
-    int rc;
-    rc = mbedtls_aes_crypt_ctr(ctx, mlen, &blk_off, counter, stream_block, m, c);
-    memset(stream_block, 0, BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE);
-    return rc;
+    return mbedtls_aes_crypt_ctr(ctx, mlen, &blk_off, counter, stream_block, m, c);
 }
 
 static inline int bootutil_aes_ctr_decrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter, const uint8_t *c, uint32_t clen, size_t blk_off, uint8_t *m)
 {
     uint8_t stream_block[BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE];
-    int rc;
-    rc = mbedtls_aes_crypt_ctr(ctx, clen, &blk_off, counter, stream_block, c, m);
-    memset(stream_block, 0, BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE);
-    return rc;
+    return mbedtls_aes_crypt_ctr(ctx, clen, &blk_off, counter, stream_block, c, m);
 }
 #endif /* MCUBOOT_USE_MBED_TLS */
 

--- a/ext/tinycrypt/lib/include/tinycrypt/ctr_mode.h
+++ b/ext/tinycrypt/lib/include/tinycrypt/ctr_mode.h
@@ -96,10 +96,12 @@ extern "C" {
  * @param in IN -- data to encrypt (or decrypt)
  * @param inlen IN -- length of input data in bytes
  * @param ctr IN/OUT -- the current counter value
+ * @param blk_off IN/OUT -- the offset in the block
  * @param sched IN -- an initialized AES key schedule
  */
 int tc_ctr_mode(uint8_t *out, unsigned int outlen, const uint8_t *in,
-		unsigned int inlen, uint8_t *ctr, const TCAesKeySched_t sched);
+		unsigned int inlen, uint8_t *ctr, uint32_t *blk_off,
+		const TCAesKeySched_t sched);
 
 #ifdef __cplusplus
 }

--- a/ext/tinycrypt/lib/source/ctr_mode.c
+++ b/ext/tinycrypt/lib/source/ctr_mode.c
@@ -35,18 +35,21 @@
 #include <tinycrypt/utils.h>
 
 int tc_ctr_mode(uint8_t *out, unsigned int outlen, const uint8_t *in,
-		unsigned int inlen, uint8_t *ctr, const TCAesKeySched_t sched)
+		unsigned int inlen, uint8_t *ctr, uint32_t *blk_off,
+		const TCAesKeySched_t sched)
 {
 
 	uint8_t buffer[TC_AES_BLOCK_SIZE];
 	uint8_t nonce[TC_AES_BLOCK_SIZE];
 	unsigned int block_num;
 	unsigned int i;
+	uint32_t n;
 
 	/* input sanity check: */
 	if (out == (uint8_t *) 0 ||
 	    in == (uint8_t *) 0 ||
 	    ctr == (uint8_t *) 0 ||
+	    blk_off == (uint32_t *) 0 ||
 	    sched == (TCAesKeySched_t) 0 ||
 	    inlen == 0 ||
 	    outlen == 0 ||
@@ -60,8 +63,9 @@ int tc_ctr_mode(uint8_t *out, unsigned int outlen, const uint8_t *in,
 	/* select the last 4 bytes of the nonce to be incremented */
 	block_num = (nonce[12] << 24) | (nonce[13] << 16) |
 		    (nonce[14] << 8) | (nonce[15]);
+	n = *blk_off;
 	for (i = 0; i < inlen; ++i) {
-		if ((i % (TC_AES_BLOCK_SIZE)) == 0) {
+		if (n == 0) {
 			/* encrypt data using the current nonce */
 			if (tc_aes_encrypt(buffer, nonce, sched)) {
 				block_num++;
@@ -74,8 +78,10 @@ int tc_ctr_mode(uint8_t *out, unsigned int outlen, const uint8_t *in,
 			}
 		}
 		/* update the output */
-		*out++ = buffer[i%(TC_AES_BLOCK_SIZE)] ^ *in++;
+		*out++ = buffer[n] ^ *in++;
+		n = (n + 1) % TC_AES_BLOCK_SIZE;
 	}
+	*blk_off = n;
 
 	/* update the counter */
 	ctr[12] = nonce[12]; ctr[13] = nonce[13];


### PR DESCRIPTION
Applies a few fixes/improvements after the last refactoring of the crypto; this should make the final binary somewhat smaller and about the same speed.

* Add an offset parameter to mode ctr so it can be properly used as a streaming cipher, like required by the flash encryption algorithm.
* Avoid memset'ing a buffer that does not hold a secret; it contains the encryption of the counter.