### PR TITLE
Update path to devicetree python package lib files

### DIFF
--- a/scripts/assemble.py
+++ b/scripts/assemble.py
@@ -127,14 +127,14 @@ def main():
             print('Need to either have ZEPHYR_BASE in environment or pass in -z')
             sys.exit(1)
 
-    sys.path.insert(0, os.path.join(zephyr_base, "scripts", "dts"))
-    import edtlib
+    sys.path.insert(0, os.path.join(zephyr_base, "scripts", "dts", "python-devicetree", "src"))
+    import devicetree.edtlib
 
     board = find_board_name(args.bootdir)
 
     dts_path = os.path.join(args.bootdir, "zephyr", board + ".dts.pre.tmp")
 
-    edt = edtlib.EDT(dts_path, [os.path.join(zephyr_base, "dts", "bindings")],
+    edt = devicetree.edtlib.EDT(dts_path, [os.path.join(zephyr_base, "dts", "bindings")],
             warn_reg_unit_address_mismatch=False)
 
     output = Assembly(args.output, args.bootdir, edt)


### PR DESCRIPTION
This PR updates the path to the devicetree python package lib files according to this Zephyr PR [zephyrproject-rtos#33746](https://github.com/zephyrproject-rtos/zephyr/pull/33746) which moved the devicetree lib files.

Old path: `ZEPHYR_BASE/scripts/dts/`
New path: `ZEPHYR_BASE/scripts/dts/python-devicetree/src/devicetree/`

This PR solves the issue [mcuboot#1043](https://github.com/mcu-tools/mcuboot/issues/1043) Without this fix mcuboot won't build with zephyr 2.6.0.