### PR TITLE
boot: zephyr: Default to LOG_MINIMAL

### DIFF
--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -31,6 +31,7 @@ CONFIG_FLASH=y
 # CONFIG_I2C is not set
 
 CONFIG_LOG=y
+CONFIG_LOG_MINIMAL=y
 ### Ensure Zephyr logging changes don't use more resources
 CONFIG_LOG_DEFAULT_LEVEL=0
 ### Decrease footprint by ~4 KB in comparison to CBPRINTF_COMPLETE=y


### PR DESCRIPTION
Enables LOG_MINIMAL in the default build.

Ref: NCSDK-7206

Signed-off-by: Stephen Stauts <stephen.stauts@nordicsemi.no>