### PR TITLE
Migrate master->main

### DIFF
--- a/.github/workflows/imgtool.yaml
+++ b/.github/workflows/imgtool.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
       - v*-branch
 
 name: imgtool

--- a/.github/workflows/mynewt.yaml
+++ b/.github/workflows/mynewt.yaml
@@ -2,7 +2,7 @@
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 name: Mynewt

--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -2,7 +2,7 @@
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 name: Sim

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status (Sim)](https://github.com/mcu-tools/mcuboot/workflows/Sim/badge.svg)][sim]
 [![Build Status (Mynewt)](https://github.com/mcu-tools/mcuboot/workflows/Mynewt/badge.svg)][mynewt]
 [![Publishing Status (imgtool)](https://github.com/mcu-tools/mcuboot/workflows/imgtool/badge.svg)][imgtool]
-[![Build Status (Travis CI)](https://img.shields.io/travis/mcu-tools/mcuboot/master.svg?label=travis-ci)][travis]
+[![Build Status (Travis CI)](https://img.shields.io/travis/mcu-tools/mcuboot/main.svg?label=travis-ci)][travis]
 [![Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)][license]
 
 [pypi]: https://pypi.org/project/imgtool/
@@ -14,7 +14,7 @@
 [mynewt]: https://github.com/mcu-tools/mcuboot/actions?query=workflow:Mynewt
 [imgtool]: https://github.com/mcu-tools/mcuboot/actions?query=workflow:imgtool
 [travis]: https://travis-ci.org/mcu-tools/mcuboot
-[license]: https://github.com/mcu-tools/mcuboot/blob/master/LICENSE
+[license]: https://github.com/mcu-tools/mcuboot/blob/main/LICENSE
 
 This is mcuboot version 1.8.0-dev
 

--- a/ci/imgtool_install.sh
+++ b/ci/imgtool_install.sh
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 if [[ $TRAVIS == "true" ]]; then
-    if [[ $TRAVIS_PULL_REQUEST != "false" || $TRAVIS_BRANCH != "master" ]]; then
-        echo "Either a PR or not \"master\" branch, exiting"
+    if [[ $TRAVIS_PULL_REQUEST != "false" || $TRAVIS_BRANCH != "main" ]]; then
+        echo "Either a PR or not \"main\" branch, exiting"
         exit 0
     fi
 fi

--- a/ci/imgtool_run.sh
+++ b/ci/imgtool_run.sh
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 if [[ $TRAVIS == "true" ]]; then
-    if [[ $TRAVIS_PULL_REQUEST != "false" || $TRAVIS_BRANCH != "master" ]]; then
-        echo "Either a PR or not \"master\" branch, exiting"
+    if [[ $TRAVIS_PULL_REQUEST != "false" || $TRAVIS_BRANCH != "main" ]]; then
+        echo "Either a PR or not \"main\" branch, exiting"
         exit 0
     fi
 fi

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,13 +61,13 @@ Information and documentation on the bootloader is stored within the source.
 
 For more information in the source, here are some pointers:
 
-- [boot/bootutil](https://github.com/mcu-tools/mcuboot/tree/master/boot/bootutil): The core of the bootloader itself.
-- [boot/boot\_serial](https://github.com/mcu-tools/mcuboot/tree/master/boot/boot_serial): Support for serial upgrade within the bootloader itself.
-- [boot/zephyr](https://github.com/mcu-tools/mcuboot/tree/master/boot/zephyr): Port of the bootloader to Zephyr
-- [boot/mynewt](https://github.com/mcu-tools/mcuboot/tree/master/boot/mynewt): Mynewt bootloader app
-- [boot/mbed](https://github.com/mcu-tools/mcuboot/tree/master/boot/mbed): Port of the bootloader to Mbed-OS
-- [imgtool](https://github.com/mcu-tools/mcuboot/tree/master/scripts/imgtool.py): A tool to securely sign firmware images for booting by MCUboot.
-- [sim](https://github.com/mcu-tools/mcuboot/tree/master/sim): A bootloader simulator for testing and regression
+- [boot/bootutil](https://github.com/mcu-tools/mcuboot/tree/main/boot/bootutil): The core of the bootloader itself.
+- [boot/boot\_serial](https://github.com/mcu-tools/mcuboot/tree/main/boot/boot_serial): Support for serial upgrade within the bootloader itself.
+- [boot/zephyr](https://github.com/mcu-tools/mcuboot/tree/main/boot/zephyr): Port of the bootloader to Zephyr
+- [boot/mynewt](https://github.com/mcu-tools/mcuboot/tree/main/boot/mynewt): Mynewt bootloader app
+- [boot/mbed](https://github.com/mcu-tools/mcuboot/tree/main/boot/mbed): Port of the bootloader to Mbed-OS
+- [imgtool](https://github.com/mcu-tools/mcuboot/tree/main/scripts/imgtool.py): A tool to securely sign firmware images for booting by MCUboot.
+- [sim](https://github.com/mcu-tools/mcuboot/tree/main/sim): A bootloader simulator for testing and regression
 
 ## Joining
 

--- a/docs/readme-mbed.md
+++ b/docs/readme-mbed.md
@@ -16,7 +16,7 @@ To use MCUboot, you need to create an Mbed OS project with the following configu
 * `"mcuboot.max-img-sectors"`: maximum number of sectors, should be at least the number of sectors in each slot
 * `"target.restrict_size"`: the maximum size of the bootloader, such that it does not overlap with the primary slot
 
-More configurations such as signing algorithm, slot swapping, etc. can be found in [mbed_lib.json](https://github.com/mcu-tools/mcuboot/tree/master/boot/mbed/mbed_lib.json). Please note that certain features are not currently supported.
+More configurations such as signing algorithm, slot swapping, etc. can be found in [mbed_lib.json](https://github.com/mcu-tools/mcuboot/tree/main/boot/mbed/mbed_lib.json). Please note that certain features are not currently supported.
 
 ### Providing a secondary slot
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -39,7 +39,7 @@ There are bug fixes, and associated imgtool updates as well.
 
 ### Zephyr-RTOS Compatibility
 
-This release of MCUboot works with the Zephyr "master" at the time of the
+This release of MCUboot works with the Zephyr "main" at the time of the
 release. It was tested as of has 7a3b253ce. This version of MCUboot also
 works with the Zephyr v2.4.0, however it is recommended to enable
 `CONFIG_MCUBOOT_CLEANUP_ARM_CORE` while using that version.
@@ -75,7 +75,7 @@ updates as well.
 
 ### Zephyr-RTOS Compatibility
 
-This release of MCUboot works the Zephyr "master" at the time of the
+This release of MCUboot works the Zephyr "main" at the time of the
 release.  It was tested as of has 1a89ca1238.  When Zephyr v2.3.0 is
 released, there will be a possible 1.6.1 or similar release of Zephyr
 if needed to address any issues.  There also may be branch releases of
@@ -145,7 +145,7 @@ compatible with previous releases of MCUboot.
 
 The 1.3.1 release of MCUboot consists mostly of small bug fixes and updates.
 There are no breaking changes in functionality. This release should work with
-Mynewt 1.6.0 and up, and any Zephyr `master` after sha
+Mynewt 1.6.0 and up, and any Zephyr `main` after sha
 f51e3c296040f73bca0e8fe1051d5ee63ce18e0d.
 
 ### About this release

--- a/docs/release.md
+++ b/docs/release.md
@@ -32,7 +32,7 @@ the official a.b.c release).  The intent is to freeze the code for a
 time, and allow testing to happen.
 
 During the time between rc1 and the final release, the only changes
-that should be merged into master are those to fix bugs found in the
+that should be merged into main are those to fix bugs found in the
 rc and Mynewt metadata as described in the next section.
 
 ## imgtool release
@@ -81,7 +81,7 @@ public key is signed by enough parties to be trusted.
 At this point, the tag can be pushed to github to make the actual
 release happen:
 ``` bash
-git push origin HEAD:refs/heads/master
+git push origin HEAD:refs/heads/main
 git push origin va.b.c-rcn
 ```
 

--- a/repository.yml
+++ b/repository.yml
@@ -20,7 +20,7 @@
 repo.name: mcuboot
 repo.submodules: ""
 repo.versions:
-    "0.0.0": "master"
+    "0.0.0": "main"
     "0.9.0": "v0.9.0"
     "1.0.0": "v1.0.0"
     "1.1.0": "v1.1.0"
@@ -34,7 +34,7 @@ repo.versions:
     "1.7.1": "v1.7.1"
     "1.7.2": "v1.7.2"
 
-    "0-dev": "0.0.0"        # master
+    "0-dev": "0.0.0"        # main
     "0-latest": "1.7.2"     # latest stable release
     "1-latest": "1.7.2"     # latest stable release
 


### PR DESCRIPTION
Change references in CI and docs from 'master' to 'main' as the primary
branch has been renamed.

Signed-off-by: David Brown <david.brown@linaro.org>