### PR TITLE
bootutil: Add cmake build file

### DIFF
--- a/boot/bootutil/CMakeLists.txt
+++ b/boot/bootutil/CMakeLists.txt
@@ -1,0 +1,35 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2020, Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#------------------------------------------------------------------------------
+
+add_library(bootutil STATIC)
+
+target_include_directories(bootutil
+    PUBLIC
+        include
+    PRIVATE
+        src
+)
+
+target_sources(bootutil
+    PRIVATE
+        src/boot_record.c
+        src/bootutil_misc.c
+        src/caps.c
+        src/encrypted.c
+        src/fault_injection_hardening.c
+        src/fault_injection_hardening_delay_rng_mbedtls.c
+        src/image_ec.c
+        src/image_ec256.c
+        src/image_ed25519.c
+        src/image_rsa.c
+        src/image_validate.c
+        src/loader.c
+        src/swap_misc.c
+        src/swap_move.c
+        src/swap_scratch.c
+        src/tlv.c
+)

--- a/ci/fih-tests_run.sh
+++ b/ci/fih-tests_run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2020 Arm Limited
+# Copyright (c) 2021 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ set -e
 pushd .. &&\
    git clone https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git &&\
    pushd trusted-firmware-m &&\
-   git checkout 8501b37db8e038ce39eb7f1039a514edea92c96e &&\
+   git checkout ed3980e7405599b39cbf19aef2d7dbbc8506f28a &&\
    popd
 
 if test -z "$FIH_LEVEL"; then

--- a/ci/fih_test_docker/execute_test.sh
+++ b/ci/fih_test_docker/execute_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2020 Arm Limited
+# Copyright (c) 2021 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ cmake -B $TFM_BUILD_DIR \
     -DTFM_PSA_API=ON \
     -DMCUBOOT_PATH=$MCUBOOT_PATH \
     -DMCUBOOT_LOG_LEVEL=INFO \
-    -DTFM_TEST_REPO_VERSION=93ce2f59c0c4a9cba6062834496b5f45deee4010 \
+    -DTFM_TEST_REPO_VERSION=98adf32da35e93aceefa6cee199350ba27e3a5b8 \
     $CMAKE_FIH_LEVEL \
     .
 cd $TFM_BUILD_DIR

--- a/ci/fih_test_docker/fi_tester_gdb.sh
+++ b/ci/fih_test_docker/fi_tester_gdb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2020 Arm Limited
+# Copyright (c) 2021 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ EOF
                 echo "    test_exec_ok: True"
                 echo "    skipped: True"
                 echo "    boot: False"
-                echo "    last_line: '$LAST_LINE' "
+                echo "    last_line: \"$LAST_LINE\" "
             fi
         else
             # The target was not stopped at the desired address.


### PR DESCRIPTION
In order to allow other projects to include the bootutil files more
easily. Allows renaming and moving of bootutil files without breaking
external projects' file lists (if they include this cmake file instead
of directly listing the files they use). Prevents an issue where
moving/renaming bootutil files breaks the FIH CI test.

The tfm and tfm-rest-repo versions have been updated not to break CI.

Signed-off-by: Raef Coles <raef.coles@arm.com>
Signed-off-by: Salome Thirot <salome.thirot@arm.com>
Change-Id: Ic982413c6a26ea2039712437f2d511fbe202e1e4