### PR TITLE
Preps for 1.7.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [travis]: https://travis-ci.org/mcu-tools/mcuboot
 [license]: https://github.com/mcu-tools/mcuboot/blob/master/LICENSE
 
-This is mcuboot version 1.7.0-rc2
+This is mcuboot version 1.7.0
 
 MCUboot is a secure bootloader for 32-bit MCUs. The goal of MCUboot is to
 define a common infrastructure for the bootloader, system flash layout on

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -37,6 +37,13 @@ There are bug fixes, and associated imgtool updates as well.
 - imgtool: added possibility to set confirm flag for hex files as well.
 - imgtool: Print image digest during verify.
 
+### Zephyr-RTOS Compatibility
+
+This release of MCUboot works with the Zephyr "master" at the time of the
+release. It was tested as of has 7a3b253ce. This version of MCUboot also
+works with the Zephyr v2.4.0, however it is recommended to enable
+`CONFIG_MCUBOOT_CLEANUP_ARM_CORE` while using that version.
+
 ## Version 1.6.0
 
 The 1.6.0 release of MCUboot adds support for the PSOC6 platform,

--- a/repository.yml
+++ b/repository.yml
@@ -30,10 +30,10 @@ repo.versions:
     "1.4.0": "v1.4.0"
     "1.5.0": "v1.5.0"
     "1.6.0": "v1.6.0"
-    "1.7.0": "v1.7.0-rc2"
+    "1.7.0": "v1.7.0"
 
     "0-dev": "0.0.0"        # master
-    "0-latest": "1.6.0"     # latest stable release
-    "1-latest": "1.6.0"     # latest stable release
+    "0-latest": "1.7.0"     # latest stable release
+    "1-latest": "1.7.0"     # latest stable release
 
-    "1.0-latest": "1.6.0"
+    "1.0-latest": "1.7.0"

--- a/scripts/imgtool/__init__.py
+++ b/scripts/imgtool/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-imgtool_version = "1.7.0rc2"
+imgtool_version = "1.7.0"


### PR DESCRIPTION
Update version fields for 1.7.0 release.
Added compatibility note for zephyr-rtos.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>