### PR TITLE
Fix version comparison result causing boot failure

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -2365,6 +2365,9 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
                 }
             }
 
+            /* Reset rc since we use it above for boot_version_cmp */
+            rc = 0;
+
 #ifdef MCUBOOT_DIRECT_XIP_REVERT
             rc = boot_select_or_erase(&slot_state, selected_slot);
             if (rc != 0) {


### PR DESCRIPTION
The variable `rc` is used in `context_boot_go` for a number of operations, mostly checking return codes for an error. It is also used to store the result of comparing the installed application version numbers (using `boot_version_cmp`).

At the end of `context_boot_go`, `rc` is returned as the result of the operation.

In some configurations, namely direct XIP (without revert or any other extra boot checks), it is possible for the comparison result to be the last value of `rc`. In most cases, this will cause `context_boot_go` to report a failure (ie: non-zero return code), as the value of `rc` will be 1 or -1 if the installed applications aren't the same version.

This commit resets the value of `rc` to 0 after the version comparison has taken place.

Fixes #976

Signed-off-by: George Beckstein <george.beckstein@gmail.com>