### PR TITLE
RFC: Replace direct access to flash_area/flash_sector fields with getter functions

### DIFF
--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -152,7 +152,7 @@ struct image_tlv {
 #define IS_ENCRYPTED(hdr) (((hdr)->ih_flags && IMAGE_F_ENCRYPTED_AES128) \
                         || ((hdr)->ih_flags && IMAGE_F_ENCRYPTED_AES256))
 #define MUST_DECRYPT(fap, idx, hdr) \
-    ((fap)->fa_id == FLASH_AREA_IMAGE_SECONDARY(idx) && IS_ENCRYPTED(hdr))
+    (flash_area_get_id(fap) == FLASH_AREA_IMAGE_SECONDARY(idx) && IS_ENCRYPTED(hdr))
 
 _Static_assert(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
                "struct image_header not required size");

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -123,12 +123,12 @@ int
 boot_status_entries(int image_index, const struct flash_area *fap)
 {
 #if MCUBOOT_SWAP_USING_SCRATCH
-    if (fap->fa_id == FLASH_AREA_IMAGE_SCRATCH) {
+    if (flash_area_get_id(fap) == FLASH_AREA_IMAGE_SCRATCH) {
         return BOOT_STATUS_STATE_COUNT;
     } else
 #endif
-    if (fap->fa_id == FLASH_AREA_IMAGE_PRIMARY(image_index) ||
-               fap->fa_id == FLASH_AREA_IMAGE_SECONDARY(image_index)) {
+    if (flash_area_get_id(fap) == FLASH_AREA_IMAGE_PRIMARY(image_index) ||
+        flash_area_get_id(fap) == FLASH_AREA_IMAGE_SECONDARY(image_index)) {
         return BOOT_STATUS_STATE_COUNT * BOOT_STATUS_MAX_ENTRIES;
     }
     return -1;
@@ -144,14 +144,14 @@ boot_status_off(const struct flash_area *fap)
 
     off_from_end = boot_trailer_sz(elem_sz);
 
-    assert(off_from_end <= fap->fa_size);
-    return fap->fa_size - off_from_end;
+    assert(off_from_end <= flash_area_get_size(fap));
+    return flash_area_get_size(fap) - off_from_end;
 }
 
 static inline uint32_t
 boot_magic_off(const struct flash_area *fap)
 {
-    return fap->fa_size - BOOT_MAGIC_SZ;
+    return flash_area_get_size(fap) - BOOT_MAGIC_SZ;
 }
 
 static inline uint32_t
@@ -301,8 +301,8 @@ boot_write_copy_done(const struct flash_area *fap)
 
     off = boot_copy_done_off(fap);
     BOOT_LOG_DBG("writing copy_done; fa_id=%d off=0x%lx (0x%lx)",
-                 fap->fa_id, (unsigned long)off,
-                 (unsigned long)(fap->fa_off + off));
+                 flash_area_get_id(fap), (unsigned long)off,
+                 (unsigned long)(flash_area_get_off(fap) + off));
     return boot_write_trailer_flag(fap, off, BOOT_FLAG_SET);
 }
 
@@ -313,8 +313,8 @@ boot_write_swap_size(const struct flash_area *fap, uint32_t swap_size)
 
     off = boot_swap_size_off(fap);
     BOOT_LOG_DBG("writing swap_size; fa_id=%d off=0x%lx (0x%lx)",
-                 fap->fa_id, (unsigned long)off,
-                 (unsigned long)fap->fa_off + off);
+                 flash_area_get_id(fap), (unsigned long)off,
+                 (unsigned long)flash_area_get_off(fap) + off);
     return boot_write_trailer(fap, off, (const uint8_t *) &swap_size, 4);
 }
 
