### PR TITLE
boot:zephyr: CONFIG_LOG_MINIMAL converted to CONFIG_LOG_MODE_MINIMAL

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -51,8 +51,14 @@ const struct boot_uart_funcs boot_funcs = {
 #include <arm_cleanup.h>
 #endif
 
+/* CONFIG_LOG_MINIMAL is the legacy Kconfig property,
+ * replaced by CONFIG_LOG_MODE_MINIMAL.
+ */
+#define ZEPHYR_LOG_MODE_MINIMAL (defined(CONFIG_LOG_MODE_MINIMAL) ||\
+                                 defined(CONFIG_LOG_MINIMAL))
+
 #if defined(CONFIG_LOG) && !defined(CONFIG_LOG_IMMEDIATE) && \
-    !defined(CONFIG_LOG_MINIMAL)
+    !ZEPHYR_LOG_MODE_MINIMAL
 #ifdef CONFIG_LOG_PROCESS_THREAD
 #warning "The log internal thread for log processing can't transfer the log"\
          "well for MCUBoot."
@@ -259,7 +265,7 @@ static void do_boot(struct boot_rsp *rsp)
 #endif
 
 #if defined(CONFIG_LOG) && !defined(CONFIG_LOG_IMMEDIATE) &&\
-    !defined(CONFIG_LOG_PROCESS_THREAD) && !defined(CONFIG_LOG_MINIMAL)
+    !defined(CONFIG_LOG_PROCESS_THREAD) && !ZEPHYR_LOG_MODE_MINIMAL
 /* The log internal thread for log processing can't transfer log well as has too
  * low priority.
  * Dedicated thread for log processing below uses highest application

--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -31,7 +31,7 @@ CONFIG_FLASH=y
 # CONFIG_I2C is not set
 
 CONFIG_LOG=y
-CONFIG_LOG_MINIMAL=y
+CONFIG_LOG_MODE_MINIMAL=y # former CONFIG_MODE_MINIMAL
 ### Ensure Zephyr logging changes don't use more resources
 CONFIG_LOG_DEFAULT_LEVEL=0
 ### Decrease footprint by ~4 KB in comparison to CBPRINTF_COMPLETE=y


### PR DESCRIPTION
CONFIG_LOG_MINIMAL was replaced by CONFIG_LOG_MODE_MINIMAL since
https://github.com/zephyrproject-rtos/zephyr/pull/31404 PR was
merged.
CONFIG_LOG_MINIMAL is still emitted as legacy property, but
cat't be assigned so prj.conf was fixed.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>