### PR TITLE
Add support in sim for direct-xip and ramload

### DIFF
--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -35,6 +35,8 @@ jobs:
         - "sig-rsa validate-primary-slot overwrite-only downgrade-prevention"
         - "sig-rsa validate-primary-slot ram-load"
         - "sig-rsa validate-primary-slot direct-xip"
+        - "sig-rsa validate-primary-slot ram-load multiimage"
+        - "sig-rsa validate-primary-slot direct-xip multiimage"
     runs-on: ubuntu-latest
     env:
       MULTI_FEATURES: ${{ matrix.features }}

--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -33,6 +33,8 @@ jobs:
         - "sig-ecdsa-mbedtls enc-ec256-mbedtls validate-primary-slot"
         - "sig-ecdsa-mbedtls enc-aes256-ec256 validate-primary-slot"
         - "sig-rsa validate-primary-slot overwrite-only downgrade-prevention"
+        - "sig-rsa validate-primary-slot ram-load"
+        - "sig-rsa validate-primary-slot direct-xip"
     runs-on: ubuntu-latest
     env:
       MULTI_FEATURES: ${{ matrix.features }}

--- a/boot/bootutil/include/bootutil/caps.h
+++ b/boot/bootutil/include/bootutil/caps.h
@@ -50,6 +50,7 @@ uint32_t bootutil_get_caps(void);
 #define BOOTUTIL_CAP_BOOTSTRAP              (1<<14)
 #define BOOTUTIL_CAP_AES256                 (1<<15)
 #define BOOTUTIL_CAP_RAM_LOAD               (1<<16)
+#define BOOTUTIL_CAP_DIRECT_XIP             (1<<17)
 
 /*
  * Query the number of images this bootloader is configured for.  This

--- a/boot/bootutil/include/bootutil/caps.h
+++ b/boot/bootutil/include/bootutil/caps.h
@@ -49,6 +49,7 @@ uint32_t bootutil_get_caps(void);
 #define BOOTUTIL_CAP_ENC_X25519             (1<<13)
 #define BOOTUTIL_CAP_BOOTSTRAP              (1<<14)
 #define BOOTUTIL_CAP_AES256                 (1<<15)
+#define BOOTUTIL_CAP_RAM_LOAD               (1<<16)
 
 /*
  * Query the number of images this bootloader is configured for.  This

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -403,10 +403,14 @@ boot_img_sector_off(const struct boot_loader_state *state, size_t slot,
 #endif  /* !defined(MCUBOOT_USE_FLASH_AREA_GET_SECTORS) */
 
 #ifdef MCUBOOT_RAM_LOAD
+#define IMAGE_RAM_BASE ((uintptr_t)0)
+
 #define LOAD_IMAGE_DATA(hdr, fap, start, output, size)       \
