### PR TITLE
boot: bootutil: loader: Populate header when read sector fails

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1560,6 +1560,9 @@ boot_prepare_image_for_update(struct boot_loader_state *state,
          * if there is one.
          */
         BOOT_SWAP_TYPE(state) = BOOT_SWAP_TYPE_NONE;
+        (void) boot_read_image_header(state, BOOT_PRIMARY_SLOT,
+				      boot_img_hdr(state, BOOT_PRIMARY_SLOT),
+				      bs);
         return;
     }
 


### PR DESCRIPTION
The primary image won't boot if read sector fails in the loader.
This is due to the header not being populated so that the TLV
values cannot be read out correctly.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>