### PR TITLE
zephyr/Kconfig: allow xip-revert only for xip-mode

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -227,6 +227,7 @@ endchoice
 
 config BOOT_DIRECT_XIP_REVERT
 	bool "Enable the revert mechanism in direct-xip mode"
+	depends on BOOT_DIRECT_XIP
 	default n
 	help
 	  If y, enables the revert mechanism in direct-xip similar to the one in


### PR DESCRIPTION
BOOT_DIRECT_XIP_REVER enable code which shall only be enabled
while BOOT_DIRECT_XIP=y.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>