### PR TITLE
bootutil: Fix boot_write_trailer write alignment

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -294,47 +294,6 @@ boot_read_enc_key(int image_index, uint8_t slot, struct boot_status *bs)
 }
 #endif
 
-/**
- * Write trailer data; status bytes, swap_size, etc
- *
- * @returns 0 on success, != 0 on error.
- */
-static int
-boot_write_trailer(const struct flash_area *fap, uint32_t off,
-        const uint8_t *inbuf, uint8_t inlen)
-{
-    uint8_t buf[BOOT_MAX_ALIGN];
-    uint8_t align;
-    uint8_t erased_val;
-    int rc;
-
-    align = flash_area_align(fap);
-    if (inlen > BOOT_MAX_ALIGN || align > BOOT_MAX_ALIGN) {
-        return -1;
-    }
-    erased_val = flash_area_erased_val(fap);
-    if (align < inlen) {
-        align = inlen;
-    }
-    memcpy(buf, inbuf, inlen);
-    memset(&buf[inlen], erased_val, align - inlen);
-
-    rc = flash_area_write(fap, off, buf, align);
-    if (rc != 0) {
-        return BOOT_EFLASH;
-    }
-
-    return 0;
-}
-
-static int
-boot_write_trailer_flag(const struct flash_area *fap, uint32_t off,
-        uint8_t flag_val)
-{
-    const uint8_t buf[1] = { flag_val };
-    return boot_write_trailer(fap, off, buf, 1);
-}
-
 int
 boot_write_copy_done(const struct flash_area *fap)
 {

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -251,6 +251,10 @@ int boot_write_image_ok(const struct flash_area *fap);
 int boot_write_swap_info(const struct flash_area *fap, uint8_t swap_type,
                          uint8_t image_num);
 int boot_write_swap_size(const struct flash_area *fap, uint32_t swap_size);
+int boot_write_trailer(const struct flash_area *fap, uint32_t off,
+                       const uint8_t *inbuf, uint8_t inlen);
+int boot_write_trailer_flag(const struct flash_area *fap, uint32_t off,
+                            uint8_t flag_val);
 int boot_read_swap_size(int image_index, uint32_t *swap_size);
 int boot_slots_compatible(struct boot_loader_state *state);
 uint32_t boot_status_internal_off(const struct boot_status *bs, int elem_sz);

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -334,7 +334,7 @@ boot_write_magic(const struct flash_area *fap)
  *
  * @returns 0 on success, != 0 on error.
  */
-static int
+int
 boot_write_trailer(const struct flash_area *fap, uint32_t off,
         const uint8_t *inbuf, uint8_t inlen)
 {
@@ -362,7 +362,7 @@ boot_write_trailer(const struct flash_area *fap, uint32_t off,
     return 0;
 }
 
-static int
+int
 boot_write_trailer_flag(const struct flash_area *fap, uint32_t off,
         uint8_t flag_val)
 {

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -344,13 +344,12 @@ boot_write_trailer(const struct flash_area *fap, uint32_t off,
     int rc;
 
     align = flash_area_align(fap);
-    if (inlen > BOOT_MAX_ALIGN || align > BOOT_MAX_ALIGN) {
+    align = (inlen + align - 1) & ~(align - 1);
+    if (align > BOOT_MAX_ALIGN) {
         return -1;
     }
     erased_val = flash_area_erased_val(fap);
-    if (align < inlen) {
-        align = inlen;
-    }
+
     memcpy(buf, inbuf, inlen);
     memset(&buf[inlen], erased_val, align - inlen);
 


### PR DESCRIPTION
The commit fixes alignment issue in boot_write_trailer, that would
occur in case when input buffer length would be greater than
alignment parameter of flash.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

Possible scenario:
```
let align = 4
let inlen = 7
```
ccording to the previous logic `align < inlen => align = inlen` (line 316-318). which means that
```
320: memset(&buf[inlen], erased_val, align - inlen);
```
does not write any erase value to fill in buffer because `align - inlen == 0`. and line
```
322: rc = flash_area_write(fap, off, buf, align);
```
writes unaligned buffer due to `align == inlen == 7`


Test PR for zephyr: https://github.com/zephyrproject-rtos/zephyr/pull/33292