### PR TITLE
imgtool: Add support for write_size > 8

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -510,7 +510,7 @@ class Image():
         if overwrite_only:
             return MAX_ALIGN * 2 + magic_size
         else:
-            if write_size not in set([1, 2, 4, 8]):
+            if write_size not in set([1, 2, 4, 8, 16]):
                 raise click.BadParameter("Invalid alignment: {}".format(
                     write_size))
             m = DEFAULT_MAX_SECTORS if max_sectors is None else max_sectors

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -284,7 +284,7 @@ class BasedIntParamType(click.ParamType):
               help='Specify the value of security counter. Use the `auto` '
               'keyword to automatically generate it from the image version.')
 @click.option('-v', '--version', callback=validate_version,  required=True)
-@click.option('--align', type=click.Choice(['1', '2', '4', '8']),
+@click.option('--align', type=click.Choice(['1', '2', '4', '8', '16']),
               required=True)
 @click.option('--public-key-format', type=click.Choice(['hash', 'full']),
               default='hash', help='In what format to add the public key to '


### PR DESCRIPTION
Increase write_size paramter to 16 to support SoCs such as Atmel SAM4S or
SAMV70 with 128-bit default flash alignments.

Signed-off-by: Arvin Farahmand <arvinf@ip-logix.com>