@@ -328,8 +328,8 @@ boot_write_enc_key(const struct flash_area *fap, uint8_t slot,
 
     off = boot_enc_key_off(fap, slot);
     BOOT_LOG_DBG("writing enc_key; fa_id=%d off=0x%lx (0x%lx)",
-                 fap->fa_id, (unsigned long)off,
-                 (unsigned long)fap->fa_off + off);
+                 flash_area_get_id(fap), (unsigned long)off,
+                 (unsigned long)flash_area_get_off(fap) + off);
 #if MCUBOOT_SWAP_SAVE_ENCTLV
     rc = flash_area_write(fap, off, bs->enctlv[slot], BOOT_ENC_TLV_ALIGN_SIZE);
 #else

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -359,7 +359,7 @@ boot_img_num_sectors(const struct boot_loader_state *state, size_t slot)
 static inline uint32_t
 boot_img_slot_off(struct boot_loader_state *state, size_t slot)
 {
-    return BOOT_IMG(state, slot).area->fa_off;
+    return flash_area_get_off(BOOT_IMG(state, slot).area);
 }
 
 #ifndef MCUBOOT_USE_FLASH_AREA_GET_SECTORS
@@ -368,7 +368,7 @@ static inline size_t
 boot_img_sector_size(const struct boot_loader_state *state,
                      size_t slot, size_t sector)
 {
-    return BOOT_IMG(state, slot).sectors[sector].fa_size;
+    return flash_area_get_size(&BOOT_IMG(state, slot).sectors[sector]);
 }
 
 /*
@@ -379,8 +379,8 @@ static inline uint32_t
 boot_img_sector_off(const struct boot_loader_state *state, size_t slot,
                     size_t sector)
 {
-    return BOOT_IMG(state, slot).sectors[sector].fa_off -
-           BOOT_IMG(state, slot).sectors[0].fa_off;
+    return flash_area_get_off(&BOOT_IMG(state, slot).sectors[sector]) -
+           flash_area_get_off(&BOOT_IMG(state, slot).sectors[0]);
 }
 
 #else  /* defined(MCUBOOT_USE_FLASH_AREA_GET_SECTORS) */
@@ -389,15 +389,15 @@ static inline size_t
 boot_img_sector_size(const struct boot_loader_state *state,
                      size_t slot, size_t sector)
 {
-    return BOOT_IMG(state, slot).sectors[sector].fs_size;
+    return flash_sector_get_size(&BOOT_IMG(state, slot).sectors[sector]);
 }
 
 static inline uint32_t
 boot_img_sector_off(const struct boot_loader_state *state, size_t slot,
                     size_t sector)
 {
-    return BOOT_IMG(state, slot).sectors[sector].fs_off -
-           BOOT_IMG(state, slot).sectors[0].fs_off;
+    return flash_sector_get_off(&BOOT_IMG(state, slot).sectors[sector]) -
+           flash_sector_get_off(&BOOT_IMG(state, slot).sectors[0]);
 }
 
 #endif  /* !defined(MCUBOOT_USE_FLASH_AREA_GET_SECTORS) */

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -138,7 +138,7 @@ boot_flag_decode(uint8_t flag)
 static inline uint32_t
 boot_magic_off(const struct flash_area *fap)
 {
-    return fap->fa_size - BOOT_MAGIC_SZ;
+    return flash_area_get_size(fap) - BOOT_MAGIC_SZ;
 }
 
 static inline uint32_t
@@ -319,8 +319,8 @@ boot_write_magic(const struct flash_area *fap)
     off = boot_magic_off(fap);
 
     BOOT_LOG_DBG("writing magic; fa_id=%d off=0x%lx (0x%lx)",
-                 fap->fa_id, (unsigned long)off,
-                 (unsigned long)(fap->fa_off + off));
+                 flash_area_get_id(fap), (unsigned long)off,
+                 (unsigned long)(flash_area_get_off(fap) + off));
     rc = flash_area_write(fap, off, boot_img_magic, BOOT_MAGIC_SZ);
     if (rc != 0) {
         return BOOT_EFLASH;
@@ -376,8 +376,8 @@ boot_write_image_ok(const struct flash_area *fap)
 
     off = boot_image_ok_off(fap);
     BOOT_LOG_DBG("writing image_ok; fa_id=%d off=0x%lx (0x%lx)",
-                 fap->fa_id, (unsigned long)off,
-                 (unsigned long)(fap->fa_off + off));
+                 flash_area_get_id(fap), (unsigned long)off,
+                 (unsigned long)(flash_area_get_off(fap) + off));
     return boot_write_trailer_flag(fap, off, BOOT_FLAG_SET);
 }
 
