### PR TITLE
bootutil: Fix some misspelling variables

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -2289,7 +2289,7 @@ boot_select_or_erase(struct boot_loader_state *state,
          * to prevent it from being selected again on the next reboot.
          */
         BOOT_LOG_DBG("Erasing faulty image in the %s slot.",
-                     (slot == BOOT_PRIMARY_SLOT) ? "primary" : "secondary");
+                     (active_slot == BOOT_PRIMARY_SLOT) ? "primary" : "secondary");
         rc = flash_area_erase(fap, 0, fap->fa_size);
         assert(rc == 0);
 
@@ -2310,7 +2310,7 @@ boot_select_or_erase(struct boot_loader_state *state,
             rc = boot_write_copy_done(fap);
             if (rc != 0) {
                 BOOT_LOG_WRN("Failed to set copy_done flag of the image in "
-                             "the %s slot.", (slot == BOOT_PRIMARY_SLOT) ?
+                             "the %s slot.", (active_slot == BOOT_PRIMARY_SLOT) ?
                              "primary" : "secondary");
                 rc = 0;
             }


### PR DESCRIPTION
There ir a couple of misspelled variables (slot -> active_slot).

fix #1028

Signed-off-by: Carlos Falgueras García <carlos.falgueras@wslw.es>