### PR TITLE
imgtool: add endianness support to verify command

### DIFF
--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -136,11 +136,13 @@ def getpriv(key, minimal):
 
 
 @click.argument('imgfile')
+@click.option('-e', '--endian', type=click.Choice(['little', 'big']),
+              default='little', help="Select little or big endian")
 @click.option('-k', '--key', metavar='filename')
 @click.command(help="Check that signed image can be verified by given key")
-def verify(key, imgfile):
+def verify(key, endian, imgfile):
     key = load_key(key) if key else None
-    ret, version, digest = image.Image.verify(imgfile, key)
+    ret, version, digest = image.Image.verify(imgfile, key, endian)
     if ret == image.VerifyResult.OK:
         print("Image was correctly validated")
         print("Image version: {}.{}.{}+{}".format(*version))


### PR DESCRIPTION
Add new cli option `-e` to specify endianness, similarly to how it is done for `create`/`sign` and use proper struct unpacking based on chosen endiannes.

This partly fixes #924 and must be rebased after #926 is merged.