@@ -403,8 +403,9 @@ boot_write_swap_info(const struct flash_area *fap, uint8_t swap_type,
     off = boot_swap_info_off(fap);
     BOOT_LOG_DBG("writing swap_info; fa_id=%d off=0x%lx (0x%lx), swap_type=0x%x"
                  " image_num=0x%x",
-                 fap->fa_id, (unsigned long)off,
-                 (unsigned long)(fap->fa_off + off), swap_type, image_num);
+                 flash_area_get_id(fap), (unsigned long)off,
+                 (unsigned long)(flash_area_get_off(fap) + off),
+                 swap_type, image_num);
     return boot_write_trailer(fap, off, (const uint8_t *) &swap_info, 1);
 }
 
@@ -529,7 +530,7 @@ boot_set_pending_multi(int image_index, int permanent)
         /* The image slot is corrupt.  There is no way to recover, so erase the
          * slot to allow future upgrades.
          */
-        flash_area_erase(fap, 0, fap->fa_size);
+        flash_area_erase(fap, 0, flash_area_get_size(fap));
         rc = BOOT_EBADIMAGE;
         break;
 

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -663,7 +663,7 @@ boot_enc_load(struct enc_key_data *enc_state, int image_index,
     uint8_t slot;
     int rc;
 
-    rc = flash_area_id_to_multi_image_slot(image_index, fap->fa_id);
+    rc = flash_area_id_to_multi_image_slot(image_index, flash_area_get_id(fap));
     if (rc < 0) {
         return rc;
     }
@@ -710,7 +710,7 @@ boot_enc_valid(struct enc_key_data *enc_state, int image_index,
 {
     int rc;
 
-    rc = flash_area_id_to_multi_image_slot(image_index, fap->fa_id);
+    rc = flash_area_id_to_multi_image_slot(image_index, flash_area_get_id(fap));
     if (rc < 0) {
         /* can't get proper slot number - skip encryption, */
         /* postpone the error for a upper layer */
@@ -742,7 +742,7 @@ boot_encrypt(struct enc_key_data *enc_state, int image_index,
     nonce[14] = (uint8_t)(off >> 8);
     nonce[15] = (uint8_t)off;
 
-    rc = flash_area_id_to_multi_image_slot(image_index, fap->fa_id);
+    rc = flash_area_id_to_multi_image_slot(image_index, flash_area_get_id(fap));
     if (rc < 0) {
         assert(0);
         return;

--- a/boot/bootutil/src/swap_misc.c
+++ b/boot/bootutil/src/swap_misc.c
@@ -46,7 +46,7 @@ swap_erase_trailer_sectors(const struct boot_loader_state *state,
     uint8_t image_index;
     int rc;
 
-    BOOT_LOG_DBG("erasing trailer; fa_id=%d", fap->fa_id);
+    BOOT_LOG_DBG("erasing trailer; fa_id=%d", flash_area_get_id(fap));
 
     image_index = BOOT_CURR_IMG(state);
     fa_id_primary = flash_area_id_from_multi_image_slot(image_index,
@@ -54,9 +54,9 @@ swap_erase_trailer_sectors(const struct boot_loader_state *state,
     fa_id_secondary = flash_area_id_from_multi_image_slot(image_index,
             BOOT_SECONDARY_SLOT);
 
-    if (fap->fa_id == fa_id_primary) {
+    if (flash_area_get_id(fap) == fa_id_primary) {
         slot = BOOT_PRIMARY_SLOT;
-    } else if (fap->fa_id == fa_id_secondary) {
+    } else if (flash_area_get_id(fap) == fa_id_secondary) {
         slot = BOOT_SECONDARY_SLOT;
     } else {
         return BOOT_EFLASH;
@@ -94,7 +94,7 @@ swap_status_init(const struct boot_loader_state *state,
 
     image_index = BOOT_CURR_IMG(state);
 
-    BOOT_LOG_DBG("initializing status; fa_id=%d", fap->fa_id);
+    BOOT_LOG_DBG("initializing status; fa_id=%d", flash_area_get_id(fap));
 
     rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_SECONDARY(image_index),
             &swap_state);

--- a/boot/bootutil/src/swap_priv.h
+++ b/boot/bootutil/src/swap_priv.h
@@ -95,7 +95,7 @@ void swap_run(struct boot_loader_state *state,
 
 static inline size_t boot_scratch_area_size(const struct boot_loader_state *state)
 {
-    return BOOT_SCRATCH_AREA(state)->fa_size;
+    return flash_area_get_size(BOOT_SCRATCH_AREA(state));
 }
 #endif
 

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -541,7 +541,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
 
     if (bs->state == BOOT_STATUS_STATE_0) {
         BOOT_LOG_DBG("erasing scratch area");
-        rc = boot_erase_region(fap_scratch, 0, fap_scratch->fa_size);
+        rc = boot_erase_region(fap_scratch, 0, flash_area_get_size(fap_scratch));
         assert(rc == 0);
 
         if (bs->idx == BOOT_STATUS_IDX_0) {
@@ -564,7 +564,8 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
                 assert(rc == 0);
 
                 /* Erase the temporary trailer from the scratch area. */
-                rc = boot_erase_region(fap_scratch, 0, fap_scratch->fa_size);
+                rc = boot_erase_region(fap_scratch, 0,
+                        flash_area_get_size(fap_scratch));
                 assert(rc == 0);
             }
         }

--- a/boot/cypress/cy_flash_pal/include/flash_map_backend/flash_map_backend.h
+++ b/boot/cypress/cy_flash_pal/include/flash_map_backend/flash_map_backend.h
@@ -92,6 +92,26 @@ struct flash_area {
     uint32_t fa_size;
 };
 
+static inline uint8_t flash_area_get_id(const struct flash_area *fa)
+{
+    return fa->fa_id;
+}
+
+static inline uint8_t flash_area_get_device_id(const struct flash_area *fa)
+{
+    return fa->fa_device_id;
+}
+
+static inline uint32_t flash_area_get_off(const struct flash_area *fa)
+{
+    return fa->fa_off;
+}
+
+static inline uint32_t flash_area_get_size(const struct flash_area *fa)
+{
+    return fa->fa_size;
+}
+
 /**
  * @brief Structure describing a sector within a flash area.
  *
@@ -110,6 +130,16 @@ struct flash_sector {
      */
     uint32_t fs_size;
 };
+
+static inline uint32_t flash_sector_get_off(const struct flash_sector *fs)
+{
+    return fs->fs_off;
+}
+
+static inline uint32_t flash_sector_get_size(const struct flash_sector *fs)
+{
+    return fs->fs_size;
+}
 
 struct flash_map_entry {
     uint32_t magic;

--- a/boot/mbed/include/flash_map_backend/flash_map_backend.h
+++ b/boot/mbed/include/flash_map_backend/flash_map_backend.h
@@ -75,6 +75,26 @@ struct flash_area {
     uint32_t fa_size;
 };
 
+static inline uint8_t flash_area_get_id(const struct flash_area *fa)
+{
+    return fa->fa_id;
+}
+
+static inline uint8_t flash_area_get_device_id(const struct flash_area *fa)
+{
+    return fa->fa_device_id;
+}
+
+static inline uint32_t flash_area_get_off(const struct flash_area *fa)
+{
+    return fa->fa_off;
+}
+
+static inline uint32_t flash_area_get_size(const struct flash_area *fa)
+{
+    return fa->fa_size;
+}
+
 /**
  * @brief Structure describing a sector within a flash area.
  *
@@ -93,6 +113,16 @@ struct flash_sector {
      */
     uint32_t fs_size;
 };
+
+static inline uint32_t flash_sector_get_off(const struct flash_sector *fs)
+{
+    return fs->fs_off;
+}
+
+static inline uint32_t flash_sector_get_size(const struct flash_sector *fs)
+{
+    return fs->fs_size;
+}
 
 /*
  * Start using flash area.

--- a/boot/mynewt/flash_map_backend/include/flash_map_backend/flash_map_backend.h
+++ b/boot/mynewt/flash_map_backend/include/flash_map_backend/flash_map_backend.h
@@ -8,6 +8,7 @@
 #define __FLASH_MAP_BACKEND_H__
 
 #include <sysflash/sysflash.h>
+#include <flash_map/flash_map.h>
 #include <mcuboot_config/mcuboot_config.h>
 
 #if (MCUBOOT_IMAGE_NUMBER == 1)
@@ -38,5 +39,25 @@
 
 int flash_area_id_from_multi_image_slot(int image_index, int slot);
 int flash_area_id_to_multi_image_slot(int image_index, int area_id);
+
+static inline uint8_t flash_area_get_id(const struct flash_area *fa)
+{
+    return fa->fa_id;
+}
+
+static inline uint8_t flash_area_get_device_id(const struct flash_area *fa)
+{
+    return fa->fa_device_id;
+}
+
+static inline uint32_t flash_area_get_off(const struct flash_area *fa)
+{
+    return fa->fa_off;
+}
+
+static inline uint32_t flash_area_get_size(const struct flash_area *fa)
+{
+    return fa->fa_size;
+}
 
 #endif /* __FLASH_MAP_BACKEND_H__ */

--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -109,6 +109,12 @@ int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
     return rc;
 }
 
+uint8_t flash_area_get_device_id(const struct flash_area *fa)
+{
+	(void)fa;
+	return FLASH_DEVICE_ID;
+}
+
 #define ERASED_VAL 0xff
 __weak uint8_t flash_area_erased_val(const struct flash_area *fap)
 {

--- a/boot/zephyr/include/flash_map_backend/flash_map_backend.h
+++ b/boot/zephyr/include/flash_map_backend/flash_map_backend.h
@@ -76,11 +76,38 @@ int flash_area_id_to_multi_image_slot(int image_index, int area_id);
  */
 int flash_area_sector_from_off(off_t off, struct flash_sector *sector);
 
+static inline uint32_t flash_area_get_off(const struct flash_area *fa)
+{
+	return (uint32_t)fa->fa_off;
+}
+
+static inline uint32_t flash_area_get_size(const struct flash_area *fa)
+{
+	return (uint32_t)fa->fa_size;
+}
+
+static inline uint8_t flash_area_get_id(const struct flash_area *fa)
+{
+	return fa->fa_id;
+}
+
+uint8_t flash_area_get_device_id(const struct flash_area *fa);
+
 /*
  * Returns the value expected to be read when accessing any erased
  * flash byte.
  */
 uint8_t flash_area_erased_val(const struct flash_area *fap);
+
+static inline uint32_t flash_sector_get_off(const struct flash_sector *fs)
+{
+	return fs->fs_off;
+}
+
+static inline uint32_t flash_sector_get_size(const struct flash_sector *fs)
+{
+	return fs->fs_size;
+}
 
 #ifdef __cplusplus
 }

--- a/boot/zephyr/single_loader.c
+++ b/boot/zephyr/single_loader.c
@@ -83,7 +83,7 @@ boot_image_load_header(const struct flash_area *fa_p,
     }
 
     if (!boot_u32_safe_add(&size, hdr->ih_img_size, hdr->ih_hdr_size) ||
-        size >= fa_p->fa_size) {
+        size >= flash_area_get_size(fa_p)) {
         return BOOT_EBADIMAGE;
     }
 
@@ -120,8 +120,8 @@ boot_go(struct boot_rsp *rsp)
     fih_rc = FIH_SUCCESS;
 #endif /* MCUBOOT_VALIDATE_PRIMARY_SLOT */
 
-    rsp->br_flash_dev_id = _fa_p->fa_device_id;
-    rsp->br_image_off = _fa_p->fa_off;
+    rsp->br_flash_dev_id = flash_area_get_device_id(_fa_p);
+    rsp->br_image_off = flash_area_get_off(_fa_p);
     rsp->br_hdr = &_hdr;
 
 out:

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -422,6 +422,12 @@ int flash_area_id_to_multi_image_slot(int image_index, int area_id)
     abort();
 }
 
+uint8_t flash_area_get_device_id(const struct flash_area *fa)
+{
+	(void)fa;
+	return 0;
+}
+
 void sim_assert(int x, const char *assertion, const char *file, unsigned int line, const char *function)
 {
     if (!(x)) {


### PR DESCRIPTION
Intention of this PR is to present an idea that should allow the mcuboot to become system agnostic regarding
the internal structure of flash_area and flash_sector objects.
The idea is to provide getter/setter macros (here) or functions that should only be used to access the fields of objects
and forbid direct access to fields.
Such approach should allow greater flexibility regarding management and processing of such objects as it should allow additional, system processing of returned values, which, after obtaining an object (for example flash_area) is not possible,
