### PR TITLE
Make boot_read_swap_state declaration public

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil_public.h
+++ b/boot/bootutil/include/bootutil/bootutil_public.h
@@ -4,7 +4,7 @@
  * Copyright (c) 2017-2019 Linaro LTD
  * Copyright (c) 2016-2019 JUUL Labs
  * Copyright (c) 2019-2021 Arm Limited
- * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2020-2021 Nordic Semiconductor ASA
  *
  * Original license:
  *
@@ -223,13 +223,25 @@ int boot_read_image_ok(const struct flash_area *fap, uint8_t *image_ok);
 /**
  * @brief Read the image swap state
  *
- * @param flash_area_id Id of flash parttition from which trailer will be read.
- * @param state Struture for holding swap state.
+ * @param flash_area_id id of flash partition from which state will be read;
+ * @param state pointer to structure for storing swap state.
  *
- * @return 0 on success, nonzero errno code on fail.
+ * @return 0 on success; non-zero error code on failure;
  */
 int
 boot_read_swap_state_by_id(int flash_area_id, struct boot_swap_state *state);
+
+/**
+ * @brief Read the image swap state
+ *
+ * @param fa pointer to flash_area object;
+ * @param state pointer to structure for storing swap state.
+ *
+ * @return 0 on success; non-zero error code on failure.
+ */
+int
+boot_read_swap_state(const struct flash_area *fa,
+                     struct boot_swap_state *state);
 
 #define BOOT_MAGIC_ARR_SZ \
     (sizeof boot_img_magic / sizeof boot_img_magic[0])

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -399,7 +399,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
  */
 void
 fixup_revert(const struct boot_loader_state *state, struct boot_status *bs,
-        const struct flash_area *fap_sec, uint8_t sec_id)
+        const struct flash_area *fap_sec)
 {
     struct boot_swap_state swap_state;
     int rc;
@@ -415,7 +415,7 @@ fixup_revert(const struct boot_loader_state *state, struct boot_status *bs,
         return;
     }
 
-    rc = boot_read_swap_state_by_id(sec_id, &swap_state);
+    rc = boot_read_swap_state(fap_sec, &swap_state);
     assert(rc == 0);
 
     BOOT_LOG_SWAP_STATE("Secondary image", &swap_state);
@@ -493,7 +493,7 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
     rc = flash_area_open(FLASH_AREA_IMAGE_SECONDARY(image_index), &fap_sec);
     assert (rc == 0);
 
-    fixup_revert(state, bs, fap_sec, FLASH_AREA_IMAGE_SECONDARY(image_index));
+    fixup_revert(state, bs, fap_sec);
 
     if (bs->op == BOOT_STATUS_OP_MOVE) {
         idx = g_last_idx;

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -619,8 +619,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
                         (BOOT_STATUS_STATE_COUNT - 1) * BOOT_WRITE_SZ(state));
             BOOT_STATUS_ASSERT(rc == 0);
 
-            rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_SCRATCH,
-                                            &swap_state);
+            rc = boot_read_swap_state(fap_scratch, &swap_state);
             assert(rc == 0);
 
             if (swap_state.image_ok == BOOT_FLAG_SET) {


### PR DESCRIPTION
The PR contains series of commits that:
 - make `boot_read_swap_state` public and available from bootutil_public.h;
 - change `fixup_revert` to use provided flash area object pointer to obtain swap state by call to `boot_read_swap_state`, instead of previously used `boot_read_swap_state_by_id`; this makes ID param (`sec_id`) no longer needed;
 - makes `boot_swap_sector` call `boot_read_swap_state` on already opened scratch flash area, instead of using `boot_read_swap_state_by_id`, with the area ID, which caused double open on the flash area;
 - changes logic of `boot_set_pending_multi` by moving `flash_area_open` to the top of the function, making that the only place where flash area object is obtained in the function; switches the function to use `boot_read_swap_state`;
 - switches `boot_set_confirmed_multi` to use `boot_read_swap_state`;