### PR TITLE
bootutil: Refactor MCUBOOT_LOG_MODULE_(DECLARE|REGISTER) macros

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -60,7 +60,7 @@
 
 #include "serial_recovery_cbor.h"
 
-MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
+BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 #define BOOT_SERIAL_INPUT_MAX   512
 #define BOOT_SERIAL_OUT_MAX     128

--- a/boot/bootutil/include/bootutil/bootutil_log.h
+++ b/boot/bootutil/include/bootutil/bootutil_log.h
@@ -36,6 +36,9 @@ extern "C" {
 #define BOOT_LOG_DBG(...) MCUBOOT_LOG_DBG(__VA_ARGS__)
 #define BOOT_LOG_SIM(...) MCUBOOT_LOG_SIM(__VA_ARGS__)
 
+#define BOOT_LOG_MODULE_DECLARE(module)  MCUBOOT_LOG_MODULE_DECLARE(module)
+#define BOOT_LOG_MODULE_REGISTER(module) MCUBOOT_LOG_MODULE_REGISTER(module)
+
 #else
 
 #define BOOT_LOG_ERR(...) IGNORE(__VA_ARGS__)
@@ -43,6 +46,9 @@ extern "C" {
 #define BOOT_LOG_INF(...) IGNORE(__VA_ARGS__)
 #define BOOT_LOG_DBG(...) IGNORE(__VA_ARGS__)
 #define BOOT_LOG_SIM(...) IGNORE(__VA_ARGS__)
+
+#define BOOT_LOG_MODULE_DECLARE(module)
+#define BOOT_LOG_MODULE_REGISTER(module)
 
 #endif /* MCUBOOT_HAVE_LOGGING */
 

--- a/boot/bootutil/include/bootutil/bootutil_log.h
+++ b/boot/bootutil/include/bootutil/bootutil_log.h
@@ -26,9 +26,9 @@ extern "C" {
 #endif
 
 #include <mcuboot_config/mcuboot_config.h>
-#include <mcuboot_config/mcuboot_logging.h>
 
 #ifdef MCUBOOT_HAVE_LOGGING
+#include <mcuboot_config/mcuboot_logging.h>
 
 #define BOOT_LOG_ERR(...) MCUBOOT_LOG_ERR(__VA_ARGS__)
 #define BOOT_LOG_WRN(...) MCUBOOT_LOG_WRN(__VA_ARGS__)

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -41,7 +41,7 @@
 #include "bootutil/enc_key.h"
 #endif
 
-MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
+BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 /* Currently only used by imgmgr */
 int boot_current_slot;

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -51,9 +51,9 @@
 #endif
 
 #ifdef CONFIG_MCUBOOT
-MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
+BOOT_LOG_MODULE_DECLARE(mcuboot);
 #else
-MCUBOOT_LOG_MODULE_REGISTER(mcuboot_util);
+BOOT_LOG_MODULE_REGISTER(mcuboot_util);
 #endif
 
 const uint32_t boot_img_magic[] = {

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -52,7 +52,7 @@
 
 #include "mcuboot_config/mcuboot_config.h"
 
-MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
+BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 static struct boot_loader_state boot_data;
 

--- a/boot/bootutil/src/swap_misc.c
+++ b/boot/bootutil/src/swap_misc.c
@@ -28,7 +28,7 @@
 
 #include "mcuboot_config/mcuboot_config.h"
 
-MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
+BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 #if defined(MCUBOOT_SWAP_USING_SCRATCH) || defined(MCUBOOT_SWAP_USING_MOVE)
 int

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -28,7 +28,7 @@
 
 #include "mcuboot_config/mcuboot_config.h"
 
-MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
+BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 #ifdef MCUBOOT_SWAP_USING_MOVE
 

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -28,7 +28,7 @@
 
 #include "mcuboot_config/mcuboot_config.h"
 
-MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
+BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 #if !defined(MCUBOOT_SWAP_USING_MOVE)
 

--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -15,7 +15,7 @@
 
 #include "bootutil/bootutil_log.h"
 
-MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
+BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 #if (!defined(CONFIG_XTENSA) && defined(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL))
 #define FLASH_DEVICE_ID SOC_FLASH_0_ID

--- a/boot/zephyr/flash_map_legacy.c
+++ b/boot/zephyr/flash_map_legacy.c
@@ -49,7 +49,7 @@
 #define FLASH_AREA_IMAGE_SECTOR_SIZE FLASH_AREA_IMAGE_SCRATCH_SIZE
 #endif
 
-MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
+BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 /*
  * Lookup the sector map for a given flash area.  This should fill in

--- a/boot/zephyr/include/platform-bench.h
+++ b/boot/zephyr/include/platform-bench.h
@@ -23,7 +23,7 @@
 #include "bootutil/bootutil_log.h"
 
 /* TODO: Unclear if this can be here (redundantly). */
-MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
+BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 typedef uint32_t bench_state_t;
 

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -105,7 +105,7 @@ static inline bool boot_skip_serial_recovery()
 }
 #endif
 
-MCUBOOT_LOG_MODULE_REGISTER(mcuboot);
+BOOT_LOG_MODULE_REGISTER(mcuboot);
 
 #ifdef CONFIG_MCUBOOT_INDICATION_LED
 /*

--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -26,7 +26,7 @@
 #error Zephyr UART console must been disabled if serial_adapter module is used.
 #endif
 
-MCUBOOT_LOG_MODULE_REGISTER(serial_adapter);
+BOOT_LOG_MODULE_REGISTER(serial_adapter);
 
 /** @brief Console input representation
  *

--- a/boot/zephyr/single_loader.c
+++ b/boot/zephyr/single_loader.c
@@ -13,7 +13,7 @@
 
 #include "mcuboot_config/mcuboot_config.h"
 
-MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
+BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 /* Variables passed outside of unit via poiters. */
 static const struct flash_area *_fa_p;


### PR DESCRIPTION
The "MCUBOOT_LOG_MODULE_(DECLARE|REGISTER)" macros should have a name
coherent with the rest of the logs macors, ie "BOOT_LOG_*". Also,
"bootutil_log.h" should define them as empty when the logs are disabled and
as "MCUBOOT_LOG_MODULE_*" when they are not.

With this change, the mcuboot user doesn't have to define
MCUBOOT_LOG_MODULE_* macros if the logs don't going to be used.

Signed-off-by: Carlos Falgueras García <carlos.falgueras@wslw.es>