### PR TITLE
github: Add workflow to mark stale issues

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -1,0 +1,23 @@
+name: "Close stale pull requests/issues"
+on:
+  schedule:
+  - cron: "16 00 * * *"
+
+jobs:
+  stale:
+    name: Find Stale issues and PRs
+    runs-on: ubuntu-latest
+    if: github.repository == 'mcu-tools/mcuboot'
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This pull request has been marked as stale because it has been open (more than) 60 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this pull request will automatically be closed in 14 days. Note, that you can always re-open a closed pull request at any time.'
+        stale-issue-message: 'This issue has been marked as stale because it has been open (more than) 60 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this issue will automatically be closed in 14 days. Note, that you can always re-open a closed issue at any time.'
+        days-before-stale: 60
+        days-before-close: 14
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        # exempt-pr-labels: 'Blocked,In progress'
+        # exempt-issue-labels: 'In progress,Enhancement,Feature,Feature Request,RFC,Meta'
+        operations-per-run: 400


### PR DESCRIPTION
This workflow will add a 'stale' label to any issues that haven't been
modified in 60 days, and then after an additional 14 days, will close
the issue.

The template was copied from Zephyr.

Signed-off-by: David Brown <david.brown@linaro.org>