### PR TITLE
boot: zephyr: Configure mimxrt106x_evk boards

### DIFF
--- a/boot/zephyr/boards/mimxrt1060_evk.conf
+++ b/boot/zephyr/boards/mimxrt1060_evk.conf
@@ -1,0 +1,4 @@
+# Copyright 2021 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BOOT_MAX_IMG_SECTORS=1024

--- a/boot/zephyr/boards/mimxrt1064_evk.conf
+++ b/boot/zephyr/boards/mimxrt1064_evk.conf
@@ -1,0 +1,4 @@
+# Copyright 2021 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BOOT_MAX_IMG_SECTORS=512


### PR DESCRIPTION
The mimxrt1060_evk and mimxrt1064_evk boards have large slots so we need
to increase CONFIG_BOOT_MAX_IMG_SECTORS from the default.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>