### PR TITLE
bootutil: Modify boot_add_data_to_shared_area function scope

### DIFF
--- a/boot/bootutil/include/bootutil/boot_record.h
+++ b/boot/bootutil/include/bootutil/boot_record.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Arm Limited
+ * Copyright (c) 2018-2021 Arm Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,22 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief Add a data item to the shared data area between bootloader and
+ *        runtime SW
+ *
+ * @param[in] major_type  TLV major type, identify consumer
+ * @param[in] minor_type  TLV minor type, identify TLV type
+ * @param[in] size        length of added data
+ * @param[in] data        pointer to data
+ *
+ * @return                0 on success; nonzero on failure.
+ */
+int boot_add_data_to_shared_area(uint8_t        major_type,
+                                 uint16_t       minor_type,
+                                 size_t         size,
+                                 const uint8_t *data);
 
 /**
  * Add an image's all boot status information to the shared memory area

--- a/boot/bootutil/src/boot_record.c
+++ b/boot/bootutil/src/boot_record.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Arm Limited
+ * Copyright (c) 2018-2021 Arm Limited
  * Copyright (c) 2020 Linaro Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,18 +44,8 @@
  */
 static bool shared_memory_init_done;
 
-/**
- * @brief Add a data item to the shared data area between bootloader and
- *        runtime SW
- *
- * @param[in] major_type  TLV major type, identify consumer
- * @param[in] minor_type  TLV minor type, identify TLV type
- * @param[in] size        length of added data
- * @param[in] data        pointer to data
- *
- * @return                0 on success; nonzero on failure.
- */
-static int
+/* See in boot_record.h */
+int
 boot_add_data_to_shared_area(uint8_t        major_type,
                              uint16_t       minor_type,
                              size_t         size,
@@ -65,6 +55,10 @@ boot_add_data_to_shared_area(uint8_t        major_type,
     struct shared_boot_data *boot_data;
     uint16_t boot_data_size;
     uintptr_t tlv_end, offset;
+
+    if (data == NULL) {
+        return SHARED_MEMORY_GEN_ERROR;
+    }
 
     boot_data = (struct shared_boot_data *)MCUBOOT_SHARED_DATA_BASE;
 


### PR DESCRIPTION
Modify the function boot_add_data_to_shared_area from static to
global as it is used in the user interface boot_save_shared_data.

Signed-off-by: Sherry Zhang <sherry.zhang2@arm.com>