### PR TITLE
zephyr: Relocate BOOT_ERASE_PROGRESSIVELY option

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -298,15 +298,6 @@ config BOOT_MAX_IMG_SECTORS
 	  memory usage; larger values allow it to support larger images.
 	  If unsure, leave at the default value.
 
-config BOOT_ERASE_PROGRESSIVELY
-	bool "Erase flash progressively when receiving new firmware"
-	default y if SOC_FAMILY_NRF
-	help
-	 If enabled, flash is erased as necessary when receiving new firmware,
-	 instead of erasing the whole image slot at once. This is necessary
-	 on some hardware that has long erase times, to prevent long wait
-	 times at the beginning of the DFU process.
-
 config MEASURED_BOOT
 	bool "Store the boot state/measurements in shared memory"
 	default n
@@ -566,6 +557,15 @@ config RECOVERY_UART_DEV_NAME
 	help
 	  This option specifies the name of UART device to be used for
 	  serial recovery.
+
+config BOOT_ERASE_PROGRESSIVELY
+	bool "Erase flash progressively when receiving new firmware"
+	default y if SOC_FAMILY_NRF
+	help
+	 If enabled, flash is erased as necessary when receiving new firmware,
+	 instead of erasing the whole image slot at once. This is necessary
+	 on some hardware that has long erase times, to prevent long wait
+	 times at the beginning of the DFU process.
 
 config ENABLE_MGMT_PERUSER
 	bool "Enable system specific mcumgr commands"


### PR DESCRIPTION
The Kconfig option is applied only when MCUBOOT_SERIAL is enabled
so it has been moved into MUCBOOT_SERIAL dependent section
of Kconfig.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>