### PR TITLE
Option for serial recovery to respect "image" parameter of mcumgr image update

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -274,7 +274,11 @@ bs_upload(char *buf, int len)
         goto out_invalid_data;
     }
 
+#if !defined(MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD)
     rc = flash_area_open(flash_area_id_from_multi_image_slot(img_num, 0), &fap);
+#else
+    rc = flash_area_open(flash_area_id_from_direct_image(img_num), &fap);
+#endif
     if (rc) {
         rc = MGMT_ERR_EINVAL;
         goto out;

--- a/boot/boot_serial/src/boot_serial_priv.h
+++ b/boot/boot_serial/src/boot_serial_priv.h
@@ -65,6 +65,19 @@ struct nmgr_hdr {
 void boot_serial_input(char *buf, int len);
 extern const struct boot_uart_funcs *boot_uf;
 
+/**
+ * @brief Selects direct image to upload according to the "image"
+ * parameter of the mcumgr update frame.
+ *
+ * @param[in] image_id  the value of the "image" parameter of the
+ *                      mcumgr update frame to be translated.
+ *
+ * @return flash area ID for the image if defined;
+ *         -EINVAL when flash area for given image number has not been
+ *         defined.
+ */
+extern int flash_area_id_from_direct_image(int image_id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -493,6 +493,21 @@ config BOOT_SERIAL_CDC_ACM
 
 endchoice
 
+config MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD
+	bool "Allow to select image number for DFU"
+	help
+	  With the option enabled, the mcuboot serial recovery will
+	  respect the "image" field in mcumgr image update frame
+	  header.
+	  The mapping of image number to partition is as follows:
+	    0 -> default behaviour, same as 1;
+	    1 -> image-0 (primary slot of the first image);
+	    2 -> image-1 (secondary slot of the first image);
+	    3 -> image-2;
+	    4 -> image-3.
+	  Note that 0 is default upload target when no explicit
+	  selection is done.
+
 config MCUBOOT_INDICATION_LED
 	bool "Turns on LED indication when device is in DFU"
 	default n

--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -93,6 +93,30 @@ int flash_area_id_to_image_slot(int area_id)
     return flash_area_id_to_multi_image_slot(0, area_id);
 }
 
+#if defined(CONFIG_MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD)
+int flash_area_id_from_direct_image(int image_id)
+{
+    switch (image_id) {
+    case 0:
+    case 1:
+        return FLASH_AREA_ID(image_0);
+#if DT_HAS_FIXED_PARTITION_LABEL(image_1)
+    case 2:
+        return FLASH_AREA_ID(image_1);
+#endif
+#if DT_HAS_FIXED_PARTITION_LABEL(image_2)
+    case 3:
+        return FLASH_AREA_ID(image_2);
+#endif
+#if DT_HAS_FIXED_PARTITION_LABEL(image_3)
+    case 4:
+        return FLASH_AREA_ID(image_3);
+#endif
+    }
+    return -EINVAL;
+}
+#endif
+
 int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
 {
     int rc;

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -146,6 +146,14 @@
 #endif
 
 /*
+ * The configuration option enables direct image upload with the
+ * serial recovery.
+ */
+#ifdef CONFIG_MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD
+#define MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD
+#endif
+
+/*
  * Enabling this option uses newer flash map APIs. This saves RAM and
  * avoids deprecated API usage.
  *


### PR DESCRIPTION
The PR adds support for respecting the "image" parameter of the mcumgr image upload command in serial recovery.
This allows to directly upload image by number; the translation of the image number to the destination is done by platform specific implementation of the `flash_area_id_from_direct_image` function.

The PR contains two commits:
 - general code change, addition of `MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD` that controls the options and prototype for `flash_area_id_from_direct_image`
 - Zephyr specific implementation.