### PR TITLE
samples: zephyr: Use move swap for Zephyr tests

### DIFF
--- a/samples/zephyr/overlay-ecdsa-p256.conf
+++ b/samples/zephyr/overlay-ecdsa-p256.conf
@@ -1,3 +1,4 @@
 # Kconfig overlay for building with ECDSA-P256 signatures
 CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256=y
 CONFIG_BOOT_SIGNATURE_KEY_FILE="root-ec-p256.pem"
+CONFIG_BOOT_SWAP_USING_MOVE=y

--- a/samples/zephyr/overlay-rsa.conf
+++ b/samples/zephyr/overlay-rsa.conf
@@ -1,2 +1,3 @@
 # Kconfig overlay for building with RSA signatures
 CONFIG_BOOT_SIGNATURE_TYPE_RSA=y
+CONFIG_BOOT_SWAP_USING_MOVE=y

--- a/samples/zephyr/overlay-skip-primary-slot-validate.conf
+++ b/samples/zephyr/overlay-skip-primary-slot-validate.conf
@@ -1,3 +1,4 @@
 # Kconfig overlay for building without validating primary slot.
 
 # CONFIG_BOOT_VALIDATE_SLOT0 is not set
+CONFIG_BOOT_SWAP_USING_MOVE=y


### PR DESCRIPTION
Change the configs for the Zephyr tests to use move swap, as this is the
code intended for future use.

Signed-off-by: David Brown <david.brown@linaro.org>