### PR TITLE
Introduce random IV and salt - REBASED to latest changes

### DIFF
--- a/boot/bootutil/include/bootutil/enc_key.h
+++ b/boot/bootutil/include/bootutil/enc_key.h
@@ -45,6 +45,7 @@ extern "C" {
 
 struct enc_key_data {
     uint8_t valid;
+    uint8_t aes_iv[BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE];
     bootutil_aes_ctr_context aes_ctr;
 };
 
@@ -58,7 +59,7 @@ int boot_enc_set_key(struct enc_key_data *enc_state, uint8_t slot,
 int boot_enc_load(struct enc_key_data *enc_state, int image_index,
         const struct image_header *hdr, const struct flash_area *fap,
         struct boot_status *bs);
-int boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey);
+int boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey, uint32_t sz, uint8_t *enciv);
 bool boot_enc_valid(struct enc_key_data *enc_state, int image_index,
         const struct flash_area *fap);
 void boot_encrypt(struct enc_key_data *enc_state, int image_index,

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -272,6 +272,8 @@ boot_read_enc_key(int image_index, uint8_t slot, struct boot_status *bs)
     if (rc == 0) {
         off = boot_enc_key_off(fap, slot);
 #if MCUBOOT_SWAP_SAVE_ENCTLV
+        uint8_t aes_iv[BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE];
+
         rc = flash_area_read(fap, off, bs->enctlv[slot], BOOT_ENC_TLV_ALIGN_SIZE);
         if (rc == 0) {
             for (i = 0; i < BOOT_ENC_TLV_ALIGN_SIZE; i++) {
@@ -281,7 +283,7 @@ boot_read_enc_key(int image_index, uint8_t slot, struct boot_status *bs)
             }
             /* Only try to decrypt non-erased TLV metadata */
             if (i != BOOT_ENC_TLV_ALIGN_SIZE) {
-                rc = boot_enc_decrypt(bs->enctlv[slot], bs->enckey[slot]);
+                rc = boot_enc_decrypt(bs->enctlv[slot], bs->enckey[slot], 0, aes_iv);
             }
         }
 #else

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -155,12 +155,6 @@ boot_copy_done_off(const struct flash_area *fap)
     return boot_image_ok_off(fap) - BOOT_MAX_ALIGN;
 }
 
-static inline uint32_t
-boot_swap_size_off(const struct flash_area *fap)
-{
-    return boot_swap_info_off(fap) - BOOT_MAX_ALIGN;
-}
-
 uint32_t
 boot_swap_info_off(const struct flash_area *fap)
 {
@@ -192,19 +186,6 @@ boot_magic_compatible_check(uint8_t tbl_val, uint8_t val)
         return tbl_val == val;
     }
 }
-
-#ifdef MCUBOOT_ENC_IMAGES
-static inline uint32_t
-boot_enc_key_off(const struct flash_area *fap, uint8_t slot)
-{
-#if MCUBOOT_SWAP_SAVE_ENCTLV
-    return boot_swap_size_off(fap) - ((slot + 1) *
-            ((((BOOT_ENC_TLV_SIZE - 1) / BOOT_MAX_ALIGN) + 1) * BOOT_MAX_ALIGN));
-#else
-    return boot_swap_size_off(fap) - ((slot + 1) * BOOT_ENC_KEY_SIZE);
-#endif
-}
-#endif
 
 bool bootutil_buffer_is_erased(const struct flash_area *area,
                                const void *buffer, size_t len)

--- a/boot/bootutil/src/image_ec256.c
+++ b/boot/bootutil/src/image_ec256.c
@@ -99,7 +99,7 @@ bootutil_parse_eckey(mbedtls_ecdsa_context *ctx, uint8_t **p, uint8_t *end)
     }
     return 0;
 }
-#endif /* CY_MBEDTLS_HW_ACCELERATION */
+#else /* !CY_MBEDTLS_HW_ACCELERATION */
 static int
 bootutil_import_key(uint8_t **cp, uint8_t *end)
 {
@@ -141,6 +141,7 @@ bootutil_import_key(uint8_t **cp, uint8_t *end)
 
     return 0;
 }
+#endif /* CY_MBEDTLS_HW_ACCELERATION */
 
 #ifndef MCUBOOT_ECDSA_NEED_ASN1_SIG
 /*

--- a/boot/cypress/BlinkyApp/BlinkyApp.mk
+++ b/boot/cypress/BlinkyApp/BlinkyApp.mk
@@ -113,6 +113,7 @@ OUT_CFG := $(OUT_TARGET)/$(BUILDCFG)
 ifeq ($(IMG_TYPE), UPGRADE)
 	ifeq ($(ENC_IMG), 1)
 		SIGN_ARGS += --encrypt ../../$(ENC_KEY_FILE).pem
+		SIGN_ARGS += --use-random-iv
 	endif
 	SIGN_ARGS += --pad
 	UPGRADE_SUFFIX :=_upgrade

--- a/boot/cypress/MCUBootApp/config/mcuboot_config/mcuboot_logging.h
+++ b/boot/cypress/MCUBootApp/config/mcuboot_config/mcuboot_logging.h
@@ -94,6 +94,7 @@ int sim_log_enabled(int level);
 #define MCUBOOT_LOG_DBG(...) IGNORE(__VA_ARGS__)
 #endif
 
-#define MCUBOOT_LOG_MODULE_DECLARE(...)
+#define MCUBOOT_LOG_MODULE_DECLARE(domain)  /* ignore */
+#define MCUBOOT_LOG_MODULE_REGISTER(domain) /* ignore */
 
 #endif /* MCUBOOT_LOGGING_H */

