### PR TITLE
boot_serial: zephyr: allow to build when CONFIG_MULTITHREADING=n

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -436,7 +436,11 @@ bs_reset(char *buf, int len)
     bs_empty_rsp(buf, len);
 
 #ifdef __ZEPHYR__
+#ifdef CONFIG_MULTITHREADING
     k_sleep(K_MSEC(250));
+#else
+    k_busy_wait(250000);
+#endif
     sys_reboot(SYS_REBOOT_COLD);
 #else
     os_cputime_delay_usecs(250000);

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -390,7 +390,11 @@ static bool detect_pin(const char* port, int pin, uint32_t expected, int delay)
 
     if (detect_value == expected) {
         if (delay > 0) {
+#ifdef CONFIG_MULTITHREADING
             k_sleep(K_MSEC(50));
+#else
+            k_busy_wait(50000);
+#endif
 
             /* Get the uptime for debounce purposes. */
             int64_t timestamp = k_uptime_get();
@@ -409,7 +413,11 @@ static bool detect_pin(const char* port, int pin, uint32_t expected, int delay)
                 }
 
                 /* Delay 1 ms */
+#ifdef CONFIG_MULTITHREADING
                 k_sleep(K_MSEC(1));
+#else
+                k_busy_wait(1000);
+#endif
             }
         }
     }


### PR DESCRIPTION
K_sleep() is not available when multithreading is disabled.
Let's use k_busy_wait() in that case.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>