### PR TITLE
Update FIH test docker flow on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,10 @@ install:
 script:
   - ./ci/${TEST}_run.sh
 
+cache:
+  directories:
+  - docker
+
 notifications:
   slack:
     rooms:

--- a/ci/fih-tests_install.sh
+++ b/ci/fih-tests_install.sh
@@ -16,13 +16,15 @@
 
 set -e
 
-# get mcuboot root; assumes running script is stored under REPO_DIR/ci/
-REPO_DIR=$(dirname $(dirname $(realpath $0)))
-pushd $(mktemp -d)
+DOCKER_DIR=docker
 
-# copy mcuboot so that it is part of the docker build context
-cp -r $REPO_DIR .
-cp -r $REPO_DIR/ci/fih_test_docker/execute_test.sh .
-cp -r $REPO_DIR/ci/fih_test_docker/Dockerfile .
-./mcuboot/ci/fih_test_docker/build.sh
-popd
+IMAGE=fih-test:0.0.1
+
+CACHED_IMAGE=$DOCKER_DIR/$IMAGE
+
+[[ -f $CACHED_IMAGE ]] && (gzip -dc $CACHED_IMAGE | docker load)
+
+if [[ $? -ne 0 ]]; then
+  docker pull mcuboot/$IMAGE
+  docker save mcuboot/$IMAGE | gzip > $CACHED_IMAGE
+fi

--- a/ci/fih-tests_run.sh
+++ b/ci/fih-tests_run.sh
@@ -16,8 +16,14 @@
 
 set -e
 
+pushd .. &&\
+   git clone https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git &&\
+   pushd trusted-firmware-m &&\
+   git checkout 8501b37db8e038ce39eb7f1039a514edea92c96e &&\
+   popd
+
 if test -z "$FIH_LEVEL"; then
-    docker run mcuboot/fih-test /bin/sh -c '/root/execute_test.sh $0 $1 $2' $SKIP_SIZE $BUILD_TYPE $DAMAGE_TYPE
+    docker run --rm -v $(pwd):/root/work/tfm:rw,z mcuboot/fih-test /bin/sh -c '/root/work/tfm/mcuboot/ci/fih_test_docker/execute_test.sh $0 $1 $2' $SKIP_SIZE $BUILD_TYPE $DAMAGE_TYPE
 else
-    docker run mcuboot/fih-test /bin/sh -c '/root/execute_test.sh $0 $1 $2 $3' $SKIP_SIZE $BUILD_TYPE $DAMAGE_TYPE $FIH_LEVEL
+    docker run --rm -v $(pwd):/root/work/tfm:rw,z mcuboot/fih-test /bin/sh -c '/root/work/tfm/mcuboot/ci/fih_test_docker/execute_test.sh $0 $1 $2 $3' $SKIP_SIZE $BUILD_TYPE $DAMAGE_TYPE $FIH_LEVEL
 fi

--- a/ci/fih_test_docker/docker-build/Dockerfile
+++ b/ci/fih_test_docker/docker-build/Dockerfile
@@ -31,24 +31,13 @@ RUN apt-get update && \
 RUN \
     # installing python packages
     python3 -m pip install \
-        imgtool==1.6.0 \
+        imgtool==1.7.0 \
         Jinja2==2.10 \
         PyYAML==3.12 \
         pyasn1==0.1.9
 
-# Clone TF-M and dependencies
-RUN mkdir -p /root/work/tfm &&\
-    cd /root/work/tfm  &&\
-    git clone https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git &&\
-    cd trusted-firmware-m &&\
-    git checkout 8501b37db8e038ce39eb7f1039a514edea92c96e &&\
-    cd .. &&\
-    mkdir mcuboot
-
-# Copy the test execution script to the image
-COPY execute_test.sh /root
-# copy the MCUBoot under test to the image
-COPY mcuboot /root/work/tfm/mcuboot
+# Add tfm work directory
+RUN mkdir -p /root/work/tfm
 
 # run the command
 CMD ["bash"]

--- a/ci/fih_test_docker/docker-build/build.sh
+++ b/ci/fih_test_docker/docker-build/build.sh
@@ -27,4 +27,3 @@ export LANG=C
 
 image=mcuboot/fih-test
 docker build --pull --tag=$image .
-echo $image > .docker-tag

--- a/ci/fih_test_docker/execute_test.sh
+++ b/ci/fih_test_docker/execute_test.sh
@@ -26,8 +26,6 @@ BUILD_TYPE=$2
 DAMAGE_TYPE=$3
 FIH_LEVEL=$4
 
-source ~/.bashrc
-
 if test -z "$FIH_LEVEL"; then
     # Use the default level
     CMAKE_FIH_LEVEL=""


### PR DESCRIPTION
Moved Dockerimage and build script to a separate directory. This should be used to build a new docker image and this image should be pushed to Docker hub. Source repos were removed from the image and only tools remain. The Travis config file was updated to pull and cache the used docker image instead of rebuilding all the time. The running script now clones trusted-firmware-m at the right place (sibiling to mcuboot clone) and runs the docker images mapping the VM's directory to the internal container.