--- a/docs/encrypted_images.md
+++ b/docs/encrypted_images.md
@@ -92,20 +92,27 @@ libraries. The whole key encryption can be summarized as:
   keypair. Those keys will be our ephemeral keys.
 * Generate a new secret (DH) using the ephemeral private key and the public key
   that corresponds to the private key embedded in the HW.
-* Derive the new keys from the secret using HKDF (built on HMAC-SHA256). We
-  are not using a `salt` and using an `info` of `MCUBoot_ECIES_v1`, generating
-  48 bytes of key material.
-* A new random encryption key is generated (for AES). This is
-  the AES key used to encrypt the images.
-* The key is encrypted with AES-128-CTR or AES-256-CTR and a `nonce` of 0 using
-  the first 16 bytes of key material generated previously by the HKDF.
+* Derive the new keys from the secret using HKDF (built on HMAC-SHA256). By
+  default we are not using a `salt` and using an `info` of `MCUBoot_ECIES_v1`,
+  generating 48 bytes of key material. Random salt value can be generated and
+  included in TLV info however, when using option `--use-random-iv` of `imgtool`.
+  MCUBoot uses random salt if it is present in TLVs.
+* A new random encryption key is generated (for AES). This is the AES key used to
+  encrypt the images.
+* The key is encrypted with AES-128-CTR or AES-256-CTR and a `nonce` of 0 by
+  default, using the first 16 bytes of key material generated previously by the
+  HKDF. Random `nonce` can be generated however, when using option
+  `--use-random-iv` of `imgtool`. In this case 12 bytes filled with random data 
+  and last 4 bytes are 0.
 * The encrypted key now goes through a HMAC-SHA256 using the remaining 32
   bytes of key material from the HKDF.
 
-The final TLV is built from the 65 bytes for ECIES-P256 or 32 bytes for
+The final TLV is built from the 65 bytes for ECIES-P256  or 32 bytes for
 ECIES-X25519, which correspond to the ephemeral public key, followed by the
 32 bytes of MAC tag and the 16 or 32 bytes of the encrypted key, resulting in
-a TLV of 113 or 129 bytes for ECIES-P256 and 80 or 96 bytes for ECIES-X25519.
+a TLV of 113 or 129 bytes (additional 32 bytes if random salt used and 16 bytes
+of CTR random nonce resulting in 161 bytes) for ECIES-P256 and 80 or 96 bytes
+for ECIES-X25519.
 
 The implemenation of ECIES-P256 is named ENC_EC256 in the source code and
 artifacts while ECIES-X25519 is named ENC_X25519.
@@ -133,7 +140,9 @@ sectors are re-encrypted when copying from the `primary slot` to
 the `secondary slot`.
 
 PS: Each encrypted image must have its own key TLV that should be unique
-and used only for this particular image.
+and used only for this particular image. Random `nonce` and `salt` can be 
+used as addtional sources of randomised data. Security is not compromised 
+however until unique key is used for each encrypted image.
 
 Also when swap method is employed, the sizes of both images are saved to
 the status area just before starting the upgrade process, because it

--- a/docs/imgtool.md
+++ b/docs/imgtool.md
@@ -89,6 +89,8 @@ primary slot and adds a header and trailer that the bootloader is expecting:
       --save-enctlv                 When upgrading, save encrypted key TLVs
                                     instead of plain keys. Enable when
                                     BOOT_SWAP_SAVE_ENCTLV config option was set.
+      --use-random-iv               Generate random nonce data for encrypted image,
+                                    0 used by default
       -L, --load-addr INTEGER       Load address for image when it should run
                                     from RAM.
       -x, --hex-addr INTEGER        Adjust address in hex output file.

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -158,6 +158,9 @@ class Image():
         self.enckey = None
         self.save_enctlv = save_enctlv
         self.enctlv_len = 0
+        self.hkdf_salt = None
+        self.hkdf_len = 48
+        self.enc_nonce = bytes([0] * 16)
 
         if security_counter == 'auto':
             # Security counter has not been explicitly provided,
@@ -229,7 +232,7 @@ class Image():
                                                   self.save_enctlv,
                                                   self.enctlv_len)
                 trailer_addr = (self.base_addr + self.slot_size) - trailer_size
