### PR TITLE
zephyr: add an option to use GPIO to enable USB DFU.

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -355,9 +355,15 @@ config BOOT_FIH_PROFILE_HIGH
 
 endchoice
 
-config BOOT_WAIT_FOR_USB_DFU
+choice BOOT_USB_DFU
+	prompt "USB DFU"
+	default BOOT_USB_DFU_NO
+
+config BOOT_USB_DFU_NO
+	prompt "Disabled"
+
+config BOOT_USB_DFU_WAIT
 	bool "Wait for a prescribed duration to see if USB DFU is invoked"
-	default n
 	select USB
 	select USB_DFU_CLASS
 	select IMG_MANAGER
@@ -365,6 +371,58 @@ config BOOT_WAIT_FOR_USB_DFU
 	  If y, MCUboot waits for a prescribed duration of time to allow
 	  for USB DFU to be invoked. Please note DFU always updates the
 	  slot1 image.
+
+config BOOT_USB_DFU_GPIO
+	bool "Use GPIO to detect whether to trigger DFU mode"
+	select USB
+	select USB_DFU_CLASS
+	select IMG_MANAGER
+	help
+	  If y, MCUboot uses GPIO to detect whether to invoke USB DFU.
+
+endchoice
+
+config BOOT_USB_DFU_WAIT_DELAY_MS
+	int "USB DFU wait duration"
+	depends on BOOT_USB_DFU_WAIT
+	default 12000
+	help
+	  Milliseconds to wait for USB DFU to be invoked.
+
+if BOOT_USB_DFU_GPIO
+
+config BOOT_USB_DFU_DETECT_PORT
+	string "GPIO device to trigger USB DFU mode"
+	default GPIO_0 if SOC_FAMILY_NRF
+	help
+	  Zephyr GPIO device that contains the pin used to trigger
+	  USB DFU.
+
+config BOOT_USB_DFU_DETECT_PIN
+	int "Pin to trigger USB DFU mode"
+	default 6 if BOARD_NRF9160DK_NRF9160
+	default 11 if BOARD_NRF52840DK_NRF52840
+	default 13 if BOARD_NRF52DK_NRF52832
+	default 23 if BOARD_NRF5340_DK_NRF5340_CPUAPP || BOARD_NRF5340_DK_NRF5340_CPUAPPNS
+	help
+	  Pin on the DFU detect port that triggers DFU mode.
+
+config BOOT_USB_DFU_DETECT_PIN_VAL
+	int "USB DFU detect pin trigger value"
+	default 0
+	range 0 1
+	help
+	  Logic value of the detect pin that triggers USB DFU mode.
+
+config BOOT_USB_DFU_DETECT_DELAY
+	int "Serial detect pin detection delay time [ms]"
+	default 0
+	help
+	  Used to prevent the bootloader from loading on button press.
+	  Useful for powering on when using the same button as
+	  the one used to place the device in bootloader mode.
+
+endif # BOOT_USB_DFU_GPIO
 
 config ZEPHYR_TRY_MASS_ERASE
 	bool "Try to mass erase flash when flashing MCUboot image"
@@ -453,7 +511,7 @@ config BOOT_SERIAL_DETECT_PORT
 	string "GPIO device to trigger serial recovery mode"
 	default GPIO_0 if SOC_FAMILY_NRF
 	help
-	  Zephyr GPIO device which contains the pin used to trigger
+	  Zephyr GPIO device that contains the pin used to trigger
 	  serial recovery mode.
 
 config BOOT_SERIAL_DETECT_PIN
@@ -464,14 +522,14 @@ config BOOT_SERIAL_DETECT_PIN
 	default 23 if BOARD_NRF5340PDK_NRF5340_CPUAPP || BOARD_NRF5340PDK_NRF5340_CPUAPPNS || \
 		BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPPNS
 	help
-	  Pin on the serial detect port which triggers serial recovery mode.
+	  Pin on the serial detect port that triggers serial recovery mode.
 
 config BOOT_SERIAL_DETECT_PIN_VAL
 	int "Serial detect pin trigger value"
 	default 0
 	range 0 1
 	help
-	  Logic value of the detect pin which triggers serial recovery
+	  Logic value of the detect pin that triggers serial recovery
 	  mode.
 
 config BOOT_SERIAL_DETECT_DELAY
@@ -576,6 +634,7 @@ comment "Zephyr configuration options"
 # hardware work.
 config MULTITHREADING
 	default y if BOOT_SERIAL_CDC_ACM #usb driver requires MULTITHREADING
+	default y if BOOT_USB_DFU_GPIO || BOOT_USB_DFU_WAIT
 	default n if SOC_FAMILY_NRF
 	default y
 


### PR DESCRIPTION
Signed-off-by: Josh Gao <josh@jmgao.dev>