### PR TITLE
Enable no signature verification configuration for Mbed-OS.

### DIFF
--- a/boot/mbed/app_enc_keys.c
+++ b/boot/mbed/app_enc_keys.c
@@ -30,8 +30,6 @@ extern unsigned int ecdsa_pub_key_len;
 #define HAVE_KEYS
 extern const unsigned char ed25519_pub_key[];
 extern unsigned int ed25519_pub_key_len;
-#else
-#error "No public key available for given signing algorithm."
 #endif
 
 /*

--- a/boot/mbed/include/mcuboot_config/mcuboot_config.h
+++ b/boot/mbed/include/mcuboot_config/mcuboot_config.h
@@ -18,6 +18,7 @@
 #define SIGNATURE_TYPE_RSA      0
 #define SIGNATURE_TYPE_EC256    1
 #define SIGNATURE_TYPE_ED25519  2
+#define SIGNATURE_TYPE_NONE     3
 
 /*
  * Signature algorithm

--- a/boot/mbed/mbed_lib.json
+++ b/boot/mbed/mbed_lib.json
@@ -35,7 +35,7 @@
             "help": "The algorithm used for digital signing.",
             "macro_name": "MCUBOOT_SIGNATURE_ALGORITHM",
             "required": true,
-            "accepted_values": ["SIGNATURE_TYPE_RSA", "SIGNATURE_TYPE_EC256", "SIGNATURE_TYPE_ED25519"],
+            "accepted_values": ["SIGNATURE_TYPE_RSA", "SIGNATURE_TYPE_EC256", "SIGNATURE_TYPE_ED25519", "SIGNATURE_TYPE_NONE"],
             "value": "SIGNATURE_TYPE_RSA"
         },
         "rsa-signature-length": {


### PR DESCRIPTION
This commit introduces changes to allow the Mbed-OS port to disable use of signature verification. Previously this was not possible even though it is a valid mcuboot configuration.

Signed-off-by: George Beckstein <george.beckstein@gmail.com>