### PR TITLE
zephyr: use minimal CBPRINTF implementation

### DIFF
--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -33,3 +33,5 @@ CONFIG_FLASH=y
 CONFIG_LOG=y
 ### Ensure Zephyr logging changes don't use more resources
 CONFIG_LOG_DEFAULT_LEVEL=0
+### Decrease footprint by ~4 KB in comparison to CBPRINTF_COMPLETE=y
+CONFIG_CBPRINTF_NANO=y


### PR DESCRIPTION
Addition of cbprintf capability in zephyr
https://github.com/zephyrproject-rtos/zephyr/pull/29876
cause flash footprint rise by ~4 KB. Selecting
CBPRINTF_NANO=y mitigates the footprint rise.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>