### PR TITLE
samples: zephyr: Fix URL in test compilation

### DIFF
--- a/samples/zephyr/test-compile.go
+++ b/samples/zephyr/test-compile.go
@@ -18,7 +18,7 @@ import (
 	"os/exec"
 	"path"
 
-	"github.com/JuulLabs-OSS/mcuboot/samples/zephyr/mcutests"
+	"github.com/mcu-tools/mcuboot/samples/zephyr/mcutests"
 )
 
 var outFile = flag.String("out", "test-images.zip", "Name of zip file to put built tests into")


### PR DESCRIPTION
This reference to the old Juul URL got missed.  Fix it as well.

Signed-off-by: David Brown <david.brown@linaro.org>