### PR TITLE
workflow: Back off stale bot a bit

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -14,10 +14,11 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This pull request has been marked as stale because it has been open (more than) 60 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this pull request will automatically be closed in 14 days. Note, that you can always re-open a closed pull request at any time.'
         stale-issue-message: 'This issue has been marked as stale because it has been open (more than) 60 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this issue will automatically be closed in 14 days. Note, that you can always re-open a closed issue at any time.'
-        days-before-stale: 60
+        days-before-stale: 180
         days-before-close: 14
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
+        exempt-issue-labels: 'someday'
         # exempt-pr-labels: 'Blocked,In progress'
         # exempt-issue-labels: 'In progress,Enhancement,Feature,Feature Request,RFC,Meta'
         operations-per-run: 400


### PR DESCRIPTION
Change the stale bot to 180 days before initial flag.  In addition,
avoid issues entirely that have the 'someday' label applied.

Signed-off-by: David Brown <david.brown@linaro.org>