### PR TITLE
Initialize aes-ctr during swap recovery

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1245,6 +1245,7 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
 
 #ifdef MCUBOOT_ENC_IMAGES
         for (slot = 0; slot < BOOT_NUM_SLOTS; slot++) {
+            boot_enc_init(BOOT_CURR_ENC(state), slot);
             rc = boot_read_enc_key(image_index, slot, bs);
             assert(rc == 0);
 


### PR DESCRIPTION
Fixes #1046 

`bootutil_aes_ctr_init` is never called when MCUboot resumes a swap after a reset, which is a problem in case of hw implementation of AES-CTR.

This pull request simply fixes this by calling `boot_enc_init` before setting keys when `!boot_status_is_reset()`

Signed-off-by: Alex Ferragni <alex.ferragni@csem.ch>