### PR TITLE
boot: bootutil: Fix memory alignment of RAM buffer

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -813,7 +813,7 @@ boot_copy_region(struct boot_loader_state *state,
     uint8_t image_index;
 #endif
 
-    TARGET_STATIC uint8_t buf[1024];
+    TARGET_STATIC uint8_t buf[1024] __attribute__((aligned(4)));
 
 #if !defined(MCUBOOT_ENC_IMAGES)
     (void)state;


### PR DESCRIPTION
Change fixes memory alignment of the RAM buffer that is used to temprorarily store data during swap. Some FLASH drivers require word-aligned input data buffer. Using unaligned buffer results in FLASH write error.