### PR TITLE
boot: Revert "boot: Check shared area more carefully before init"

### DIFF
--- a/boot/bootutil/src/boot_record.c
+++ b/boot/bootutil/src/boot_record.c
@@ -62,18 +62,13 @@ boot_add_data_to_shared_area(uint8_t        major_type,
 
     boot_data = (struct shared_boot_data *)MCUBOOT_SHARED_DATA_BASE;
 
-    /* Check whether first time to call this function. If it is, then check
-     * whether the shared data area needs to be initialised.
+    /* Check whether first time to call this function. If does then initialise
+     * shared data area.
      */
     if (!shared_memory_init_done) {
-        if ((boot_data->header.tlv_magic != SHARED_DATA_TLV_INFO_MAGIC) ||
-            (boot_data->header.tlv_tot_len > MCUBOOT_SHARED_DATA_SIZE)) {
-            memset((void *)MCUBOOT_SHARED_DATA_BASE, 0,
-                           MCUBOOT_SHARED_DATA_SIZE);
-            boot_data->header.tlv_magic   = SHARED_DATA_TLV_INFO_MAGIC;
-            boot_data->header.tlv_tot_len = SHARED_DATA_HEADER_SIZE;
-        }
-
+        memset((void *)MCUBOOT_SHARED_DATA_BASE, 0, MCUBOOT_SHARED_DATA_SIZE);
+        boot_data->header.tlv_magic   = SHARED_DATA_TLV_INFO_MAGIC;
+        boot_data->header.tlv_tot_len = SHARED_DATA_HEADER_SIZE;
         shared_memory_init_done = true;
     }
 


### PR DESCRIPTION
The commit "boot: Check shared area more carefully before init" adds
the support that the shared area can be used by other boot stages.
Before this commit, MCUboot initialize the shared memory based on a
global variable which indicates whether the shared memory has been
initialized by MCUboot. After this commit, MCUboot also checks the magic
value as well as the sanity check before initialization. So if the data
in shared memory retains after a reset, MCUboot does not initialize the
shared memory thus 'SHARED_MEMORY_OVERWRITE' error happens in
'boot_add_data_to_shared_area'.

So reverted this commit temporarily.

Signed-off-by: Sherry Zhang <sherry.zhang2@arm.com>
Change-Id: I1fc390bc17f90c2624024bc101ba8b4d5a75fe23