### PR TITLE
boot: zephyr: cleanup NXP MPU configuration before boot

### DIFF
--- a/boot/zephyr/arm_cleanup.c
+++ b/boot/zephyr/arm_cleanup.c
@@ -5,6 +5,11 @@
  */
 
 #include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <toolchain.h>
+
+#if CONFIG_CPU_HAS_NXP_MPU
+#include <fsl_sysmpu.h>
+#endif
 
 void cleanup_arm_nvic(void) {
 	/* Allow any pending interrupts to be recognized */
@@ -31,6 +36,20 @@ __weak void z_arm_clear_arm_mpu_config(void)
 
 	for (i = 0; i < num_regions; i++) {
 		ARM_MPU_ClrRegion(i);
+	}
+}
+#elif CONFIG_CPU_HAS_NXP_MPU
+__weak void z_arm_clear_arm_mpu_config(void)
+{
+	int i;
+
+	int num_regions = FSL_FEATURE_SYSMPU_DESCRIPTOR_COUNT;
+
+	SYSMPU_Enable(SYSMPU, false);
+
+	/* NXP MPU region 0 is reserved for the debugger */
+	for (i = 1; i < num_regions; i++) {
+		SYSMPU_RegionEnable(SYSMPU, i, false);
 	}
 }
 #endif

--- a/boot/zephyr/include/arm_cleanup.h
+++ b/boot/zephyr/include/arm_cleanup.h
@@ -13,7 +13,7 @@
  */
 void cleanup_arm_nvic(void);
 
-#if defined(CONFIG_CPU_HAS_ARM_MPU)
+#if defined(CONFIG_CPU_HAS_ARM_MPU) || defined(CONFIG_CPU_HAS_NXP_MPU)
 /**
  * Cleanup all ARM MPU region configuration
  */

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -148,7 +148,7 @@ static void do_boot(struct boot_rsp *rsp)
     SCB_DisableICache();
 #endif
 
-#if CONFIG_CPU_HAS_ARM_MPU
+#if CONFIG_CPU_HAS_ARM_MPU || CONFIG_CPU_HAS_NXP_MPU
     z_arm_clear_arm_mpu_config();
 #endif
 


### PR DESCRIPTION
Cleanup the NXP MPU configuration before chain-loading the application.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>