### PR TITLE
add call to boot_enc_init during swap recovery

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1245,6 +1245,7 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
 
 #ifdef MCUBOOT_ENC_IMAGES
         for (slot = 0; slot < BOOT_NUM_SLOTS; slot++) {
+            boot_enc_init(BOOT_CURR_ENC(state), slot);
             rc = boot_read_enc_key(image_index, slot, bs);
             assert(rc == 0);
 


### PR DESCRIPTION
Fixes #1046

`bootutil_aes_ctr_init` is never called during a swap recovery, which is problematic if hw crypto is used. This pull request simply adds a call to `boot_enc_init` to fix that