### PR TITLE
sim: Rich boot return

### DIFF
--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -233,10 +233,10 @@ struct area_desc {
     uint32_t num_slots;
 };
 
-int invoke_boot_go(struct sim_context *ctx, struct area_desc *adesc)
+int invoke_boot_go(struct sim_context *ctx, struct area_desc *adesc,
+                   struct boot_rsp *rsp)
 {
     int res;
-    struct boot_rsp rsp;
     struct boot_loader_state *state;
 
 #if defined(MCUBOOT_SIGN_RSA) || \
@@ -253,7 +253,7 @@ int invoke_boot_go(struct sim_context *ctx, struct area_desc *adesc)
     sim_set_context(ctx);
 
     if (setjmp(ctx->boot_jmpbuf) == 0) {
-        res = context_boot_go(state, &rsp);
+        res = context_boot_go(state, rsp);
         sim_reset_flash_areas();
         sim_reset_context();
         free(state);

--- a/sim/mcuboot-sys/src/api.rs
+++ b/sim/mcuboot-sys/src/api.rs
@@ -26,6 +26,38 @@ pub struct FlashParamsStruct {
 
 pub type FlashParams = HashMap<u8, FlashParamsStruct>;
 
+/// The `boot_rsp` structure used by boot_go.
+#[repr(C)]
+#[derive(Debug)]
+pub struct BootRsp {
+    pub br_hdr: *const ImageHeader,
+    pub flash_dev_id: u8,
+    pub image_off: u32,
+}
+
+// TODO: Don't duplicate this image header declaration.
+#[repr(C)]
+#[derive(Debug)]
+pub struct ImageHeader {
+    magic: u32,
+    load_addr: u32,
+    hdr_size: u16,
+    protect_tlv_size: u16,
+    img_size: u32,
+    flags: u32,
+    ver: ImageVersion,
+    _pad2: u32,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct ImageVersion {
+    pub major: u8,
+    pub minor: u8,
+    pub revision: u16,
+    pub build_num: u32,
+}
+
 pub struct CAreaDescPtr {
    pub ptr: *const CAreaDesc,
 }

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -20,6 +20,8 @@ pub enum BootGoResult {
     Normal {
         result: i32,
         asserts: u8,
+
+        resp: api::BootRsp,
     },
 }
 
@@ -39,6 +41,7 @@ impl BootGoResult {
         matches!(self, BootGoResult::Normal {
             result: 0,
             asserts: 0,
+            ..
         })
     }
 
@@ -47,6 +50,14 @@ impl BootGoResult {
         match self {
             BootGoResult::Normal { asserts, .. } => *asserts,
             _ => 0,
+        }
+    }
+
+    /// Retrieve the 'resp' field that is filled in.
+    pub fn resp(&self) -> Option<&api::BootRsp> {
+        match self {
+            BootGoResult::Normal { resp, .. } => Some(resp),
+            _ => None,
         }
     }
 }
@@ -86,7 +97,7 @@ pub fn boot_go(multiflash: &mut SimMultiFlash, areadesc: &AreaDesc,
     if result == -0x13579 {
         BootGoResult::Stopped
     } else {
-        BootGoResult::Normal { result, asserts }
+        BootGoResult::Normal { result, asserts, resp: rsp }
     }
 }
 

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -26,8 +26,14 @@ pub fn boot_go(multiflash: &mut SimMultiFlash, areadesc: &AreaDesc,
         c_catch_asserts: if catch_asserts { 1 } else { 0 },
         boot_jmpbuf: [0; 16],
     };
+    let mut rsp = api::BootRsp {
+        br_hdr: std::ptr::null(),
+        flash_dev_id: 0,
+        image_off: 0,
+    };
     let result = unsafe {
-        raw::invoke_boot_go(&mut sim_ctx as *mut _, &areadesc.get_c() as *const _) as i32
+        raw::invoke_boot_go(&mut sim_ctx as *mut _, &areadesc.get_c() as *const _,
+            &mut rsp as *mut _) as i32
     };
     let asserts = sim_ctx.c_asserts;
     if let Some(c) = counter {
@@ -82,13 +88,14 @@ pub fn kw_encrypt(kek: &[u8], seckey: &[u8], keylen: u32) -> Result<Vec<u8>, &'s
 
 mod raw {
     use crate::area::CAreaDesc;
-    use crate::api::CSimContext;
+    use crate::api::{BootRsp, CSimContext};
 
     extern "C" {
         // This generates a warning about `CAreaDesc` not being foreign safe.  There doesn't appear to
         // be any way to get rid of this warning.  See https://github.com/rust-lang/rust/issues/34798
         // for information and tracking.
-        pub fn invoke_boot_go(sim_ctx: *mut CSimContext, areadesc: *const CAreaDesc) -> libc::c_int;
+        pub fn invoke_boot_go(sim_ctx: *mut CSimContext, areadesc: *const CAreaDesc,
+            rsp: *mut BootRsp) -> libc::c_int;
 
         pub fn boot_trailer_sz(min_write_sz: u32) -> u32;
         pub fn boot_status_sz(min_write_sz: u32) -> u32;


### PR DESCRIPTION
Enhance the return type from `boot_go` in the simulator. Instead of pattern matching, return an abstract type, and provide accessors to get to the necessary functionality. As part of this, return the boot_rsp structure that passes additional information back from the bootloader.