### PR TITLE
Adding IMAGE_F_ROM_FIXED flag

### DIFF
--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -60,6 +60,12 @@ struct flash_area;
 #define IMAGE_F_RAM_LOAD                 0x00000020
 
 /*
+ * Indicates that ih_load_addr stores information on flash/ROM address the
+ * image has been built for.
+ */
+#define IMAGE_F_ROM_FIXED                0x00000100
+
+/*
  * ECSDA224 is with NIST P-224
  * ECSDA256 is with NIST P-256
  */

--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -50,8 +50,8 @@ struct flash_area;
  * Image header flags.
  */
 #define IMAGE_F_PIC                      0x00000001 /* Not supported. */
-#define IMAGE_F_NON_BOOTABLE             0x00000010 /* Split image app. */
 #define IMAGE_F_ENCRYPTED                0x00000004 /* Encrypted. */
+#define IMAGE_F_NON_BOOTABLE             0x00000010 /* Split image app. */
 /*
  * Indicates that this image should be loaded into RAM instead of run
  * directly from flash.  The address to load should be in the


### PR DESCRIPTION
The series of commits adds IMAGE_F_ROM_FIXED flag, which has already been defined in imgtool and used in mcumgr, but has been missed in mcuboot, and code that uses the flag to skip application images that have been placed in incorrect slot.
