### PR TITLE
bootutil: Do not include mcuboot_logging.h when logging is disabled

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil_log.h
+++ b/boot/bootutil/include/bootutil/bootutil_log.h
@@ -26,9 +26,9 @@ extern "C" {
 #endif
 
 #include <mcuboot_config/mcuboot_config.h>
-#include <mcuboot_config/mcuboot_logging.h>
 
 #ifdef MCUBOOT_HAVE_LOGGING
+#include <mcuboot_config/mcuboot_logging.h>
 
 #define BOOT_LOG_ERR(...) MCUBOOT_LOG_ERR(__VA_ARGS__)
 #define BOOT_LOG_WRN(...) MCUBOOT_LOG_WRN(__VA_ARGS__)


### PR DESCRIPTION
This frees the user from the need of create an empty "mcuboot_logging.h"
when the logging is disabled.

Signed-off-by: Carlos Falgueras García <carlos.falgueras@wslw.es>