### PR TITLE
Add reference counting to Mbed OS flash backend

### DIFF
--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -132,6 +132,8 @@ int     flash_area_id_from_multi_image_slot(int image_index, int slot);
 int     flash_area_id_to_multi_image_slot(int image_index, int area_id);
 ```
 
+**Note:** As of writing, it is possible that mcuboot will open a flash area multiple times simultaneously (through nested calls to `flash_area_open`). As a result, mcuboot may call `flash_area_close` on a flash area that is still opened by another part of mcuboot. As a workaround when porting, it may be necessary to implement a counter of the number of times a given flash area has been opened by mcuboot. The `flash_area_close` implementation should only fully deinitialize the underlying flash area when the open counter is decremented to 0. See [this GitHub PR](https://github.com/mcu-tools/mcuboot/pull/894/) for a more detailed discussion.
+
 ## Memory management for mbed TLS
 
 `mbed TLS` employs dynamic allocation of memory, making use of the pair


### PR DESCRIPTION
The internal functions of mcuboot are not consistent in opening/closing flash areas and sometimes nested calls happen to `flash_area_open` and `flash_area_close`. With the previous implementation, a nested call to `flash_area_close` would deinitialize the underlying `BlockDevice`. This could cause subsequent flash operations on an "open" flash area to fail.

This PR adds a simple open counter for each flash area and ensures the underlying `BlockDevice` is initialized and deinitialized appropriately. The `BlockDevice` is only initialized when transitioning from an open count of 0 to 1. The `BlockDevice` is only deinitialized when the open count falls to 0.

Signed-off-by: George Beckstein <becksteing@embeddedplanet.com>