### PR TITLE
boot: Fix LOAD_IMAGE_DATA macro

### DIFF
--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -460,7 +460,7 @@ boot_img_sector_off(const struct boot_loader_state *state, size_t slot,
 #ifdef MCUBOOT_RAM_LOAD
 #define LOAD_IMAGE_DATA(hdr, fap, start, output, size)       \
     (memcpy((output),(void*)((hdr)->ih_load_addr + (start)), \
-    (size)) != (output))
+    (size)), 0)
 #else
 #define LOAD_IMAGE_DATA(hdr, fap, start, output, size)       \
     (flash_area_read((fap), (start), (output), (size)))


### PR DESCRIPTION
If RAM_LOAD is defined then the return value of memcpy() is
always compared against its first parameter. By definition
memcpy() returns with its first paramter (destination) so
the not equal check is always false. The fix replaces this
runtime check with a comma operator assigning 0 to the
variable at build time, as a result compiler can be done
dead code elimination much better.

Signed-off-by: Tamas Ban <tamas.ban@arm.com>
Change-Id: I8d0d6e68a931661fa19d395556beb20470d74fb1