### PR TITLE
Mbed: Make scratch BlockDevice customizable

### DIFF
--- a/boot/mbed/include/flash_map_backend/secondary_bd.h
+++ b/boot/mbed/include/flash_map_backend/secondary_bd.h
@@ -27,9 +27,30 @@
  * This is implemented as a weak function and may be redefined
  * by the application. The default case is to return the
  * BlockDevice object returned by BlockDevice::get_default_instance();
+ * 
+ * For an XIP build, the secondary BD is provided by mcuboot by default.
+ * 
+ * This is implemented as a weak symbol so the user can override it.
  *
  * @retval secondary_bd Secondary BlockDevice where update candidates are stored
  */
 mbed::BlockDevice* get_secondary_bd(void);
+
+/**
+ * This is implemented as a weak function and may be redefined
+ * by the application. By default, scratch space is at the end of 
+ * internal flash, after the main application.
+ *
+ * This is implemented as a weak symbol so the user can override it.
+ * 
+ * Security warning: Using an external scratch memory might compromise 
+ * the security of encrypted images. In this case, the scratch and 
+ * slot 0 are encrypted. If the swap is moved to external memory, 
+ * it could be read if the swap were interrupted. Done enough 
+ * times, this could be used to extract the plaintext image.
+ *
+ * @retval scratch_bd BlockDevice containing the scratch region
+ */
+mbed::BlockDevice* get_scratch_bd(void);
 
 #endif /* MCUBOOT_BOOT_MBED_INCLUDE_FLASH_MAP_BACKEND_SECONDARY_BD_H_ */

--- a/boot/mbed/src/flash_map_backend.cpp
+++ b/boot/mbed/src/flash_map_backend.cpp
@@ -39,15 +39,14 @@ mbed::BlockDevice* mcuboot_secondary_bd = get_secondary_bd();
 static FlashIAPBlockDevice mcuboot_primary_bd(MCUBOOT_PRIMARY_SLOT_START_ADDR, MCUBOOT_SLOT_SIZE);
 
 #if MCUBOOT_SWAP_USING_SCRATCH
-/** Scratch space is at the end of internal flash, after the main application */
-static FlashIAPBlockDevice mcuboot_scratch_bd(MCUBOOT_SCRATCH_START_ADDR, MCUBOOT_SCRATCH_SIZE);
+mbed::BlockDevice* mcuboot_scratch_bd = get_scratch_bd();
 #endif
 
 static mbed::BlockDevice* flash_map_bd[FLASH_AREAS] = {
-        (mbed::BlockDevice*) &mcuboot_primary_bd,       /** Primary (loadable) image area */
-        mcuboot_secondary_bd,                           /** Secondary (update candidate) image area */
+    (mbed::BlockDevice*) &mcuboot_primary_bd,       /** Primary (loadable) image area */
+    mcuboot_secondary_bd,                           /** Secondary (update candidate) image area */
 #if MCUBOOT_SWAP_USING_SCRATCH
-        (mbed::BlockDevice*) &mcuboot_scratch_bd        /** Scratch space for swapping images */
+    mcuboot_scratch_bd                              /** Scratch space for swapping images */
 #else
         nullptr
 #endif

--- a/boot/mbed/src/secondary_bd.cpp
+++ b/boot/mbed/src/secondary_bd.cpp
@@ -17,17 +17,13 @@
  * limitations under the License
  */
 
-#if MCUBOOT_DIRECT_XIP
-
 #include "flash_map_backend/secondary_bd.h"
 #include "platform/mbed_toolchain.h"
 #include "FlashIAPBlockDevice.h"
+#include "bootutil_priv.h"
 
-/**
- * For an XIP build, the secondary BD is provided by mcuboot by default.
- *
- * This is a weak symbol so the user can override it.
- */
+#if MCUBOOT_DIRECT_XIP
+
 MBED_WEAK mbed::BlockDevice* get_secondary_bd(void) {
     static FlashIAPBlockDevice secondary_bd(MBED_CONF_MCUBOOT_XIP_SECONDARY_SLOT_ADDRESS,
             MCUBOOT_SLOT_SIZE);
@@ -37,4 +33,12 @@ MBED_WEAK mbed::BlockDevice* get_secondary_bd(void) {
 
 #endif
 
+#if MCUBOOT_SWAP_USING_SCRATCH
 
+MBED_WEAK mbed::BlockDevice* get_scratch_bd(void) {
+    static FlashIAPBlockDevice scratch_bd(MCUBOOT_SCRATCH_START_ADDR, MCUBOOT_SCRATCH_SIZE);
+
+    return &scratch_bd;
+}
+
+#endif


### PR DESCRIPTION
This change makes it possible to provide a custom scratch region BlockDevice, such as an external flash.

@AGlass0fMilk