### PR TITLE
boot/mynewt: De-initialize peripherals before calling app

### DIFF
--- a/boot/mynewt/src/main.c
+++ b/boot/mynewt/src/main.c
@@ -251,6 +251,7 @@ main(void)
 #if MYNEWT_VAL(BOOT_CUSTOM_START)
     boot_custom_start(flash_base, &rsp);
 #else
+    hal_bsp_deinit();
     hal_system_start((void *)(flash_base + rsp.br_image_off +
                               rsp.br_hdr->ih_hdr_size));
 #endif


### PR DESCRIPTION
mynewt code calls hal_bsp_init() at start of bootloader.
This may initialize some resources (timer/uart/dma).
mynewt has now hal_bsp_deinit() function that should be called
before application is executed.
This new function allows to stop resources that were started.

This can stop cputimer which was started including enabled
interrupt. This timer interrupt was very likely to fire
for STM devices that has 16 bits timer used, when mcuboot
did not started LSE and application wanted to.
Starting LSE oscillator takes so much time in some cases
that timer interrupt will execute MCU from mcuboot vector
after RAM was already cleared by startup code and that
would lead to crash loop.
Blocking interrupts before starting application would
also help but leaving peripherals in reset state
seems reasonable.

This pull request depends on:
https://github.com/apache/mynewt-core/pull/2415