### PR TITLE
boot: introduce MCUBOOT_CPU_IDLE() for support low power single thread 

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -613,6 +613,7 @@ boot_serial_start(const struct boot_uart_funcs *f)
 
     off = 0;
     while (1) {
+        MCUBOOT_CPU_IDLE();
         rc = f->read(in_buf + off, sizeof(in_buf) - off, &full_line);
         if (rc <= 0 && !full_line) {
             continue;

--- a/boot/cypress/MCUBootApp/config/mcuboot_config/mcuboot_config.h
+++ b/boot/cypress/MCUBootApp/config/mcuboot_config/mcuboot_config.h
@@ -152,4 +152,11 @@
 #define NUM_ECC_BYTES (256 / 8)
 #endif /* ENC_IMG */
 
+/*
+ * No direct idle call implemented
+ */
+#define MCUBOOT_CPU_IDLE() \
+    do {                   \
+    } while (0)
+
 #endif /* MCUBOOT_CONFIG_H */

--- a/boot/mbed/include/mcuboot_config/mcuboot_config.h
+++ b/boot/mbed/include/mcuboot_config/mcuboot_config.h
@@ -79,5 +79,11 @@
     do {                                        \
     } while (0)
 
+/*
+ * No direct idle call implemented
+ */
+#define MCUBOOT_CPU_IDLE() \
+    do {                   \
+    } while (0)
 
 #endif /* __MCUBOOT_CONFIG_H__ */

--- a/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_config.h
+++ b/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_config.h
@@ -101,4 +101,11 @@
 #define MCUBOOT_WATCHDOG_FEED()    do {} while (0)
 #endif
 
+/*
+ * No direct idle call implemented
+ */
+#define MCUBOOT_CPU_IDLE() \
+    do {                   \
+    } while (0)
+
 #endif /* __MCUBOOT_CONFIG_H__ */

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -205,4 +205,9 @@
 
 #endif /* CONFIG_BOOT_WATCHDOG_FEED */
 
+#define MCUBOOT_CPU_IDLE() \
+  if (!IS_ENABLED(CONFIG_MULTITHREADING)) { \
+    k_cpu_idle(); \
+  }
+
 #endif /* __MCUBOOT_CONFIG_H__ */

--- a/samples/mcuboot_config/mcuboot_config.template.h
+++ b/samples/mcuboot_config/mcuboot_config.template.h
@@ -146,4 +146,14 @@
  *    do { do watchdog feeding here! } while (0)
  */
 
+/* If a OS ports support single thread mode or is bare-metal then:
+ * This macro implements call that switches CPU to an idle state, from which
+ * the CPU may be woken up by, for example, UART transmission event.
+ * 
+ * Otherwise this macro should be no-op.
+ */
+#define MCUBOOT_CPU_IDLE() \
+    do {                   \
+    } while (0)
+
 #endif /* __MCUBOOT_CONFIG_H__ */


### PR DESCRIPTION
If a port supports single thread or is bare-metal then might be need
to switch to idle mode explicitly form MCUboot code.
The call allows to enable lower power consumption while waiting for
incoming transmission in serial recovery etc.

Especially:
Sine a while there is no silent idle thread created automatically while
CONFIG_MULTITHREADING=n in zephyr. Since that any single thread application
needs to call k_cpu_idle() by itself for entering idle mode, which
allows for reduction power consumption.