### PR TITLE
Introduce random IV and salt for encrypted image

### DIFF
--- a/boot/bootutil/include/bootutil/enc_key.h
+++ b/boot/bootutil/include/bootutil/enc_key.h
@@ -38,14 +38,11 @@
 extern "C" {
 #endif
 
-#define BOOT_ENC_KEY_SIZE_BITS  (BOOT_ENC_KEY_SIZE * 8)
-
-#define BOOT_ENC_TLV_ALIGN_SIZE \
-    ((((BOOT_ENC_TLV_SIZE - 1) / BOOT_MAX_ALIGN) + 1) * BOOT_MAX_ALIGN)
+#define BOOT_ENC_TLV_ALIGN_SIZE ENC_ALIGN_SIZE(BOOT_ENC_TLV_SIZE + BOOT_ENC_TLV_EXT_SIZE - 1)
 
 struct enc_key_data {
     uint8_t valid;
-    uint8_t aes_iv[BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE];
+    uint8_t aes_iv[BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE];
     bootutil_aes_ctr_context aes_ctr;
 };
 
@@ -59,7 +56,7 @@ int boot_enc_set_key(struct enc_key_data *enc_state, uint8_t slot,
 int boot_enc_load(struct enc_key_data *enc_state, int image_index,
         const struct image_header *hdr, const struct flash_area *fap,
         struct boot_status *bs);
-int boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey, uint32_t sz, uint8_t *enciv);
+int boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey, uint32_t sz);
 bool boot_enc_valid(struct enc_key_data *enc_state, int image_index,
         const struct flash_area *fap);
 void boot_encrypt(struct enc_key_data *enc_state, int image_index,

--- a/boot/bootutil/include/bootutil/enc_key.h
+++ b/boot/bootutil/include/bootutil/enc_key.h
@@ -45,6 +45,7 @@ extern "C" {
 
 struct enc_key_data {
     uint8_t valid;
+    uint8_t aes_iv[BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE];
     bootutil_aes_ctr_context aes_ctr;
 };
 
@@ -58,7 +59,7 @@ int boot_enc_set_key(struct enc_key_data *enc_state, uint8_t slot,
 int boot_enc_load(struct enc_key_data *enc_state, int image_index,
         const struct image_header *hdr, const struct flash_area *fap,
         struct boot_status *bs);
-int boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey);
+int boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey, uint32_t sz, uint8_t *enciv);
 bool boot_enc_valid(struct enc_key_data *enc_state, int image_index,
         const struct flash_area *fap);
 void boot_encrypt(struct enc_key_data *enc_state, int image_index,

--- a/boot/bootutil/include/bootutil/enc_key_public.h
+++ b/boot/bootutil/include/bootutil/enc_key_public.h
@@ -32,6 +32,8 @@
 extern "C" {
 #endif
 
+#define ENC_ALIGN_SIZE(x)       (((x) / BOOT_MAX_ALIGN + 1) * BOOT_MAX_ALIGN)
+
 #ifdef MCUBOOT_AES_256
 #define BOOT_ENC_KEY_SIZE       32
 #else
@@ -45,13 +47,30 @@ extern "C" {
 
 #if defined(MCUBOOT_ENCRYPT_RSA)
 #define BOOT_ENC_TLV_SIZE TLV_ENC_RSA_SZ
+#define BOOT_ENC_NONCE_SIZE 0
 #elif defined(MCUBOOT_ENCRYPT_EC256)
 #define BOOT_ENC_TLV_SIZE TLV_ENC_EC256_SZ
+#if defined(MCUBOOT_SWAP_SAVE_ENCTLV_RANDOM_IV)
+#define BOOT_ENC_TLV_EXT_SIZE 32  /* optional HKDF salt (sha256 digest size) */
+#else
+#define BOOT_ENC_TLV_EXT_SIZE 0
+#endif
+#define BOOT_ENC_NONCE_SIZE 16
 #elif defined(MCUBOOT_ENCRYPT_X25519)
 #define BOOT_ENC_TLV_SIZE TLV_ENC_X25519_SZ
+#if defined(MCUBOOT_SWAP_SAVE_ENCTLV_RANDOM_IV)
+#define BOOT_ENC_TLV_EXT_SIZE 32  /* optional HKDF salt (sha256 digest size) */
+#else
+#define BOOT_ENC_TLV_EXT_SIZE 0
+#endif
+#define BOOT_ENC_NONCE_SIZE 16
 #else
 #define BOOT_ENC_TLV_SIZE TLV_ENC_KW_SZ
+#define BOOT_ENC_TLV_EXT_SIZE 0
+#define BOOT_ENC_NONCE_SIZE 0
 #endif
+
+#define BOOT_ENC_ALIGN_SIZE ENC_ALIGN_SIZE((BOOT_ENC_KEY_SIZE + BOOT_ENC_NONCE_SIZE) - 1)
 
 #ifdef __cplusplus
 }

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -272,6 +272,8 @@ boot_read_enc_key(int image_index, uint8_t slot, struct boot_status *bs)
     if (rc == 0) {
         off = boot_enc_key_off(fap, slot);
 #if MCUBOOT_SWAP_SAVE_ENCTLV
+        uint8_t aes_iv[BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE];
+
         rc = flash_area_read(fap, off, bs->enctlv[slot], BOOT_ENC_TLV_ALIGN_SIZE);
         if (rc == 0) {
             for (i = 0; i < BOOT_ENC_TLV_ALIGN_SIZE; i++) {
@@ -281,7 +283,7 @@ boot_read_enc_key(int image_index, uint8_t slot, struct boot_status *bs)
             }
             /* Only try to decrypt non-erased TLV metadata */
             if (i != BOOT_ENC_TLV_ALIGN_SIZE) {
-                rc = boot_enc_decrypt(bs->enctlv[slot], bs->enckey[slot]);
+                rc = boot_enc_decrypt(bs->enctlv[slot], bs->enckey[slot], 0, aes_iv);
             }
         }
 #else

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -82,7 +82,7 @@ struct boot_status {
     uint8_t swap_type;    /* The type of swap in effect */
     uint32_t swap_size;   /* Total size of swapped image */
 #ifdef MCUBOOT_ENC_IMAGES
-    uint8_t enckey[BOOT_NUM_SLOTS][BOOT_ENC_KEY_SIZE];
+    uint8_t encinfo[BOOT_NUM_SLOTS][BOOT_ENC_ALIGN_SIZE];
 #if MCUBOOT_SWAP_SAVE_ENCTLV
     uint8_t enctlv[BOOT_NUM_SLOTS][BOOT_ENC_TLV_ALIGN_SIZE];
 #endif

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -153,12 +153,6 @@ boot_copy_done_off(const struct flash_area *fap)
     return boot_image_ok_off(fap) - BOOT_MAX_ALIGN;
 }
 
-static inline uint32_t
-boot_swap_size_off(const struct flash_area *fap)
-{
-    return boot_swap_info_off(fap) - BOOT_MAX_ALIGN;
-}
-
 uint32_t
 boot_swap_info_off(const struct flash_area *fap)
 {
@@ -190,19 +184,6 @@ boot_magic_compatible_check(uint8_t tbl_val, uint8_t val)
         return tbl_val == val;
     }
 }
-
-#ifdef MCUBOOT_ENC_IMAGES
-static inline uint32_t
-boot_enc_key_off(const struct flash_area *fap, uint8_t slot)
-{
-#if MCUBOOT_SWAP_SAVE_ENCTLV
-    return boot_swap_size_off(fap) - ((slot + 1) *
-            ((((BOOT_ENC_TLV_SIZE - 1) / BOOT_MAX_ALIGN) + 1) * BOOT_MAX_ALIGN));
-#else
-    return boot_swap_size_off(fap) - ((slot + 1) * BOOT_ENC_KEY_SIZE);
-#endif
-}
-#endif
 
 bool bootutil_buffer_is_erased(const struct flash_area *area,
                                const void *buffer, size_t len)

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -297,15 +297,16 @@ parse_x25519_enckey(uint8_t **p, uint8_t *end, uint8_t *private_key)
  * @param ikm_len   Length of the input data.
  * @param info      An information tag.
  * @param info_len  Length of the information tag.
+ * @param salt      An salt tag.
+ * @param salt_len  Length of the salt tag.
  * @param okm       Output of the KDF computation.
  * @param okm_len   On input the requested length; on output the generated length
  */
 static int
-hkdf(uint8_t *ikm, uint16_t ikm_len, uint8_t *info, uint16_t info_len,
-        uint8_t *okm, uint16_t *okm_len)
+hkdf(const uint8_t *ikm, uint16_t ikm_len, const uint8_t *info, uint16_t info_len,
+        const uint8_t *salt, uint16_t salt_len, uint8_t *okm, uint16_t *okm_len)
 {
     bootutil_hmac_sha256_context hmac;
-    uint8_t salt[BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE];
     uint8_t prk[BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE];
     uint8_t T[BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE];
     uint16_t off;
@@ -324,8 +325,7 @@ hkdf(uint8_t *ikm, uint16_t ikm_len, uint8_t *info, uint16_t info_len,
 
     bootutil_hmac_sha256_init(&hmac);
 
-    memset(salt, 0, BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
-    rc = bootutil_hmac_sha256_set_key(&hmac, salt, BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
+    rc = bootutil_hmac_sha256_set_key(&hmac, salt, salt_len);
     if (rc != 0) {
         goto error;
     }
@@ -436,7 +436,8 @@ boot_enc_set_key(struct enc_key_data *enc_state, uint8_t slot,
 #elif defined(MCUBOOT_ENCRYPT_KW)
 #    define EXPECTED_ENC_TLV    IMAGE_TLV_ENC_KW
 #elif defined(MCUBOOT_ENCRYPT_EC256)
-#    define EXPECTED_ENC_TLV    IMAGE_TLV_ENC_EC256
+#    define EXPECTED_ENC_TLV     IMAGE_TLV_ENC_EC256
+#    define EXPECTED_ENC_EXT_LEN (EXPECTED_ENC_LEN + BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE)
 #    define EC_PUBK_INDEX       (0)
 #    define EC_TAG_INDEX        (65)
 #    define EC_CIPHERKEY_INDEX  (65 + 32)
@@ -451,14 +452,19 @@ _Static_assert(EC_CIPHERKEY_INDEX + BOOT_ENC_KEY_SIZE == EXPECTED_ENC_LEN,
         "Please fix ECIES-X25519 component indexes");
 #endif
 
+#ifndef EXPECTED_ENC_EXT_LEN
+#define EXPECTED_ENC_EXT_LEN        EXPECTED_ENC_LEN
+#endif
+
 /*
  * Decrypt an encryption key TLV.
  *
  * @param buf An encryption TLV read from flash (build time fixed length)
+ * @param sz An encryption TLV buffer data size
  * @param enckey An AES-128 or AES-256 key sized buffer to store to plain key.
  */
 int
-boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey)
+boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey, uint32_t sz, uint8_t *enciv)
 {
 #if defined(MCUBOOT_ENCRYPT_RSA)
     mbedtls_rsa_context rsa;
@@ -475,14 +481,24 @@ boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey)
 #if defined(MCUBOOT_ENCRYPT_EC256) || defined(MCUBOOT_ENCRYPT_X25519)
     bootutil_hmac_sha256_context hmac;
     bootutil_aes_ctr_context aes_ctr;
+    uint8_t salt[BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE];
     uint8_t tag[BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE];
     uint8_t shared[SHARED_KEY_LEN];
-    uint8_t derived_key[BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE + BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE];
+    uint8_t derived_key[BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE + 
+                        BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE + 
+                        BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE * 2];
     uint8_t *cp;
     uint8_t *cpend;
     uint8_t private_key[PRIV_KEY_LEN];
     uint8_t counter[BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE];
     uint16_t len;
+    uint16_t out_len;
+    const uint8_t *my_salt = salt;
+    uint8_t *my_key_iv = counter;
+    uint8_t *my_counter = counter;
+#else
+    (void)sz;
+    (void)enciv;
 #endif
     int rc = -1;
 
@@ -532,6 +548,7 @@ boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey)
     bootutil_ecdh_p256_init(&ecdh_p256);
 
     rc = bootutil_ecdh_p256_shared_secret(&ecdh_p256, &buf[EC_PUBK_INDEX], private_key, shared);
+
     bootutil_ecdh_p256_drop(&ecdh_p256);
     if (rc != 0) {
         return -1;
@@ -573,10 +590,31 @@ boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey)
      * Expand shared secret to create keys for AES-128-CTR + HMAC-SHA256
      */
 
+    /* Prepare for default encryption scheme with zero salt and AES IVs */
+    memset(counter, 0, BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE);
+    memset(salt, 0, BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
+
     len = BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE + BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE;
-    rc = hkdf(shared, SHARED_KEY_LEN, (uint8_t *)"MCUBoot_ECIES_v1", 16,
-            derived_key, &len);
-    if (rc != 0 || len != (BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE + BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE)) {
+
+    if (sz > EXPECTED_ENC_LEN) {
+        /* Use new enhanced encryption scheme with randomly generated salt and AES IVs */
+        len += BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE * 2;
+
+        my_salt = &buf[EXPECTED_ENC_LEN];
+
+        my_key_iv = &derived_key[BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE +
+                                 BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE];
+
+        my_counter = &derived_key[BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE +
+                                  BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE +
+                                  BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE];
+    }
+
+    out_len = len;
+    rc = hkdf(shared, SHARED_KEY_LEN, (uint8_t *)"MCUBoot_ECIES_v1", BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE,
+              my_salt, BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE, derived_key, &out_len);
+
+    if (rc != 0 || len != out_len) {
         return -1;
     }
 
@@ -586,13 +624,14 @@ boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey)
 
     bootutil_hmac_sha256_init(&hmac);
 
-    rc = bootutil_hmac_sha256_set_key(&hmac, &derived_key[BOOT_ENC_KEY_SIZE], 32);
+    rc = bootutil_hmac_sha256_set_key(&hmac, &derived_key[BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE],
+                                      BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
     if (rc != 0) {
         (void)bootutil_hmac_sha256_drop(&hmac);
         return -1;
     }
 
-    rc = bootutil_hmac_sha256_update(&hmac, &buf[EC_CIPHERKEY_INDEX], BOOT_ENC_KEY_SIZE);
+    rc = bootutil_hmac_sha256_update(&hmac, &buf[EC_CIPHERKEY_INDEX], BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE);
     if (rc != 0) {
         (void)bootutil_hmac_sha256_drop(&hmac);
         return -1;
@@ -605,22 +644,20 @@ boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey)
         return -1;
     }
 
-    if (bootutil_constant_time_compare(tag, &buf[EC_TAG_INDEX], 32) != 0) {
+    if (bootutil_constant_time_compare(tag, &buf[EC_TAG_INDEX], BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE) != 0) {
         (void)bootutil_hmac_sha256_drop(&hmac);
         return -1;
     }
 
     bootutil_hmac_sha256_drop(&hmac);
 
+    (void)memcpy(enciv, my_counter, BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE);
+
     /*
      * Finally decrypt the received ciphered key
      */
 
     bootutil_aes_ctr_init(&aes_ctr);
-    if (rc != 0) {
-        bootutil_aes_ctr_drop(&aes_ctr);
-        return -1;
-    }
 
     rc = bootutil_aes_ctr_set_key(&aes_ctr, derived_key);
     if (rc != 0) {
@@ -628,8 +665,8 @@ boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey)
         return -1;
     }
 
-    memset(counter, 0, BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE);
-    rc = bootutil_aes_ctr_decrypt(&aes_ctr, counter, &buf[EC_CIPHERKEY_INDEX], BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE, 0, enckey);
+    rc = bootutil_aes_ctr_decrypt(&aes_ctr, my_key_iv, &buf[EC_CIPHERKEY_INDEX],
+                                  BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE, 0, enckey);
     if (rc != 0) {
         bootutil_aes_ctr_drop(&aes_ctr);
         return -1;
@@ -658,7 +695,7 @@ boot_enc_load(struct enc_key_data *enc_state, int image_index,
 #if MCUBOOT_SWAP_SAVE_ENCTLV
     uint8_t *buf;
 #else
-    uint8_t buf[EXPECTED_ENC_LEN];
+    uint8_t buf[EXPECTED_ENC_EXT_LEN];
 #endif
     uint8_t slot;
     int rc;
@@ -687,7 +724,7 @@ boot_enc_load(struct enc_key_data *enc_state, int image_index,
         return rc;
     }
 
-    if (len != EXPECTED_ENC_LEN) {
+    if ((len < EXPECTED_ENC_LEN) || (len > EXPECTED_ENC_EXT_LEN)) {
         return -1;
     }
 
@@ -696,12 +733,12 @@ boot_enc_load(struct enc_key_data *enc_state, int image_index,
     memset(buf, 0xff, BOOT_ENC_TLV_ALIGN_SIZE);
 #endif
 
-    rc = flash_area_read(fap, off, buf, EXPECTED_ENC_LEN);
+    rc = flash_area_read(fap, off, buf, len);
     if (rc) {
         return -1;
     }
 
-    return boot_enc_decrypt(buf, bs->enckey[slot]);
+    return (boot_enc_decrypt(buf, bs->enckey[slot], len, enc_state[slot].aes_iv));
 }
 
 bool
@@ -726,7 +763,7 @@ boot_encrypt(struct enc_key_data *enc_state, int image_index,
         uint32_t blk_off, uint8_t *buf)
 {
     struct enc_key_data *enc;
-    uint8_t nonce[16];
+    uint8_t *nonce;
     int rc;
 
     /* boot_copy_region will call boot_encrypt with sz = 0 when skipping over
@@ -734,13 +771,6 @@ boot_encrypt(struct enc_key_data *enc_state, int image_index,
     if (sz == 0) {
        return;
     }
-
-    memset(nonce, 0, 12);
-    off >>= 4;
-    nonce[12] = (uint8_t)(off >> 24);
-    nonce[13] = (uint8_t)(off >> 16);
-    nonce[14] = (uint8_t)(off >> 8);
-    nonce[15] = (uint8_t)off;
 
     rc = flash_area_id_to_multi_image_slot(image_index, fap->fa_id);
     if (rc < 0) {
@@ -750,6 +780,15 @@ boot_encrypt(struct enc_key_data *enc_state, int image_index,
 
     enc = &enc_state[rc];
     assert(enc->valid == 1);
+
+    nonce = enc->aes_iv;
+
+    off >>= 4;
+    nonce[12] = (uint8_t)(off >> 24);
+    nonce[13] = (uint8_t)(off >> 16);
+    nonce[14] = (uint8_t)(off >> 8);
+    nonce[15] = (uint8_t)off;
+
     bootutil_aes_ctr_encrypt(&enc->aes_ctr, nonce, buf, sz, blk_off, buf);
 }
 

--- a/boot/bootutil/src/image_ec256.c
+++ b/boot/bootutil/src/image_ec256.c
@@ -97,7 +97,7 @@ bootutil_parse_eckey(mbedtls_ecdsa_context *ctx, uint8_t **p, uint8_t *end)
     }
     return 0;
 }
-#endif /* CY_MBEDTLS_HW_ACCELERATION */
+#else /* !CY_MBEDTLS_HW_ACCELERATION */
 static int
 bootutil_import_key(uint8_t **cp, uint8_t *end)
 {
@@ -139,6 +139,7 @@ bootutil_import_key(uint8_t **cp, uint8_t *end)
 
     return 0;
 }
+#endif /* CY_MBEDTLS_HW_ACCELERATION */
 
 #ifndef MCUBOOT_ECDSA_NEED_ASN1_SIG
 /*

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -294,7 +294,7 @@ void
 boot_status_reset(struct boot_status *bs)
 {
 #ifdef MCUBOOT_ENC_IMAGES
-    memset(&bs->enckey, 0xff, BOOT_NUM_SLOTS * BOOT_ENC_KEY_SIZE);
+    memset(&bs->encinfo, 0xff, BOOT_NUM_SLOTS * BOOT_ENC_ALIGN_SIZE);
 #if MCUBOOT_SWAP_SAVE_ENCTLV
     memset(&bs->enctlv, 0xff, BOOT_NUM_SLOTS * BOOT_ENC_TLV_ALIGN_SIZE);
 #endif
@@ -1106,7 +1106,7 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
                 rc = 0;
             }
         } else {
-            memset(bs->enckey[0], 0xff, BOOT_ENC_KEY_SIZE);
+            memset(bs->encinfo[0], 0xff, BOOT_ENC_ALIGN_SIZE);
         }
 #endif
 
@@ -1130,7 +1130,7 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
                 rc = 0;
             }
         } else {
-            memset(bs->enckey[1], 0xff, BOOT_ENC_KEY_SIZE);
+            memset(bs->encinfo[1], 0xff, BOOT_ENC_ALIGN_SIZE);
         }
 #endif
 
@@ -1154,13 +1154,13 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
             rc = boot_read_enc_key(image_index, slot, bs);
             assert(rc == 0);
 
-            for (i = 0; i < BOOT_ENC_KEY_SIZE; i++) {
-                if (bs->enckey[slot][i] != 0xff) {
+            for (i = 0; i < BOOT_ENC_ALIGN_SIZE; i++) {
+                if (bs->encinfo[slot][i] != 0xff) {
                     break;
                 }
             }
 
-            if (i != BOOT_ENC_KEY_SIZE) {
+            if (i != BOOT_ENC_ALIGN_SIZE) {
                 boot_enc_set_key(BOOT_CURR_ENC(state), slot, bs);
             }
         }

--- a/boot/cypress/BlinkyApp/BlinkyApp.mk
+++ b/boot/cypress/BlinkyApp/BlinkyApp.mk
@@ -113,6 +113,7 @@ OUT_CFG := $(OUT_TARGET)/$(BUILDCFG)
 ifeq ($(IMG_TYPE), UPGRADE)
 	ifeq ($(ENC_IMG), 1)
 		SIGN_ARGS += --encrypt ../../$(ENC_KEY_FILE).pem
+		SIGN_ARGS += --use-random-iv
 	endif
 	SIGN_ARGS += --pad
 	UPGRADE_SUFFIX :=_upgrade

--- a/boot/cypress/MCUBootApp/config/mcuboot_config/mcuboot_logging.h
+++ b/boot/cypress/MCUBootApp/config/mcuboot_config/mcuboot_logging.h
@@ -94,6 +94,7 @@ int sim_log_enabled(int level);
 #define MCUBOOT_LOG_DBG(...) IGNORE(__VA_ARGS__)
 #endif
 
-#define MCUBOOT_LOG_MODULE_DECLARE(...)
+#define MCUBOOT_LOG_MODULE_DECLARE(domain)  /* ignore */
+#define MCUBOOT_LOG_MODULE_REGISTER(domain) /* ignore */
 
 #endif /* MCUBOOT_LOGGING_H */

--- a/docs/design.md
+++ b/docs/design.md
@@ -380,13 +380,19 @@ image trailer. An image trailer has the following structure:
     ~    Swap status (BOOT_MAX_IMG_SECTORS * min-write-size * 3)    ~
     ~                                                               ~
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                 Encryption key 0 (16 octets) [*]              |
+    |                 Encryption key 1 (16 octets) [1]              |
     |                                                               |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                 Encryption key 1 (16 octets) [*]              |
+    |                Encryption nonce 1 (12 octets) [2]             |
+    |                               |     0xff padding (4 octets)   |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                 Encryption key 0 (16 octets) [1]              |
     |                                                               |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                      Swap size (4 octets)                     |
+    |                Encryption nonce 0 (12 octets) [2]             |
+    |                               |     0xff padding (4 octets)   |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |    0xff padding (4 octets)    |     Swap size (4 octets)      |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |   Swap info   |           0xff padding (7 octets)             |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -399,7 +405,8 @@ image trailer. An image trailer has the following structure:
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ```
 
-[*]: Only present if the encryption option is enabled (`MCUBOOT_ENC_IMAGES`).
+[1]: Only present if the encryption option is enabled (`MCUBOOT_ENC_IMAGES`).
+[2]: Only present with encryption using `MCUBOOT_ENC_EC256` or `MCUBOOT_ENC_X25519`.
 
 The offset immediately following such a record represents the start of the next
 flash area.

--- a/docs/encrypted_images.md
+++ b/docs/encrypted_images.md
@@ -92,20 +92,25 @@ libraries. The whole key encryption can be summarized as:
   keypair. Those keys will be our ephemeral keys.
 * Generate a new secret (DH) using the ephemeral private key and the public key
   that corresponds to the private key embedded in the HW.
-* Derive the new keys from the secret using HKDF (built on HMAC-SHA256). We
+* Derive the new keys from the secret using HKDF (built on HMAC-SHA256). By default we
   are not using a `salt` and using an `info` of `MCUBoot_ECIES_v1`, generating
-  48 bytes of key material.
-* A new random encryption key is generated (for AES). This is
+  48 bytes of key material. Random salt value can be generated and included in TLV
+  info however, when using option `--use-random-iv` of `imgtool`. MCUBoot uses random
+  salt if it is present in TLVs.
+* A new random encryption key of 16 bytes is generated (for AES-128). This is
   the AES key used to encrypt the images.
-* The key is encrypted with AES-128-CTR or AES-256-CTR and a `nonce` of 0 using
-  the first 16 bytes of key material generated previously by the HKDF.
+* The key is encrypted with AES-128-CTR and a `nonce` of 0 by default, using the first
+  16 bytes of key material generated previously by the HKDF. Random `nonce` can be
+  generated however, when using option `--use-random-iv` of `imgtool`. In this case
+  12 bytes filled with random data and last 4 bytes are 0.
 * The encrypted key now goes through a HMAC-SHA256 using the remaining 32
   bytes of key material from the HKDF.
 
-The final TLV is built from the 65 bytes for ECIES-P256 or 32 bytes for
+The final TLV is built from the 65 bytes for ECIES-P256  or 32 bytes for
 ECIES-X25519, which correspond to the ephemeral public key, followed by the
-32 bytes of MAC tag and the 16 or 32 bytes of the encrypted key, resulting in
-a TLV of 113 or 129 bytes for ECIES-P256 and 80 or 96 bytes for ECIES-X25519.
+32 bytes of MAC tag and the 16 bytes of the encrypted key, resulting in a TLV
+of 113 bytes (additional 32 bytes if random salt used and 16 bytes of CTR random nonce
+resulting in 161 bytes) for ECIES-P256 or 80 bytes for ECIES-X25519.
 
 The implemenation of ECIES-P256 is named ENC_EC256 in the source code and
 artifacts while ECIES-X25519 is named ENC_X25519.
@@ -133,7 +138,9 @@ sectors are re-encrypted when copying from the `primary slot` to
 the `secondary slot`.
 
 PS: Each encrypted image must have its own key TLV that should be unique
-and used only for this particular image.
+and used only for this particular image. Random `nonce` and `salt` can be
+used as addtional sources of randomised data. Security is not compromised
+however until unique key is used for each encrypted image.
 
 Also when swap method is employed, the sizes of both images are saved to
 the status area just before starting the upgrade process, because it

--- a/docs/imgtool.md
+++ b/docs/imgtool.md
@@ -89,6 +89,8 @@ primary slot and adds a header and trailer that the bootloader is expecting:
       --save-enctlv                 When upgrading, save encrypted key TLVs
                                     instead of plain keys. Enable when
                                     BOOT_SWAP_SAVE_ENCTLV config option was set.
+      --use-random-iv               Generate random nonce data for encrypted image,
+                                    0 used by default
       -L, --load-addr INTEGER       Load address for image when it should run
                                     from RAM.
       -x, --hex-addr INTEGER        Adjust address in hex output file.

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -158,6 +158,9 @@ class Image():
         self.enckey = None
         self.save_enctlv = save_enctlv
         self.enctlv_len = 0
+        self.hkdf_salt = None
+        self.hkdf_len = 48
+        self.enc_nonce = bytes([0] * 16)
 
         if security_counter == 'auto':
             # Security counter has not been explicitly provided,
@@ -229,7 +232,7 @@ class Image():
                                                   self.save_enctlv,
                                                   self.enctlv_len)
                 trailer_addr = (self.base_addr + self.slot_size) - trailer_size
-                padding = bytearray([self.erased_val] * 
+                padding = bytearray([self.erased_val] *
                                     (trailer_size - len(boot_magic)))
                 if self.confirm and not self.overwrite_only:
                     padding[-MAX_ALIGN] = 0x01  # image_ok = 0x01
@@ -268,13 +271,18 @@ class Image():
             newpk = X25519PrivateKey.generate()
             shared = newpk.exchange(enckey._get_public())
         derived_key = HKDF(
-            algorithm=hashes.SHA256(), length=48, salt=None,
+            algorithm=hashes.SHA256(), length=self.hkdf_len, salt=self.hkdf_salt,
             info=b'MCUBoot_ECIES_v1', backend=default_backend()).derive(shared)
+        if self.hkdf_salt is not None:
+            key_nonce = derived_key[48:64]
+            self.enc_nonce = derived_key[64:76] + bytes([0] * 4)
+        else:
+            key_nonce = bytes([0] * 16)
         encryptor = Cipher(algorithms.AES(derived_key[:16]),
-                           modes.CTR(bytes([0] * 16)),
+                           modes.CTR(key_nonce),
                            backend=default_backend()).encryptor()
         cipherkey = encryptor.update(plainkey) + encryptor.finalize()
-        mac = hmac.HMAC(derived_key[16:], hashes.SHA256(),
+        mac = hmac.HMAC(derived_key[16:48], hashes.SHA256(),
                         backend=default_backend())
         mac.update(cipherkey)
         ciphermac = mac.finalize()
@@ -289,8 +297,12 @@ class Image():
         return cipherkey, ciphermac, pubk
 
     def create(self, key, public_key_format, enckey, dependencies=None,
-               sw_type=None, custom_tlvs=None, encrypt_keylen=128):
+               sw_type=None, custom_tlvs=None, encrypt_keylen=128, use_random_iv=False):
         self.enckey = enckey
+
+        if use_random_iv:
+            self.hkdf_salt = os.urandom(32)
+            self.hkdf_len += 16 * 2   # 48 for basic scheme + 16 * 2 for random IVs
 
         # Calculate the hash of the public key
         if key is not None:
@@ -450,13 +462,15 @@ class Image():
                                      x25519.X25519Public)):
                 cipherkey, mac, pubk = self.ecies_hkdf(enckey, plainkey)
                 enctlv = pubk + mac + cipherkey
+                if self.hkdf_salt is not None:
+                    enctlv += self.hkdf_salt
                 self.enctlv_len = len(enctlv)
                 if isinstance(enckey, ecdsa.ECDSA256P1Public):
                     tlv.add('ENCEC256', enctlv)
                 else:
                     tlv.add('ENCX25519', enctlv)
 
-            nonce = bytes([0] * 16)
+            nonce = self.enc_nonce
             cipher = Cipher(algorithms.AES(plainkey), modes.CTR(nonce),
                             backend=default_backend())
             encryptor = cipher.encryptor()

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -302,7 +302,7 @@ class Image():
 
         if use_random_iv:
             self.hkdf_salt = os.urandom(32)
-            self.hkdf_len += 16 * 2   # 48 for basic scheme + 16 * 2 for random IVs
+            self.hkdf_len += 16 + 12
 
         # Calculate the hash of the public key
         if key is not None:

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -294,14 +294,17 @@ class BasedIntParamType(click.ParamType):
               default='hash', help='In what format to add the public key to '
               'the image manifest: full key or hash of the key.')
 @click.option('-k', '--key', metavar='filename')
+@click.option('--use-random-iv', default=False, is_flag=True,
+              help='Use random Salt and IV (initial vectors) for the image '
+              'encrypting scheme')
 @click.command(help='''Create a signed or unsigned image\n
                INFILE and OUTFILE are parsed as Intel HEX if the params have
                .hex extension, otherwise binary format is used''')
 def sign(key, public_key_format, align, version, pad_sig, header_size,
          pad_header, slot_size, pad, confirm, max_sectors, overwrite_only,
-         endian, encrypt_keylen, encrypt, infile, outfile, dependencies,
-         load_addr, hex_addr, erased_val, save_enctlv, security_counter,
-         boot_record, custom_tlv, rom_fixed):
+         endian, encrypt_keylen, encrypt, infile, outfile, dependencies, load_addr, hex_addr,
+         erased_val, save_enctlv, security_counter, boot_record, custom_tlv,
+         rom_fixed, use_random_iv):
 
     if confirm:
         # Confirmed but non-padded images don't make much sense, because
@@ -348,7 +351,7 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
             custom_tlvs[tag] = value.encode('utf-8')
 
     img.create(key, public_key_format, enckey, dependencies, boot_record,
-               custom_tlvs, int(encrypt_keylen))
+               custom_tlvs, int(encrypt_keylen), use_random_iv=use_random_iv)
     img.save(outfile, hex_addr)
 
 

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -296,7 +296,8 @@ class BasedIntParamType(click.ParamType):
 @click.option('-k', '--key', metavar='filename')
 @click.option('--use-random-iv', default=False, is_flag=True,
               help='Use random Salt and IV (initial vectors) for the image '
-              'encrypting scheme')
+              'encrypting scheme. This might require build time configuration '
+              'changes in the bootloader.')
 @click.command(help='''Create a signed or unsigned image\n
                INFILE and OUTFILE are parsed as Intel HEX if the params have
                .hex extension, otherwise binary format is used''')

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -28,6 +28,7 @@ bootstrap = ["mcuboot-sys/bootstrap"]
 multiimage = ["mcuboot-sys/multiimage"]
 large-write = []
 downgrade-prevention = ["mcuboot-sys/downgrade-prevention"]
+random-iv = ["mcuboot-sys/random-iv"]
 
 [dependencies]
 byteorder = "1.3"

--- a/sim/mcuboot-sys/Cargo.toml
+++ b/sim/mcuboot-sys/Cargo.toml
@@ -71,6 +71,10 @@ multiimage = []
 # Check (in software) against version downgrades.
 downgrade-prevention = []
 
+# For ECIES based encryption, add a random salt to the HKDF and expand extra
+# key material to be used to encrypt the key and image using random nonces
+# instead of zeros.
+random-iv = []
 
 [build-dependencies]
 cc = "1.0.25"

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -30,6 +30,7 @@ fn main() {
     let bootstrap = env::var("CARGO_FEATURE_BOOTSTRAP").is_ok();
     let multiimage = env::var("CARGO_FEATURE_MULTIIMAGE").is_ok();
     let downgrade_prevention = env::var("CARGO_FEATURE_DOWNGRADE_PREVENTION").is_ok();
+    let random_iv = env::var("CARGO_FEATURE_RANDOM_IV").is_ok();
 
     let mut conf = cc::Build::new();
     conf.define("__BOOTSIM__", None);
@@ -221,6 +222,9 @@ fn main() {
         conf.define("MCUBOOT_ENC_IMAGES", None);
         conf.define("MCUBOOT_USE_TINYCRYPT", None);
         conf.define("MCUBOOT_SWAP_SAVE_ENCTLV", None);
+        if random_iv {
+            conf.define("MCUBOOT_SWAP_SAVE_ENCTLV_RANDOM_IV", None);
+        }
 
         conf.file("../../boot/bootutil/src/encrypted.c");
         conf.file("csupport/keys.c");
@@ -274,6 +278,9 @@ fn main() {
         conf.define("MCUBOOT_ENC_IMAGES", None);
         conf.define("MCUBOOT_USE_TINYCRYPT", None);
         conf.define("MCUBOOT_SWAP_SAVE_ENCTLV", None);
+        if random_iv {
+            conf.define("MCUBOOT_SWAP_SAVE_ENCTLV_RANDOM_IV", None);
+        }
 
         conf.file("../../boot/bootutil/src/encrypted.c");
         conf.file("csupport/keys.c");

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1323,6 +1323,18 @@ fn install_image(flash: &mut SimMultiFlash, slot: &SlotInfo, len: usize,
     }
     let mut b_tlv = tlv.make_tlv();
 
+    // Generate encrypted images
+    let mut b_encimg = vec![];
+    if is_encrypted {
+        let enc_key = tlv.get_enc_key();
+        let key = GenericArray::from_slice(enc_key.as_slice());
+        let enc_nonce = tlv.get_enc_nonce();
+        let nonce = GenericArray::from_slice(enc_nonce.as_slice());
+        let mut cipher = Aes128Ctr::new(&key, &nonce);
+        b_encimg = b_img.clone();
+        cipher.apply_keystream(&mut b_encimg);
+    }
+
     let dev = flash.get_mut(&dev_id).unwrap();
 
     let mut buf = vec![];


### PR DESCRIPTION
This PR introduces randomised IV (nonce) and salt as input to form HKDF data for encrypted images.

Commits:
**imgtool:** adds flag `--use-random-iv` which allows randomised data embedding to HKDF data - turned off by default to keep compatibility.
**bootutil:** changes to support update in mcuboot
**cypress:** updates to cypress code to support changes

This PR is dependent on: https://github.com/mcu-tools/mcuboot/pull/957 and https://github.com/mcu-tools/mcuboot/pull/884
