### PR TITLE
ci: add wheel dependency to imgtool publishing

### DIFF
--- a/ci/imgtool_install.sh
+++ b/ci/imgtool_install.sh
@@ -19,5 +19,5 @@ if [[ $TRAVIS == "true" ]]; then
     fi
 fi
 
-pip3 install setuptools twine packaging
+pip3 install setuptools twine packaging wheel
 pip3 install --pre imgtool --no-binary :all:


### PR DESCRIPTION
Should fix the current fail trying to build a bdist_wheel.