### PR TITLE
boot: zephyr: always clear SPLIM registers when present

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -152,6 +152,8 @@ static void do_boot(struct boot_rsp *rsp)
     z_arm_clear_arm_mpu_config();
 #endif
 
+#endif /* CONFIG_MCUBOOT_CLEANUP_ARM_CORE */
+
 #if defined(CONFIG_BUILTIN_STACK_GUARD) && \
     defined(CONFIG_CPU_CORTEX_M_HAS_SPLIM)
     /* Reset limit registers to avoid inflicting stack overflow on image
@@ -160,8 +162,6 @@ static void do_boot(struct boot_rsp *rsp)
     __set_PSPLIM(0);
     __set_MSPLIM(0);
 #endif
-
-#endif /* CONFIG_MCUBOOT_CLEANUP_ARM_CORE */
 
 #ifdef CONFIG_BOOT_INTR_VEC_RELOC
 #if defined(CONFIG_SW_VECTOR_RELAY)


### PR DESCRIPTION
This fixes a bug where zephyr images would not boot correctly
on M33 cores.

PR-847 (commit 70af708b85b3) made clearing SPLIM registers
configurable. The registers would not be cleared if the architecture
had support for cleaning the state of the core before booting.

However, if the SPLIM register is not cleared before booting the
next image that image will get a fault when jumping to the routine
which cleans the core.

In other words we must clear the SPLIM registers when it is present.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>