### PR TITLE
boot: add support for custom user code to handle bootloader events

### DIFF
--- a/boot/bootutil/include/bootutil/bootloader_events.h
+++ b/boot/bootutil/include/bootutil/bootloader_events.h
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2020, IP-Logix Inc.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef H_BOOTLOADER_EVENTS_
+#define H_BOOTLOADER_EVENTS_
+
+enum bootloader_event {
+	EVT_BL_START					= 0,
+	EVT_BL_BOOTING_IMAGE,
+	EVT_BL_ENTER_SERIAL_RECOVERY,
+	EVT_BL_WAIT_FOR_DFU,
+	EVT_BL_DFU_TIMEOUT,
+	EVT_BL_SWAP_OP,
+	EVT_BL_SWAP_SECTOR_PROGRESS,
+	EVT_BL_MOVE_SECTOR_PROGRESS,
+	EVT_BL_ERROR_NO_BOOTABLE_IMAGE,
+	EVT_BL_ERROR_FLASH_NOT_FOUND,
+	EVT_BL_ERROR_USB_ENABLE_FAILED,
+	EVT_BL_ERROR_FLASH_PROTECT_FAILED,
+	EVT_BL_ERROR_SWAP_PANIC,
+};
+
+struct bootloader_event_param {
+	union {
+		struct {
+			int image_index;
+			int op;
+		} swap_op;
+		struct {
+			int image_index;
+			int sector;
+			int total_sectors;
+		} sector_op;
+		struct {
+			int rc;
+		} error;
+	};
+};
+
+void bootloader_event(enum bootloader_event event, 
+		      		  struct bootloader_event_param *param);
+
+#endif /* H_BOOTLOADER_EVENTS_ */

--- a/boot/bootutil/src/bootloader_events.c
+++ b/boot/bootutil/src/bootloader_events.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2020 IP-Logix Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bootutil/bootloader_events.h"
+
+/* The user can provide an implementation of this function in their own code
+ * to respond to bootloader events, for example to update UI or LEDs.
+ */
+ __attribute__((weak))
+void bootloader_event(enum bootloader_event event,
+					  struct bootloader_event_param *param)
+{
+	/* -- */
+}

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -44,6 +44,7 @@
 #include "bootutil/security_cnt.h"
 #include "bootutil/boot_record.h"
 #include "bootutil/fault_injection_hardening.h"
+#include "bootutil/bootloader_events.h"
 
 #ifdef MCUBOOT_ENC_IMAGES
 #include "bootutil/enc_key.h"
@@ -1780,6 +1781,14 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
         /* Set the previously determined swap type */
         bs.swap_type = BOOT_SWAP_TYPE(state);
 
+        struct bootloader_event_param p = {
+            .swap_op = {
+                .image_index    = BOOT_CURR_IMG(state),
+                .op             = BOOT_SWAP_TYPE(state),
+            }
+        };
+        bootloader_event(EVT_BL_SWAP_OP, &p);
+
         switch (BOOT_SWAP_TYPE(state)) {
         case BOOT_SWAP_TYPE_NONE:
             break;
@@ -1810,6 +1819,7 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
         }
 
         if (BOOT_SWAP_TYPE(state) == BOOT_SWAP_TYPE_PANIC) {
+            bootloader_event(EVT_BL_ERROR_SWAP_PANIC, NULL);
             BOOT_LOG_ERR("panic!");
             assert(0);
 

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -25,6 +25,7 @@
 #include "bootutil_priv.h"
 #include "swap_priv.h"
 #include "bootutil/bootutil_log.h"
+#include "bootutil/bootloader_events.h"
 
 #include "mcuboot_config/mcuboot_config.h"
 
@@ -499,6 +500,14 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
         idx = g_last_idx;
         while (idx > 0) {
             if (idx <= (g_last_idx - bs->idx + 1)) {
+                struct bootloader_event_param p = {
+                    .sector_op = {
+                        .image_index    = image_index,
+                        .sector         = idx,
+                        .total_sectors  = g_last_idx
+                    }
+                };
+                bootloader_event(EVT_BL_MOVE_SECTOR_PROGRESS, &p);
                 boot_move_sector_up(idx, sector_sz, state, bs, fap_pri, fap_sec);
             }
             idx--;
@@ -511,6 +520,14 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
     idx = 1;
     while (idx <= g_last_idx) {
         if (idx >= bs->idx) {
+            struct bootloader_event_param p = {
+                .sector_op = {
+                    .image_index    = image_index,
+                    .sector         = idx,
+                    .total_sectors  = g_last_idx
+                }
+            };
+            bootloader_event(EVT_BL_SWAP_SECTOR_PROGRESS, &p);
             boot_swap_sectors(idx, sector_sz, state, bs, fap_pri, fap_sec);
         }
         idx++;

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -25,6 +25,7 @@
 #include "bootutil_priv.h"
 #include "swap_priv.h"
 #include "bootutil/bootutil_log.h"
+#include "bootutil/bootloader_events.h"
 
 #include "mcuboot_config/mcuboot_config.h"
 
@@ -713,6 +714,14 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
     while (last_sector_idx >= 0) {
         sz = boot_copy_sz(state, last_sector_idx, &first_sector_idx);
         if (swap_idx >= (bs->idx - BOOT_STATUS_IDX_0)) {
+            struct bootloader_event_param p = {
+                .sector_op = {
+                    .image_index    = image_index,
+                    .sector         = idx,
+                    .total_sectors  = g_last_idx
+                }
+            };
+            bootloader_event(EVT_BL_SWAP_SECTOR_PROGRESS, &p);
             boot_swap_sectors(first_sector_idx, sz, state, bs);
         }
 

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -86,12 +86,17 @@ if(EXISTS targets/${BOARD}.h)
   zephyr_library_compile_definitions(MCUBOOT_TARGET_CONFIG="${BOARD}.h")
 endif()
 
+if (NOT DEFINED USER_ADDON_FILES)
+  set(USER_ADDON_FILES, "")
+endif()
+
 # Zephyr port-specific sources.
 zephyr_library_sources(
   main.c
   flash_map_extended.c
   os.c
   keys.c
+  ${USER_ADDON_FILES}
   )
 
 if(NOT DEFINED CONFIG_FLASH_PAGE_LAYOUT)
@@ -131,6 +136,7 @@ zephyr_library_sources(
   ${BOOT_DIR}/bootutil/src/swap_scratch.c
   ${BOOT_DIR}/bootutil/src/swap_move.c
   ${BOOT_DIR}/bootutil/src/caps.c
+  ${BOOT_DIR}/bootutil/src/bootloader_events.c
   )
 endif()
 


### PR DESCRIPTION
An event callback is invoked at each stage of the bootloader
lifecycle to indicate progress, errors, and image swap operations.
The user application can provide the function `bootloader_event`
to receives these events and performs design specific tasks such
as updating UI indicators to show image swap progress or bootloader
error.

`USER_ADDON_FILES` can be used to pass a list of user source files,
with custom code to handle events, to cmake be built as part of the
bootloader.

This feature enables users to customize some aspects of the bootloader
for their own application and board without needing to modify
the bootloader source code and keeping it in sync the master repo.
