### PR TITLE
bootutil: Include missing header and prevent ASSERT redefinition

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil_public.h
+++ b/boot/bootutil/include/bootutil/bootutil_public.h
@@ -116,7 +116,9 @@ extern "C" {
 #include "mcuboot_config/mcuboot_assert.h"
 #else
 #include <assert.h>
+#ifndef ASSERT
 #define ASSERT assert
+#endif
 #endif
 
 struct boot_swap_state {

--- a/boot/bootutil/include/bootutil/bootutil_public.h
+++ b/boot/bootutil/include/bootutil/bootutil_public.h
@@ -41,6 +41,7 @@
 #include <inttypes.h>
 #include <string.h>
 #include <flash_map_backend/flash_map_backend.h>
+#include <mcuboot_config/mcuboot_config.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This PR intends to provide two fixes for minor issues encountered during the creation of a new port:
- The `mcuboot_config.h` header is missing from `bootutil_public.h` includes for the evaluation of the `MCUBOOT_HAVE_ASSERT_H` definition.
- `ASSERT` macro may be already defined by the underlying OS, so we need to avoid redefining it.