### PR TITLE
ci: Update TF-M version

### DIFF
--- a/ci/fih-tests_run.sh
+++ b/ci/fih-tests_run.sh
@@ -19,7 +19,7 @@ set -e
 pushd .. &&\
    git clone https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git &&\
    pushd trusted-firmware-m &&\
-   git checkout 8501b37db8e038ce39eb7f1039a514edea92c96e &&\
+   git checkout 7ad5c5f23f4619add4aa6c88f4b25fc6fd84ec6e &&\
    popd
 
 if test -z "$FIH_LEVEL"; then


### PR DESCRIPTION
To fix a regression caused by f68473814f17a299ff8766bc3cf86e014552f479,
where an older TF-M version was used that didn't support the bootutil
cmake.

Signed-off-by: Raef Coles <raef.coles@arm.com>