### PR TITLE
boot: zephyr: Update after change in logging Kconfig

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -563,7 +563,7 @@ config MULTITHREADING
 	default n if SOC_FAMILY_NRF
 	default y
 
-config LOG_IMMEDIATE
+config LOG_FORCE_IMMEDIATE
 	default n if MULTITHREADING
 	default y
 


### PR DESCRIPTION
LOG_IMMEDIATE become a choice so cannot be redefined. Added
LOG_FORCE_IMMEDIATE to serve same purpose.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>