### PR TITLE
ci: relax signed-off-by checks on forks

### DIFF
--- a/ci/check-signed-off-by.sh
+++ b/ci/check-signed-off-by.sh
@@ -32,7 +32,16 @@ for sha in $commits; do
   lines="$(git show -s --format=%B ${sha})"
 
   found_author=false
-  found_committer=false
+  # Don't enforce committer email on forks; this primarily avoids issues
+  # running workflows on the zephyr fork, because rebases done in the GH UX
+  # use the primary email of the committer, which might not match the one
+  # used in git CLI.
+  if [[ $GITHUB_REPOSITORY == mcu-tools/* ]]; then
+    found_committer=false
+  else
+    found_committer=true
+  fi
+
   IFS=$'\n'
   for line in ${lines}; do
     stripped=$(echo $line | sed -e 's/^\s*//' | sed -e 's/\s*$//')


### PR DESCRIPTION
Addresses issues when running signed-off-by checks on the Zephyr fork due to GH rebases done on UX rewriting the commit with the primary email instead of whatever email was used originally.