### PR TITLE
bootutil_public: allow to confirm padded image without copy-done flag

### DIFF
--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -583,11 +583,10 @@ boot_set_confirmed(void)
         goto done;
     }
 
-    if (state_primary_slot.copy_done == BOOT_FLAG_UNSET) {
-        /* Swap never completed.  This is unexpected. */
-        rc = BOOT_EBADVECT;
-        goto done;
-    }
+    /* Intentionally do not check copy_done flag
+     * so can confirm a padded image which was programed using a programing
+     * interface.
+     */
 
     if (state_primary_slot.image_ok != BOOT_FLAG_UNSET) {
         /* Already confirmed. */


### PR DESCRIPTION
This patch is for fixing:
https://github.com/zephyrproject-rtos/zephyr/issues/34683

copy-done flag is used to design completely copied image.
It is used to recognize whether need to complete image upgrade.
If image is running then:
1) it was already verified and copied by MCUboot
   copy-done flag is set for sure.
2) or it was programmed directly using programming interface

For case 2) when image contains magic but not copy-done flag it was
impossible to confirm it. This patch removes needs of having copy-done
flag set while confirming. This make API behavior similar to situation
when the not-padded image was programmed.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>