### PR TITLE
bootutil: Reduce boot_initialize_area variants

### DIFF
--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -207,14 +207,14 @@ struct boot_loader_state {
         struct image_header hdr;
         const struct flash_area *area;
         boot_sector_t *sectors;
-        size_t num_sectors;
+        uint32_t num_sectors;
     } imgs[BOOT_IMAGE_NUMBER][BOOT_NUM_SLOTS];
 
 #if MCUBOOT_SWAP_USING_SCRATCH
     struct {
         const struct flash_area *area;
         boot_sector_t *sectors;
-        size_t num_sectors;
+        uint32_t num_sectors;
     } scratch;
 #endif
 


### PR DESCRIPTION
The commit removes implementation of boot_initialize_area
specific for flash_area_to_sectors, and applies changes to
the flash_area_get_sectors using variant, to make it
alternatively work with flash_area_to_sectors.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>