### PR TITLE
cmake: fix evaluation with empty signature key file

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -250,20 +250,20 @@ if(CONFIG_MCUBOOT_SERIAL)
     )
 endif()
 
-# CONF_FILE points to the KConfig configuration files of the bootloader.
-foreach (filepath ${CONF_FILE})
-  file(READ ${filepath} temp_text)
-  string(FIND "${temp_text}" ${CONFIG_BOOT_SIGNATURE_KEY_FILE} match)
-  if (${match} GREATER_EQUAL 0)
-    if (NOT DEFINED CONF_DIR)
-      get_filename_component(CONF_DIR ${filepath} DIRECTORY)
-    else()
-      message(FATAL_ERROR "Signature key file defined in multiple conf files")
-    endif()
-  endif()
-endforeach()
-
 if(NOT CONFIG_BOOT_SIGNATURE_KEY_FILE STREQUAL "")
+  # CONF_FILE points to the KConfig configuration files of the bootloader.
+  foreach (filepath ${CONF_FILE})
+    file(READ ${filepath} temp_text)
+    string(FIND "${temp_text}" ${CONFIG_BOOT_SIGNATURE_KEY_FILE} match)
+    if (${match} GREATER_EQUAL 0)
+      if (NOT DEFINED CONF_DIR)
+        get_filename_component(CONF_DIR ${filepath} DIRECTORY)
+      else()
+        message(FATAL_ERROR "Signature key file defined in multiple conf files")
+      endif()
+    endif()
+  endforeach()
+
   if(IS_ABSOLUTE ${CONFIG_BOOT_SIGNATURE_KEY_FILE})
     set(KEY_FILE ${CONFIG_BOOT_SIGNATURE_KEY_FILE})
   elseif((DEFINED CONF_DIR) AND


### PR DESCRIPTION
When CONFIG_BOOT_SIGNATURE_KEY_FILE is left empty, the cmake find command gets
called with a wrong number of arguments. This patch skips the search for the
signature key file within config files in that case.

Signed-off-by: Nico Lastzka <Nico.Lastzka@ATSonline.de>