### PR TITLE
Enable support for building mcuboot for Mbed with direct-xip

### DIFF
--- a/boot/mbed/mbed_lib.json
+++ b/boot/mbed/mbed_lib.json
@@ -160,6 +160,20 @@
             "help": "Share data (NOT TESTED)",
             "macro_name": "MCUBOOT_DATA_SHARING",
             "value": null
+        },
+        "direct-xip": {
+            "help": "Enable ability to boot update candidates in-place.",
+            "macro_name": "MCUBOOT_DIRECT_XIP",
+            "value": null
+        },
+        "direct-xip-revert": {
+            "help": "Enable XIP revert mechanism. Only valid if direct-xip is also enabled.",
+            "macro_name": "MCUBOOT_DIRECT_XIP_REVERT",
+            "value": null
+        },
+        "xip-secondary-slot-address": {
+            "help": "Specify start address for secondary slot address in XIP-accessible memory. This is required if direct-xip is enabled.",
+            "value": null
         }
     }
 }

--- a/boot/mbed/src/secondary_bd.cpp
+++ b/boot/mbed/src/secondary_bd.cpp
@@ -1,0 +1,40 @@
+/*
+ * Mbed-OS Microcontroller Library
+ * Copyright (c) 2020 Embedded Planet
+ * Copyright (c) 2020 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#if MCUBOOT_DIRECT_XIP
+
+#include "flash_map_backend/secondary_bd.h"
+#include "platform/mbed_toolchain.h"
+#include "FlashIAPBlockDevice.h"
+
+/**
+ * For an XIP build, the secondary BD is provided by mcuboot by default.
+ *
+ * This is a weak symbol so the user can override it.
+ */
+MBED_WEAK mbed::BlockDevice* get_secondary_bd(void) {
+    static FlashIAPBlockDevice secondary_bd(MBED_CONF_MCUBOOT_XIP_SECONDARY_SLOT_ADDRESS,
+            MCUBOOT_SLOT_SIZE);
+
+    return &secondary_bd;
+}
+
+#endif
+
+


### PR DESCRIPTION
This commit introduces changes that allow users to build for other non-swap type update methods (overwrite only, swap using move, direct xip, or RAM loading). Changes include:

- Adding configuration options relating to XIP
- Updating the Mbed flash map backend to be compatible with XIP updates
- Add default secondary_bd in internal flash for XIP on Mbed OS.

Signed-off-by: George Beckstein <becksteing@embeddedplanet.com>
