### PR TITLE
zephyr: allow to build nRF52840 targets in zephyr-rtos CI

### DIFF
--- a/boot/zephyr/sample.yaml
+++ b/boot/zephyr/sample.yaml
@@ -1,6 +1,10 @@
 sample:
   description: mcuboot test build sample
   name: mcuboot
+common:
+  integration_platforms:
+    - nrf52840dk_nrf52840
+    - nrf52840dongle_nrf52840
 
 tests:
   sample.bootloader.mcuboot:


### PR DESCRIPTION
MCUboot was build only for frdm_k64f in zephyr CI.
Extended Zephyr-RTOS integration platform by nrf52840dk_nrf52840
and nrf52840dongle_nrf52840 which allow to build MCUBoot on
these platform in Zephyr-RTOS CI.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>