### PR TITLE
boot: zephyr: Switch to chosen zephyr,uart-mcumgr for serial recovery

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -483,16 +483,17 @@ config BOOT_SERIAL_DETECT_DELAY
 	  the one used to place the device in bootloader mode.
 
 # Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_CONSOLE := zephyr,console
+DT_CHOSEN_Z_UART_MCUMGR := zephyr,uart-mcumgr
 
 config RECOVERY_UART_DEV_NAME
 	string "UART Device Name for Recovery UART"
-	default "$(dt_chosen_label,$(DT_CHOSEN_Z_CONSOLE))" if HAS_DTS
+	default "$(dt_chosen_label,$(DT_CHOSEN_Z_UART_MCUMGR))" if HAS_DTS
 	default "UART_0"
 	depends on BOOT_SERIAL_UART
 	help
 	  This option specifies the name of UART device to be used for
 	  serial recovery.
+	  By default the chosen zephyr,uart-mcumgr device is used.
 
 endif # MCUBOOT_SERIAL
 

--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -22,10 +22,6 @@
 #include "bootutil/bootutil_log.h"
 #include <usb/usb_device.h>
 
-#if defined(CONFIG_BOOT_SERIAL_UART) && defined(CONFIG_UART_CONSOLE)
-#error Zephyr UART console must been disabled if serial_adapter module is used.
-#endif
-
 MCUBOOT_LOG_MODULE_REGISTER(serial_adapter);
 
 /** @brief Console input representation


### PR DESCRIPTION
The commit changes the default device selection, for serial recovery,
from the DTS chosen zephyr,console to zephyr,uart-mcumgr.
This is more in line with Zephyr which uses the later for mcumgr
UART, which is also used for serial recovery in mcuboot.

The default configurations of Zephyr boards select the same device,
uart0, for both chosen devices; projects that do not use overlays to
change these selections will not be affected.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>