-                padding = bytearray([self.erased_val] * 
+                padding = bytearray([self.erased_val] *
                                     (trailer_size - len(boot_magic)))
                 if self.confirm and not self.overwrite_only:
                     padding[-MAX_ALIGN] = 0x01  # image_ok = 0x01
@@ -268,13 +271,18 @@ class Image():
             newpk = X25519PrivateKey.generate()
             shared = newpk.exchange(enckey._get_public())
         derived_key = HKDF(
-            algorithm=hashes.SHA256(), length=48, salt=None,
+            algorithm=hashes.SHA256(), length=self.hkdf_len, salt=self.hkdf_salt,
             info=b'MCUBoot_ECIES_v1', backend=default_backend()).derive(shared)
+        if self.hkdf_salt is not None:
+            key_nonce = derived_key[48:64]
+            self.enc_nonce = derived_key[64:76] + bytes([0] * 4)
+        else:
+            key_nonce = bytes([0] * 16)
         encryptor = Cipher(algorithms.AES(derived_key[:16]),
-                           modes.CTR(bytes([0] * 16)),
+                           modes.CTR(key_nonce),
                            backend=default_backend()).encryptor()
         cipherkey = encryptor.update(plainkey) + encryptor.finalize()
-        mac = hmac.HMAC(derived_key[16:], hashes.SHA256(),
+        mac = hmac.HMAC(derived_key[16:48], hashes.SHA256(),
                         backend=default_backend())
         mac.update(cipherkey)
         ciphermac = mac.finalize()
@@ -289,8 +297,12 @@ class Image():
         return cipherkey, ciphermac, pubk
 
     def create(self, key, public_key_format, enckey, dependencies=None,
-               sw_type=None, custom_tlvs=None, encrypt_keylen=128):
+               sw_type=None, custom_tlvs=None, encrypt_keylen=128, use_random_iv=False):
         self.enckey = enckey
+
+        if use_random_iv:
+            self.hkdf_salt = os.urandom(32)
+            self.hkdf_len += 16 * 2   # 48 for basic scheme + 16 * 2 for random IVs
 
         # Calculate the hash of the public key
         if key is not None:
@@ -450,13 +462,15 @@ class Image():
                                      x25519.X25519Public)):
                 cipherkey, mac, pubk = self.ecies_hkdf(enckey, plainkey)
                 enctlv = pubk + mac + cipherkey
+                if self.hkdf_salt is not None:
+                    enctlv += self.hkdf_salt
                 self.enctlv_len = len(enctlv)
                 if isinstance(enckey, ecdsa.ECDSA256P1Public):
                     tlv.add('ENCEC256', enctlv)
                 else:
                     tlv.add('ENCX25519', enctlv)
 
-            nonce = bytes([0] * 16)
+            nonce = self.enc_nonce
             cipher = Cipher(algorithms.AES(plainkey), modes.CTR(nonce),
                             backend=default_backend())
             encryptor = cipher.encryptor()

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -294,6 +294,9 @@ class BasedIntParamType(click.ParamType):
               default='hash', help='In what format to add the public key to '
               'the image manifest: full key or hash of the key.')
 @click.option('-k', '--key', metavar='filename')
+@click.option('--use-random-iv', default=False, is_flag=True,
+              help='Use random Salt and IV (initial vectors) for the image '
+              'encrypting scheme')
 @click.command(help='''Create a signed or unsigned image\n
                INFILE and OUTFILE are parsed as Intel HEX if the params have
                .hex extension, otherwise binary format is used''')
@@ -301,7 +304,7 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
          pad_header, slot_size, pad, confirm, max_sectors, overwrite_only,
          endian, encrypt_keylen, encrypt, infile, outfile, dependencies,
          load_addr, hex_addr, erased_val, save_enctlv, security_counter,
-         boot_record, custom_tlv, rom_fixed):
+         boot_record, custom_tlv, rom_fixed, use_random_iv):
 
     if confirm:
         # Confirmed but non-padded images don't make much sense, because
@@ -348,7 +351,7 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
             custom_tlvs[tag] = value.encode('utf-8')
 
     img.create(key, public_key_format, enckey, dependencies, boot_record,
-               custom_tlvs, int(encrypt_keylen))
+               custom_tlvs, int(encrypt_keylen), use_random_iv=use_random_iv)
     img.save(outfile, hex_addr)
 
 


### PR DESCRIPTION
Creating new PR, since previous one (https://github.com/mcu-tools/mcuboot/pull/962) became incompatible with latest changes in mcuboot.

This one does not include @utzig changes (https://github.com/mcu-tools/mcuboot/pull/980), because now they cause failures in sim run. Do we need to investigate on that?

Commits:
imgtool: adds flag --use-random-iv which allows randomised data embedding to HKDF data - turned off by default to keep compatibility.
bootutil: changes to support update in mcuboot
cypress: updates to cypress code to support changes