### PR TITLE
bootutil: Fix wrong decryption attempt on invalid images

### DIFF
--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -104,6 +104,9 @@ boot_read_image_header(struct boot_loader_state *state, int slot,
 
     /* We only know where the headers are located when bs is valid */
     if (bs != NULL && out_hdr->ih_magic != IMAGE_MAGIC) {
+        /*  Image is not valid, unset all flags to avoid further
+         *  unexpected behaviour */
+        out_hdr->ih_flags = 0;
         rc = -1;
         goto done;
     }

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -73,6 +73,13 @@ boot_read_image_header(struct boot_loader_state *state, int slot,
         rc = BOOT_EFLASH;
     }
 
+    if (out_hdr->ih_magic != IMAGE_MAGIC) {
+       /*  Image is not valid, unset all flags to avoid further
+        *  unexpected behaviour */
+        out_hdr->ih_flags = 0;
+        rc = -1;
+    }
+
     return rc;
 }
 


### PR DESCRIPTION
With swap, and encryption active : virgin primary slots on flash
having 0xff erased pattern are detected as encrypted, and install
from secondary slot fails, when primary slot is fully erased

Signed-off-by: Michel Jaouen <michel.jaouen@st.com>