### PR TITLE
Fix Mbed OS logging port when trace is disabled.

### DIFF
--- a/boot/mbed/include/mcuboot_config/mcuboot_logging.h
+++ b/boot/mbed/include/mcuboot_config/mcuboot_logging.h
@@ -55,6 +55,7 @@
 
 #define TRACE_GROUP "MCUb"
 #include "mbed_trace.h"
+#include "bootutil/ignore.h"
 
 #define MCUBOOT_LOG_MODULE_DECLARE(domain)  /* ignore */
 #define MCUBOOT_LOG_MODULE_REGISTER(domain) /* ignore */


### PR DESCRIPTION
This PR prevents the following build error:

```
./mcuboot/boot/mbed/include/mcuboot_config/mcuboot_logging.h:65:30: error: 'IGNORE' was not declared in this scope
   65 | #define MCUBOOT_LOG_ERR(...) IGNORE(__VA_ARGS__)
```

This build error occurs when the bootloader is configured with Mbed's logging library, mbed-trace, disabled or when a logging level other than "MCUBOOT_LOG_LEVEL_DEBUG" is used. Since "bootutil/ignore.h" was not included previously, the "IGNORE(...)" macro was undefined in this scope.

Signed-off-by: George Beckstein <becksteing@embeddedplanet.com>