### PR TITLE
Rename CONFIG_BOOT_ERASE_PROGRESSIVELY to platform agnostic MCUBOOT_ERASE_PROGRESSIVELY

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -54,7 +54,7 @@
 #include "boot_serial/boot_serial.h"
 #include "boot_serial_priv.h"
 
-#ifdef CONFIG_BOOT_ERASE_PROGRESSIVELY
+#ifdef MCUBOOT_ERASE_PROGRESSIVELY
 #include "bootutil_priv.h"
 #endif
 
@@ -218,7 +218,7 @@ bs_upload(char *buf, int len)
     size_t slen;
     const struct flash_area *fap = NULL;
     int rc;
-#ifdef CONFIG_BOOT_ERASE_PROGRESSIVELY
+#ifdef MCUBOOT_ERASE_PROGRESSIVELY
     static off_t off_last = -1;
     struct flash_sector sector;
 #endif
@@ -285,7 +285,7 @@ bs_upload(char *buf, int len)
         if (data_len > flash_area_get_size(fap)) {
             goto out_invalid_data;
         }
-#ifndef CONFIG_BOOT_ERASE_PROGRESSIVELY
+#ifndef MCUBOOT_ERASE_PROGRESSIVELY
         rc = flash_area_erase(fap, 0, flash_area_get_size(fap));
         if (rc) {
             goto out_invalid_data;
@@ -310,7 +310,7 @@ bs_upload(char *buf, int len)
         rem_bytes = 0;
     }
 
-#ifdef CONFIG_BOOT_ERASE_PROGRESSIVELY
+#ifdef MCUBOOT_ERASE_PROGRESSIVELY
     rc = flash_area_sector_from_off(curr_off + img_blen, &sector);
     if (rc) {
         BOOT_LOG_ERR("Unable to determine flash sector size");
@@ -357,7 +357,7 @@ bs_upload(char *buf, int len)
 
     if (rc == 0) {
         curr_off += img_blen;
-#ifdef CONFIG_BOOT_ERASE_PROGRESSIVELY
+#ifdef MCUBOOT_ERASE_PROGRESSIVELY
         if (curr_off == img_size) {
             /* get the last sector offset */
             rc = flash_area_sector_from_off(boot_status_off(fap), &sector);

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -146,6 +146,18 @@
 #endif
 
 /*
+ * The option enables code, currently in boot_serial, that attempts
+ * to erase flash progressively, as update fragments are received,
+ * instead of erasing whole image size of flash area after receiving
+ * first frame.
+ * Enabling this options prevents stalling the beginning of transfer
+ * for the time needed to erase large chunk of flash.
+ */
+#ifdef CONFIG_BOOT_ERASE_PROGRESSIVELY
+#define MCBOOT_ERASE_PROGRESSIVELY
+#endif
+
+/*
  * Enabling this option uses newer flash map APIs. This saves RAM and
  * avoids deprecated API usage.
  *


### PR DESCRIPTION
The `CONFIG_BOOT_ERASE_PROGRESSIVELY` is used in common boot_serial.c code to turn on the progressive erase;
because the code is common and the options is Zephyr characteristic Kconfig option, the PR renames the option to port agnostic `MCUBOOT_ERASE_PROGRESSIVELY`, and adds proper mcuboot_config.h code to handle the change for Zephyr.
