### PR TITLE
boot: zephyr: fix Zephyr build

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -52,7 +52,7 @@ const struct boot_uart_funcs boot_funcs = {
 #endif
 
 #if defined(CONFIG_LOG) && !defined(CONFIG_LOG_IMMEDIATE) && \
-    !defined(CONFIG_LOG_MINIMAL)
+    !defined(CONFIG_LOG_MODE_MINIMAL)
 #ifdef CONFIG_LOG_PROCESS_THREAD
 #warning "The log internal thread for log processing can't transfer the log"\
          "well for MCUBoot."
@@ -259,7 +259,7 @@ static void do_boot(struct boot_rsp *rsp)
 #endif
 
 #if defined(CONFIG_LOG) && !defined(CONFIG_LOG_IMMEDIATE) &&\
-    !defined(CONFIG_LOG_PROCESS_THREAD) && !defined(CONFIG_LOG_MINIMAL)
+    !defined(CONFIG_LOG_PROCESS_THREAD) && !defined(CONFIG_LOG_MODE_MINIMAL)
 /* The log internal thread for log processing can't transfer log well as has too
  * low priority.
  * Dedicated thread for log processing below uses highest application

--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -31,7 +31,7 @@ CONFIG_FLASH=y
 # CONFIG_I2C is not set
 
 CONFIG_LOG=y
-CONFIG_LOG_MINIMAL=y
+CONFIG_LOG_MODE_MINIMAL=y
 ### Ensure Zephyr logging changes don't use more resources
 CONFIG_LOG_DEFAULT_LEVEL=0
 ### Decrease footprint by ~4 KB in comparison to CBPRINTF_COMPLETE=y


### PR DESCRIPTION
CONFIG_LOG_MINIMAL has now become CONFIG_LOG_MODE_MINIMAL.

Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>