### PR TITLE
boot: boot_serial: use new Zephyr reboot header

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -27,7 +27,7 @@
 #include "bootutil/bootutil_log.h"
 
 #ifdef __ZEPHYR__
-#include <power/reboot.h>
+#include <sys/reboot.h>
 #include <sys/byteorder.h>
 #include <sys/__assert.h>
 #include <drivers/flash.h>


### PR DESCRIPTION
Use the new header used for `sys_reboot` on Zephyr.

Ref. https://github.com/zephyrproject-rtos/zephyr/pull/34599