### PR TITLE
zephyr: serial: Remove unnecessary call to irq_unlock

### DIFF
--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -222,11 +222,5 @@ boot_uart_fifo_init(void)
 
 	uart_irq_rx_enable(uart_dev);
 
-	/* Enable all interrupts unconditionally. Note that this is due
-	 * to Zephyr issue #8393. This should be removed once the
-	 * issue is fixed in upstream Zephyr.
-	 */
-	irq_unlock(0);
-
 	return 0;
 }


### PR DESCRIPTION
The following commit in Zephyr removed the need to unlock interrupts
when booting in single-threaded mode:
https://github.com/zephyrproject-rtos/zephyr/commit/3b89cf173b6b0085c84a09fd97b42e08a25ae4b3

Remove the now obsolete lines.

Fixes #302.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>