-    (memcpy((output),(void*)((hdr)->ih_load_addr + (start)), \
+    (memcpy((output),(void*)(IMAGE_RAM_BASE + (hdr)->ih_load_addr + (start)), \
     (size)), 0)
 #else
+#define IMAGE_RAM_BASE ((uintptr_t)0)
+
 #define LOAD_IMAGE_DATA(hdr, fap, start, output, size)       \
     (flash_area_read((fap), (start), (output), (size)))
 #endif /* MCUBOOT_RAM_LOAD */

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -403,7 +403,26 @@ boot_img_sector_off(const struct boot_loader_state *state, size_t slot,
 #endif  /* !defined(MCUBOOT_USE_FLASH_AREA_GET_SECTORS) */
 
 #ifdef MCUBOOT_RAM_LOAD
-#define IMAGE_RAM_BASE ((uintptr_t)0)
+#   ifdef __BOOTSIM__
+
+/* Query for the layout of a RAM buffer appropriate for holding the
+ * image.  This will be per-test-thread, and therefore must be queried
+ * through this call. */
+struct bootsim_ram_info {
+    uint32_t start;
+    uint32_t size;
+    uintptr_t base;
+};
+struct bootsim_ram_info *bootsim_get_ram_info(void);
+
+#define IMAGE_GET_FIELD(field) (bootsim_get_ram_info()->field)
+#define IMAGE_RAM_BASE IMAGE_GET_FIELD(base)
+#define IMAGE_EXECUTABLE_RAM_START IMAGE_GET_FIELD(start)
+#define IMAGE_EXECUTABLE_RAM_SIZE IMAGE_GET_FIELD(size)
+
+#   else
+#       define IMAGE_RAM_BASE ((uintptr_t)0)
+#   endif
 
 #define LOAD_IMAGE_DATA(hdr, fap, start, output, size)       \
     (memcpy((output),(void*)(IMAGE_RAM_BASE + (hdr)->ih_load_addr + (start)), \

--- a/boot/bootutil/src/caps.c
+++ b/boot/bootutil/src/caps.c
@@ -72,6 +72,9 @@ uint32_t bootutil_get_caps(void)
 #if defined(MCUBOOT_AES_256)
     res |= BOOTUTIL_CAP_AES256;
 #endif
+#if defined(MCUBOOT_RAM_LOAD)
+    res |= BOOTUTIL_CAP_RAM_LOAD;
+#endif
 
     return res;
 }

--- a/boot/bootutil/src/caps.c
+++ b/boot/bootutil/src/caps.c
@@ -75,6 +75,9 @@ uint32_t bootutil_get_caps(void)
 #if defined(MCUBOOT_RAM_LOAD)
     res |= BOOTUTIL_CAP_RAM_LOAD;
 #endif
+#if defined(MCUBOOT_DIRECT_XIP)
+    res |= BOOTUTIL_CAP_DIRECT_XIP;
+#endif
 
     return res;
 }

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -85,6 +85,9 @@ bootutil_img_hash(struct enc_key_data *enc_state, int image_index,
     (void)blk_sz;
     (void)off;
     (void)rc;
+    (void)fap;
+    (void)tmp_buf;
+    (void)tmp_buf_sz;
 #endif
 #endif
 

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -116,7 +116,9 @@ bootutil_img_hash(struct enc_key_data *enc_state, int image_index,
     size += hdr->ih_protect_tlv_size;
 
 #ifdef MCUBOOT_RAM_LOAD
-    bootutil_sha256_update(&sha256_ctx,(void*)(hdr->ih_load_addr), size);
+    bootutil_sha256_update(&sha256_ctx,
+                           (void*)(IMAGE_RAM_BASE + hdr->ih_load_addr),
+                           size);
 #else
     for (off = 0; off < size; off += blk_sz) {
         blk_sz = size - off;

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -2242,6 +2242,8 @@ print_loaded_images(struct boot_loader_state *state,
 {
     uint32_t active_slot;
 
+    (void)state;
+
     IMAGES_ITER(BOOT_CURR_IMG(state)) {
         active_slot = slot_usage[BOOT_CURR_IMG(state)].active_slot;
 
@@ -2354,6 +2356,9 @@ boot_verify_ram_load_address(struct boot_loader_state *state,
     uint32_t img_end_addr;
     uint32_t exec_ram_start;
     uint32_t exec_ram_size;
+
+    (void)state;
+
 #ifdef MULTIPLE_EXECUTABLE_RAM_REGIONS
     int      rc;
 
@@ -2582,11 +2587,13 @@ static inline int
 boot_remove_image_from_sram(struct boot_loader_state *state,
                             struct slot_usage_t slot_usage[])
 {
+    (void)state;
+
     BOOT_LOG_INF("Removing image from SRAM at address 0x%x",
                  slot_usage[BOOT_CURR_IMG(state)].img_dst);
 
-    memset((void*)slot_usage[BOOT_CURR_IMG(state)].img_dst, 0,
-           slot_usage[BOOT_CURR_IMG(state)].img_sz);
+    memset((void*)(IMAGE_RAM_BASE + slot_usage[BOOT_CURR_IMG(state)].img_dst),
+           0, slot_usage[BOOT_CURR_IMG(state)].img_sz);
 
     slot_usage[BOOT_CURR_IMG(state)].img_dst = 0;
     slot_usage[BOOT_CURR_IMG(state)].img_sz = 0;
@@ -2608,6 +2615,8 @@ boot_remove_image_from_flash(struct boot_loader_state *state, uint32_t slot)
     int area_id;
     int rc;
     const struct flash_area *fap;
+
+    (void)state;
 
     BOOT_LOG_INF("Removing image %d slot %d from flash", BOOT_CURR_IMG(state),
                                                          slot);
@@ -2917,7 +2926,7 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
 {
     struct slot_usage_t slot_usage[BOOT_IMAGE_NUMBER];
     int rc;
-    fih_int fih_rc;
+    fih_int fih_rc = fih_int_encode(0);
 
     memset(state, 0, sizeof(struct boot_loader_state));
     memset(slot_usage, 0, sizeof(struct slot_usage_t) * BOOT_IMAGE_NUMBER);

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -857,6 +857,7 @@ boot_validated_swap_type(struct boot_loader_state *state,
 
     return swap_type;
 }
+#endif
 
 /**
  * Erases a region of flash.
@@ -874,6 +875,7 @@ boot_erase_region(const struct flash_area *fap, uint32_t off, uint32_t sz)
     return flash_area_erase(fap, off, sz);
 }
 
+#if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)
 /**
  * Copies the contents of one flash region to another.  You must erase the
  * destination region prior to calling this function.

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -2416,7 +2416,7 @@ boot_copy_image_to_sram(struct boot_loader_state *state, int slot,
     }
 
     /* Direct copy from flash to its new location in SRAM. */
-    rc = flash_area_read(fap_src, 0, (void *)img_dst, img_sz);
+    rc = flash_area_read(fap_src, 0, (void *)(IMAGE_RAM_BASE + img_dst), img_sz);
     if (rc != 0) {
         BOOT_LOG_INF("Error whilst copying image from Flash to SRAM: %d", rc);
     }

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -26,6 +26,7 @@ enc-x25519 = ["mcuboot-sys/enc-x25519"]
 enc-aes256-x25519 = ["mcuboot-sys/enc-aes256-x25519"]
 bootstrap = ["mcuboot-sys/bootstrap"]
 multiimage = ["mcuboot-sys/multiimage"]
+ram-load = ["mcuboot-sys/ram-load"]
 large-write = []
 downgrade-prevention = ["mcuboot-sys/downgrade-prevention"]
 

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -27,6 +27,7 @@ enc-aes256-x25519 = ["mcuboot-sys/enc-aes256-x25519"]
 bootstrap = ["mcuboot-sys/bootstrap"]
 multiimage = ["mcuboot-sys/multiimage"]
 ram-load = ["mcuboot-sys/ram-load"]
+direct-xip = ["mcuboot-sys/direct-xip"]
 large-write = []
 downgrade-prevention = ["mcuboot-sys/downgrade-prevention"]
 

--- a/sim/mcuboot-sys/Cargo.toml
+++ b/sim/mcuboot-sys/Cargo.toml
@@ -68,6 +68,10 @@ bootstrap = []
 # Support multiple images (currently 2 instead of 1).
 multiimage = []
 
+# Support simulation of ram-loading.  No swaps are performed, and the
+# image is copied to RAM before loading it.
+ram-load = []
+
 # Check (in software) against version downgrades.
 downgrade-prevention = []
 

--- a/sim/mcuboot-sys/Cargo.toml
+++ b/sim/mcuboot-sys/Cargo.toml
@@ -72,6 +72,11 @@ multiimage = []
 # image is copied to RAM before loading it.
 ram-load = []
 
+# Support simulation of direct XIP.  No swaps are performed, the image
+# is directly executed out of whichever partition contains the most
+# appropriate image.
+direct-xip = []
+
 # Check (in software) against version downgrades.
 downgrade-prevention = []
 

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -31,6 +31,7 @@ fn main() {
     let multiimage = env::var("CARGO_FEATURE_MULTIIMAGE").is_ok();
     let downgrade_prevention = env::var("CARGO_FEATURE_DOWNGRADE_PREVENTION").is_ok();
     let ram_load = env::var("CARGO_FEATURE_RAM_LOAD").is_ok();
+    let direct_xip = env::var("CARGO_FEATURE_DIRECT_XIP").is_ok();
 
     let mut conf = cc::Build::new();
     conf.define("__BOOTSIM__", None);
@@ -62,6 +63,10 @@ fn main() {
 
         conf.define("IMAGE_EXECUTABLE_RAM_START", "0x10000");
         conf.define("IMAGE_EXECUTABLE_RAM_SIZE", "0x10000");
+    }
+
+    if direct_xip {
+        conf.define("MCUBOOT_DIRECT_XIP", None);
     }
 
     // Currently no more than one sig type can be used simultaneously.

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -60,9 +60,6 @@ fn main() {
 
     if ram_load {
         conf.define("MCUBOOT_RAM_LOAD", None);
-
-        conf.define("IMAGE_EXECUTABLE_RAM_START", "0x10000");
-        conf.define("IMAGE_EXECUTABLE_RAM_SIZE", "0x10000");
     }
 
     if direct_xip {

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -30,6 +30,7 @@ fn main() {
     let bootstrap = env::var("CARGO_FEATURE_BOOTSTRAP").is_ok();
     let multiimage = env::var("CARGO_FEATURE_MULTIIMAGE").is_ok();
     let downgrade_prevention = env::var("CARGO_FEATURE_DOWNGRADE_PREVENTION").is_ok();
+    let ram_load = env::var("CARGO_FEATURE_RAM_LOAD").is_ok();
 
     let mut conf = cc::Build::new();
     conf.define("__BOOTSIM__", None);
@@ -54,6 +55,13 @@ fn main() {
 
     if downgrade_prevention {
         conf.define("MCUBOOT_DOWNGRADE_PREVENTION", None);
+    }
+
+    if ram_load {
+        conf.define("MCUBOOT_RAM_LOAD", None);
+
+        conf.define("IMAGE_EXECUTABLE_RAM_START", "0x10000");
+        conf.define("IMAGE_EXECUTABLE_RAM_SIZE", "0x10000");
     }
 
     // Currently no more than one sig type can be used simultaneously.

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -427,6 +427,11 @@ uint8_t flash_area_get_device_id(const struct flash_area *fa)
     return fa->fa_device_id;
 }
 
+int flash_area_id_from_image_slot(int slot) {
+    /* For single image cases, just use the first image. */
+    return flash_area_id_from_multi_image_slot(0, slot);
+}
+
 void sim_assert(int x, const char *assertion, const char *file, unsigned int line, const char *function)
 {
     if (!(x)) {

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -424,8 +424,7 @@ int flash_area_id_to_multi_image_slot(int image_index, int area_id)
 
 uint8_t flash_area_get_device_id(const struct flash_area *fa)
 {
-	(void)fa;
-	return 0;
+    return fa->fa_device_id;
 }
 
 void sim_assert(int x, const char *assertion, const char *file, unsigned int line, const char *function)

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -233,10 +233,10 @@ struct area_desc {
     uint32_t num_slots;
 };
 
-int invoke_boot_go(struct sim_context *ctx, struct area_desc *adesc)
+int invoke_boot_go(struct sim_context *ctx, struct area_desc *adesc,
+                   struct boot_rsp *rsp)
 {
     int res;
-    struct boot_rsp rsp;
     struct boot_loader_state *state;
 
 #if defined(MCUBOOT_SIGN_RSA) || \
@@ -253,7 +253,7 @@ int invoke_boot_go(struct sim_context *ctx, struct area_desc *adesc)
     sim_set_context(ctx);
 
     if (setjmp(ctx->boot_jmpbuf) == 0) {
-        res = context_boot_go(state, &rsp);
+        res = context_boot_go(state, rsp);
         sim_reset_flash_areas();
         sim_reset_context();
         free(state);

--- a/sim/mcuboot-sys/src/api.rs
+++ b/sim/mcuboot-sys/src/api.rs
@@ -26,6 +26,38 @@ pub struct FlashParamsStruct {
 
 pub type FlashParams = HashMap<u8, FlashParamsStruct>;
 
+/// The `boot_rsp` structure used by boot_go.
+#[repr(C)]
+#[derive(Debug)]
+pub struct BootRsp {
+    pub br_hdr: *const ImageHeader,
+    pub flash_dev_id: u8,
+    pub image_off: u32,
+}
+
+// TODO: Don't duplicate this image header declaration.
+#[repr(C)]
+#[derive(Debug)]
+pub struct ImageHeader {
+    magic: u32,
+    load_addr: u32,
+    hdr_size: u16,
+    protect_tlv_size: u16,
+    img_size: u32,
+    flags: u32,
+    ver: ImageVersion,
+    _pad2: u32,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct ImageVersion {
+    pub major: u8,
+    pub minor: u8,
+    pub revision: u16,
+    pub build_num: u32,
+}
+
 pub struct CAreaDescPtr {
    pub ptr: *const CAreaDesc,
 }

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -20,6 +20,8 @@ pub enum BootGoResult {
     Normal {
         result: i32,
         asserts: u8,
+
+        resp: api::BootRsp,
     },
 }
 
@@ -39,6 +41,7 @@ impl BootGoResult {
         matches!(self, BootGoResult::Normal {
             result: 0,
             asserts: 0,
+            ..
         })
     }
 
@@ -47,6 +50,14 @@ impl BootGoResult {
         match self {
             BootGoResult::Normal { asserts, .. } => *asserts,
             _ => 0,
+        }
+    }
+
+    /// Retrieve the 'resp' field that is filled in.
+    pub fn resp(&self) -> Option<&api::BootRsp> {
+        match self {
+            BootGoResult::Normal { resp, .. } => Some(resp),
+            _ => None,
         }
     }
 }
@@ -86,7 +97,7 @@ pub fn boot_go(multiflash: &mut SimMultiFlash, areadesc: &AreaDesc,
     if result == -0x13579 {
         BootGoResult::Stopped
     } else {
-        BootGoResult::Normal { result, asserts }
+        BootGoResult::Normal { result, asserts, resp: rsp }
     }
 }
 

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -26,8 +26,14 @@ pub fn boot_go(multiflash: &mut SimMultiFlash, areadesc: &AreaDesc,
         c_catch_asserts: if catch_asserts { 1 } else { 0 },
         boot_jmpbuf: [0; 16],
     };
+    let mut rsp = api::BootRsp {
+        br_hdr: std::ptr::null(),
+        flash_dev_id: 0,
+        image_off: 0,
+    };
     let result = unsafe {
-        raw::invoke_boot_go(&mut sim_ctx as *mut _, &areadesc.get_c() as *const _) as i32
+        raw::invoke_boot_go(&mut sim_ctx as *mut _, &areadesc.get_c() as *const _,
+            &mut rsp as *mut _) as i32
     };
     let asserts = sim_ctx.c_asserts;
     if let Some(c) = counter {
@@ -82,13 +88,14 @@ pub fn kw_encrypt(kek: &[u8], seckey: &[u8], keylen: u32) -> Result<Vec<u8>, &'s
 
 mod raw {
     use crate::area::CAreaDesc;
-    use crate::api::CSimContext;
+    use crate::api::{BootRsp, CSimContext};
 
     extern "C" {
         // This generates a warning about `CAreaDesc` not being foreign safe.  There doesn't appear to
         // be any way to get rid of this warning.  See https://github.com/rust-lang/rust/issues/34798
         // for information and tracking.
-        pub fn invoke_boot_go(sim_ctx: *mut CSimContext, areadesc: *const CAreaDesc) -> libc::c_int;
+        pub fn invoke_boot_go(sim_ctx: *mut CSimContext, areadesc: *const CAreaDesc,
+            rsp: *mut BootRsp) -> libc::c_int;
 
         pub fn boot_trailer_sz(min_write_sz: u32) -> u32;
         pub fn boot_status_sz(min_write_sz: u32) -> u32;

--- a/sim/mcuboot-sys/src/lib.rs
+++ b/sim/mcuboot-sys/src/lib.rs
@@ -32,6 +32,11 @@ impl RamBlock {
         &self.ram
     }
 
+    /// Borrow a piece of the ram, with 'offset' being the beginning of the buffer.
+    pub fn borrow_part(&self, base: usize, size: usize) -> &[u8] {
+        &self.ram[base..base+size]
+    }
+
     pub fn invoke<F, R>(&self, act: F) -> R
         where F: FnOnce() -> R
     {

--- a/sim/mcuboot-sys/src/lib.rs
+++ b/sim/mcuboot-sys/src/lib.rs
@@ -10,3 +10,38 @@ pub mod c;
 pub mod api;
 
 pub use crate::area::{AreaDesc, FlashId};
+
+/// For testing the ram load feature, we need to emulate a block of RAM and be able to pass that
+/// down to the C code.  The call down to boot_go should go through this object so that the buffer
+/// itself is managed properly.
+pub struct RamBlock {
+    ram: Vec<u8>,
+    offset: u32, // 32-bit offset.
+}
+
+impl RamBlock {
+    pub fn new(size: u32, offset: u32) -> RamBlock {
+        RamBlock {
+            ram: vec![0; size as usize],
+            offset: offset,
+        }
+    }
+
+    /// Borrow the RAM buffer, with 'offset' being the beginning of the buffer.
+    pub fn borrow(&self) -> &[u8] {
+        &self.ram
+    }
+
+    pub fn invoke<F, R>(&self, act: F) -> R
+        where F: FnOnce() -> R
+    {
+        api::set_ram_info(api::BootsimRamInfo {
+            start: self.offset,
+            size: self.ram.len() as u32,
+            base: &self.ram[0] as *const u8 as usize - self.offset as usize,
+        });
+        let result = act();
+        api::clear_ram_info();
+        result
+    }
+}

--- a/sim/src/caps.rs
+++ b/sim/src/caps.rs
@@ -26,6 +26,7 @@ pub enum Caps {
     EncX25519            = (1 << 13),
     Bootstrap            = (1 << 14),
     Aes256               = (1 << 15),
+    RamLoad              = (1 << 16),
 }
 
 impl Caps {
@@ -38,6 +39,12 @@ impl Caps {
     /// MCUboot build.
     pub fn get_num_images() -> usize {
         (unsafe { bootutil_get_num_images() }) as usize
+    }
+
+    /// Query if this configuration performs some kind of upgrade by writing to flash.
+    pub fn modifies_flash() -> bool {
+        // All other configurations perform upgrades by writing to flash.
+        !Self::RamLoad.present()
     }
 }
 

--- a/sim/src/caps.rs
+++ b/sim/src/caps.rs
@@ -27,6 +27,7 @@ pub enum Caps {
     Bootstrap            = (1 << 14),
     Aes256               = (1 << 15),
     RamLoad              = (1 << 16),
+    DirectXip            = (1 << 17),
 }
 
 impl Caps {
@@ -44,7 +45,7 @@ impl Caps {
     /// Query if this configuration performs some kind of upgrade by writing to flash.
     pub fn modifies_flash() -> bool {
         // All other configurations perform upgrades by writing to flash.
-        !Self::RamLoad.present()
+        !(Self::RamLoad.present() || Self::DirectXip.present())
     }
 }
 

--- a/sim/src/tlv.rs
+++ b/sim/src/tlv.rs
@@ -17,6 +17,7 @@
 use byteorder::{
     LittleEndian, WriteBytesExt,
 };
+use crate::caps::Caps;
 use crate::image::ImageVersion;
 use log::info;
 use ring::{digest, rand, agreement, hkdf, hmac};
@@ -295,7 +296,12 @@ impl ManifestGen for TlvGen {
 
     /// Retrieve the header flags for this configuration.  This can be called at any time.
     fn get_flags(&self) -> u32 {
-        self.flags
+        // For the RamLoad case, add in the flag for this feature.
+        if Caps::RamLoad.present() {
+            self.flags | (TlvFlags::RAM_LOAD as u32)
+        } else {
+            self.flags
+        }
     }
 
     /// Add bytes to the covered hash.

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -60,6 +60,7 @@ sim_test!(status_write_fails_with_reset, make_image(&NO_DEPS, true), run_with_st
 sim_test!(downgrade_prevention, make_image(&REV_DEPS, true), run_nodowngrade());
 
 sim_test!(direct_xip_first, make_no_upgrade_image(&NO_DEPS), run_direct_xip());
+sim_test!(ram_load_first, make_no_upgrade_image(&NO_DEPS), run_ram_load());
 
 // Test various combinations of incorrect dependencies.
 test_shell!(dependency_combos, r, {

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -59,6 +59,8 @@ sim_test!(status_write_fails_complete, make_image(&NO_DEPS, true), run_with_stat
 sim_test!(status_write_fails_with_reset, make_image(&NO_DEPS, true), run_with_status_fails_with_reset());
 sim_test!(downgrade_prevention, make_image(&REV_DEPS, true), run_nodowngrade());
 
+sim_test!(direct_xip_first, make_no_upgrade_image(&NO_DEPS), run_direct_xip());
+
 // Test various combinations of incorrect dependencies.
 test_shell!(dependency_combos, r, {
     // Only test setups with two images.


### PR DESCRIPTION
Fix enough in the simulator so that the direct-xip and ramload configurations can be run. All of the existing tests assume that MCUboot modifies flash to make use of the new image. This PR does not add additional tests for this functionality, but fixes enough so that they can be compiled, and that inappropriate tests will be avoided.