### PR TITLE
ESP32-S2: Basic MCUboot support

### DIFF
--- a/boot/espressif/hal/CMakeLists.txt
+++ b/boot/espressif/hal/CMakeLists.txt
@@ -7,11 +7,13 @@ set(esp_idf_dir ${IDF_PATH})
 set(SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/src)
 set(INCLUDE_DIRS
     ${CMAKE_CURRENT_LIST_DIR}/include
-    ${CMAKE_CURRENT_LIST_DIR}/include/${MCUBOOT_TARGET})
+    ${CMAKE_CURRENT_LIST_DIR}/include/${MCUBOOT_TARGET}
+    )
 
 list(APPEND INCLUDE_DIRS
     ${esp_idf_dir}/components/esp_common/include
     ${esp_idf_dir}/components/esp_rom/include
+    ${esp_idf_dir}/components/esp_rom/include/${MCUBOOT_TARGET}
     ${esp_idf_dir}/components/xtensa/${MCUBOOT_TARGET}/include
     ${esp_idf_dir}/components/spi_flash/include
     ${esp_idf_dir}/components/spi_flash/private_include
@@ -21,6 +23,7 @@ list(APPEND INCLUDE_DIRS
     ${esp_idf_dir}/components/soc/include
     ${esp_idf_dir}/components/esp_hw_support/include
     ${esp_idf_dir}/components/hal/${MCUBOOT_TARGET}/include
+    ${esp_idf_dir}/components/hal/${MCUBOOT_TARGET}/include/hal
     ${esp_idf_dir}/components/esp_hw_support/port/${MCUBOOT_TARGET}
     ${esp_idf_dir}/components/esp_hw_support/port/${MCUBOOT_TARGET}/private_include
     ${esp_idf_dir}/components/bootloader_support/include
@@ -30,8 +33,8 @@ list(APPEND INCLUDE_DIRS
     ${esp_idf_dir}/components/efuse/${MCUBOOT_TARGET}/include
     )
 set(hal_srcs
-    ${SRC_DIR}/bootloader_init.c
     ${SRC_DIR}/bootloader_wdt.c
+    ${SRC_DIR}/${MCUBOOT_TARGET}/bootloader_init.c
     ${esp_idf_dir}/components/hal/mpu_hal.c
     ${esp_idf_dir}/components/bootloader_support/src/bootloader_flash.c
     ${esp_idf_dir}/components/bootloader_support/src/bootloader_flash_config_${MCUBOOT_TARGET}.c
@@ -49,6 +52,12 @@ set(hal_srcs
     ${esp_idf_dir}/components/esp_rom/patches/esp_rom_uart.c
     ${esp_idf_dir}/components/${MCUBOOT_TARGET}/clk.c
     )
+
+if ("${MCUBOOT_TARGET}" STREQUAL "esp32s2")
+    list(APPEND hal_srcs
+        ${esp_idf_dir}/components/esp_hw_support/port/${MCUBOOT_TARGET}/regi2c_ctrl.c
+    )
+endif()
 
 set(CFLAGS
     "-nostdlib"
@@ -97,6 +106,7 @@ add_library(hal STATIC ${hal_srcs} ${INCLUDE_DIRS})
 set_source_files_properties(
     ${esp_idf_dir}/components/bootloader_support/src/bootloader_flash.c
     ${esp_idf_dir}/components/esp_hw_support/port/${MCUBOOT_TARGET}/rtc_clk_init.c
+    ${esp_idf_dir}/components/esp_hw_support/port/${MCUBOOT_TARGET}/rtc_init.c
     ${esp_idf_dir}/components/esp_hw_support/port/${MCUBOOT_TARGET}/rtc_clk.c
     ${esp_idf_dir}/components/esp_hw_support/port/${MCUBOOT_TARGET}/rtc_time.c
     PROPERTIES COMPILE_FLAGS
@@ -114,13 +124,23 @@ target_compile_options(
     ${CFLAGS}
     )
 
-target_link_libraries(
-    hal
-    PUBLIC
-    ${LDFLAGS}
+set(LINKER_SCRIPTS
     -T${esp_idf_dir}/components/esp_rom/${MCUBOOT_TARGET}/ld/${MCUBOOT_TARGET}.rom.ld
     -T${esp_idf_dir}/components/esp_rom/${MCUBOOT_TARGET}/ld/${MCUBOOT_TARGET}.rom.libgcc.ld
     -T${esp_idf_dir}/components/esp_rom/${MCUBOOT_TARGET}/ld/${MCUBOOT_TARGET}.rom.api.ld
     -T${esp_idf_dir}/components/${MCUBOOT_TARGET}/ld/${MCUBOOT_TARGET}.peripherals.ld
     -T${esp_idf_dir}/components/esp_rom/${MCUBOOT_TARGET}/ld/${MCUBOOT_TARGET}.rom.newlib-funcs.ld
+    )
+
+if ("${MCUBOOT_TARGET}" STREQUAL "esp32s2")
+    list(APPEND LINKER_SCRIPTS
+        -T${esp_idf_dir}/components/esp_rom/${MCUBOOT_TARGET}/ld/${MCUBOOT_TARGET}.rom.spiflash.ld
+    )
+endif()
+
+target_link_libraries(
+    hal
+    PUBLIC
+    ${LDFLAGS}
+    ${LINKER_SCRIPTS}
     )

--- a/boot/espressif/hal/include/esp32s2/sdkconfig.h
+++ b/boot/espressif/hal/include/esp32s2/sdkconfig.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define BOOTLOADER_BUILD 1
+#define CONFIG_IDF_TARGET_ESP32S2 1
+#define CONFIG_SPI_FLASH_ROM_DRIVER_PATCH 1
+#define CONFIG_ESP32S2_XTAL_FREQ 40
+#define CONFIG_MCUBOOT 1
+#define NDEBUG 1
+#define CONFIG_BOOTLOADER_WDT_TIME_MS 9000
+#define CONFIG_ESP_CONSOLE_UART_BAUDRATE 115200
+#define CONFIG_BOOTLOADER_OFFSET_IN_FLASH 0x1000

--- a/boot/espressif/hal/include/mcuboot_config/mcuboot_logging.h
+++ b/boot/espressif/hal/include/mcuboot_config/mcuboot_logging.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "sdkconfig.h"
+
 extern int ets_printf(const char *fmt, ...);
 
 #define MCUBOOT_LOG_LEVEL_OFF      0
@@ -14,8 +16,10 @@ extern int ets_printf(const char *fmt, ...);
 #define MCUBOOT_LOG_LEVEL_INFO     3
 #define MCUBOOT_LOG_LEVEL_DEBUG    4
 
-#if (MCUBOOT_TARGET == esp32)
+#if CONFIG_IDF_TARGET_ESP32
 #define TARGET "[esp32]"
+#elif CONFIG_IDF_TARGET_ESP32S2
+#define TARGET "[esp32s2]"
 #else
 #error "Selected target not supported."
 #endif

--- a/boot/espressif/hal/src/esp32/bootloader_init.c
+++ b/boot/espressif/hal/src/esp32/bootloader_init.c
@@ -23,10 +23,10 @@
 
 #include "hal/wdt_hal.h"
 
-#include "esp32/rom/cache.h"
-#include "esp32/rom/ets_sys.h"
-#include "esp32/rom/spi_flash.h"
-#include "esp32/rom/uart.h"
+#include "rom/cache.h"
+#include "rom/ets_sys.h"
+#include "rom/spi_flash.h"
+#include "rom/uart.h"
 
 esp_image_header_t WORD_ALIGNED_ATTR bootloader_image_hdr;
 

--- a/boot/espressif/hal/src/esp32s2/bootloader_init.c
+++ b/boot/espressif/hal/src/esp32s2/bootloader_init.c
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include "sdkconfig.h"
+#include "esp_attr.h"
+#include "esp_image_format.h"
+
+#include "esp_rom_efuse.h"
+#include "esp_rom_gpio.h"
+
+#include "bootloader_init.h"
+#include "bootloader_mem.h"
+#include "bootloader_clock.h"
+#include "bootloader_flash_config.h"
+#include "bootloader_flash.h"
+#include "bootloader_flash_priv.h"
+
+#include "soc/dport_reg.h"
+#include "soc/efuse_reg.h"
+#include "soc/rtc.h"
+#include "soc/extmem_reg.h"
+#include "soc/io_mux_reg.h"
+
+#include "hal/wdt_hal.h"
+
+#include "rom/cache.h"
+#include "rom/ets_sys.h"
+#include "rom/spi_flash.h"
+#include "rom/uart.h"
+
+esp_image_header_t WORD_ALIGNED_ATTR bootloader_image_hdr;
+
+void bootloader_clear_bss_section(void)
+{
+    memset(&_bss_start, 0, (&_bss_end - &_bss_start) * sizeof(_bss_start));
+}
+
+static void bootloader_reset_mmu(void)
+{
+    Cache_Suspend_ICache();
+    Cache_Invalidate_ICache_All();
+    Cache_MMU_Init();
+
+    /* normal ROM boot exits with DROM0 cache unmasked,
+    but serial bootloader exits with it masked. */
+    REG_CLR_BIT(EXTMEM_PRO_ICACHE_CTRL1_REG, EXTMEM_PRO_ICACHE_MASK_DROM0);
+}
+
+esp_err_t bootloader_read_bootloader_header(void)
+{
+    if (bootloader_flash_read(ESP_BOOTLOADER_OFFSET, &bootloader_image_hdr, sizeof(esp_image_header_t), true) != ESP_OK) {
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+static void update_flash_config(const esp_image_header_t *bootloader_hdr)
+{
+    uint32_t size;
+    switch (bootloader_hdr->spi_size) {
+    case ESP_IMAGE_FLASH_SIZE_1MB:
+        size = 1;
+        break;
+    case ESP_IMAGE_FLASH_SIZE_2MB:
+        size = 2;
+        break;
+    case ESP_IMAGE_FLASH_SIZE_4MB:
+        size = 4;
+        break;
+    case ESP_IMAGE_FLASH_SIZE_8MB:
+        size = 8;
+        break;
+    case ESP_IMAGE_FLASH_SIZE_16MB:
+        size = 16;
+        break;
+    default:
+        size = 2;
+    }
+    uint32_t autoload = Cache_Suspend_ICache();
+    // Set flash chip size
+    esp_rom_spiflash_config_param(g_rom_flashchip.device_id, size * 0x100000, 0x10000, 0x1000, 0x100, 0xffff);
+    Cache_Resume_ICache(autoload);
+}
+
+void IRAM_ATTR bootloader_configure_spi_pins(int drv)
+{
+    const uint32_t spiconfig = esp_rom_efuse_get_flash_gpio_info();
+    uint8_t wp_pin = esp_rom_efuse_get_flash_wp_gpio();
+    uint8_t clk_gpio_num = SPI_CLK_GPIO_NUM;
+    uint8_t q_gpio_num   = SPI_Q_GPIO_NUM;
+    uint8_t d_gpio_num   = SPI_D_GPIO_NUM;
+    uint8_t cs0_gpio_num = SPI_CS0_GPIO_NUM;
+    uint8_t hd_gpio_num  = SPI_HD_GPIO_NUM;
+    uint8_t wp_gpio_num  = SPI_WP_GPIO_NUM;
+    if (spiconfig != 0) {
+        clk_gpio_num = spiconfig         & 0x3f;
+        q_gpio_num = (spiconfig >> 6)    & 0x3f;
+        d_gpio_num = (spiconfig >> 12)   & 0x3f;
+        cs0_gpio_num = (spiconfig >> 18) & 0x3f;
+        hd_gpio_num = (spiconfig >> 24)  & 0x3f;
+        wp_gpio_num = wp_pin;
+    }
+    esp_rom_gpio_pad_set_drv(clk_gpio_num, drv);
+    esp_rom_gpio_pad_set_drv(q_gpio_num,   drv);
+    esp_rom_gpio_pad_set_drv(d_gpio_num,   drv);
+    esp_rom_gpio_pad_set_drv(cs0_gpio_num, drv);
+    if (hd_gpio_num <= MAX_PAD_GPIO_NUM) {
+        esp_rom_gpio_pad_set_drv(hd_gpio_num, drv);
+    }
+    if (wp_gpio_num <= MAX_PAD_GPIO_NUM) {
+        esp_rom_gpio_pad_set_drv(wp_gpio_num, drv);
+    }
+}
+
+static void IRAM_ATTR bootloader_init_flash_configure(void)
+{
+    bootloader_flash_dummy_config(&bootloader_image_hdr);
+    bootloader_flash_cs_timing_config();
+}
+
+static esp_err_t bootloader_init_spi_flash(void)
+{
+    bootloader_init_flash_configure();
+    esp_rom_spiflash_unlock();
+
+    update_flash_config(&bootloader_image_hdr);
+    return ESP_OK;
+}
+
+void bootloader_config_wdt(void)
+{
+    wdt_hal_context_t rtc_wdt_ctx = {.inst = WDT_RWDT, .rwdt_dev = &RTCCNTL};
+    wdt_hal_write_protect_disable(&rtc_wdt_ctx);
+    wdt_hal_set_flashboot_en(&rtc_wdt_ctx, false);
+    wdt_hal_write_protect_enable(&rtc_wdt_ctx);
+
+#ifdef CONFIG_ESP_MCUBOOT_WDT_ENABLE
+    wdt_hal_init(&rtc_wdt_ctx, WDT_RWDT, 0, false);
+    uint32_t stage_timeout_ticks = (uint32_t)((uint64_t)CONFIG_BOOTLOADER_WDT_TIME_MS * rtc_clk_slow_freq_get_hz() / 1000);
+    wdt_hal_write_protect_disable(&rtc_wdt_ctx);
+    wdt_hal_config_stage(&rtc_wdt_ctx, WDT_STAGE0, stage_timeout_ticks, WDT_STAGE_ACTION_RESET_RTC);
+    wdt_hal_enable(&rtc_wdt_ctx);
+    wdt_hal_write_protect_enable(&rtc_wdt_ctx);
+#endif
+
+    wdt_hal_context_t wdt_ctx = {.inst = WDT_MWDT0, .mwdt_dev = &TIMERG0};
+    wdt_hal_write_protect_disable(&wdt_ctx);
+    wdt_hal_set_flashboot_en(&wdt_ctx, false);
+    wdt_hal_write_protect_enable(&wdt_ctx);
+}
+
+static void bootloader_init_uart_console(void)
+{
+    const int uart_num = 0;
+
+    uartAttach(NULL);
+    ets_install_uart_printf();
+    uart_tx_wait_idle(0);
+
+    const int uart_baud = CONFIG_ESP_CONSOLE_UART_BAUDRATE;
+    uart_div_modify(uart_num, (rtc_clk_apb_freq_get() << 4) / uart_baud);
+}
+
+static void bootloader_super_wdt_auto_feed(void)
+{
+    REG_SET_BIT(RTC_CNTL_SWD_CONF_REG, RTC_CNTL_SWD_AUTO_FEED_EN);
+}
+
+esp_err_t bootloader_init(void)
+{
+    esp_err_t ret = ESP_OK;
+    bootloader_super_wdt_auto_feed();
+
+    bootloader_init_mem();
+
+    /* check that static RAM is after the stack */
+#ifndef NDEBUG
+    {
+        assert(&_bss_start <= &_bss_end);
+        assert(&_data_start <= &_data_end);
+    }
+#endif
+    /* clear bss section */
+    bootloader_clear_bss_section();
+    /* reset MMU */
+    bootloader_reset_mmu();
+    /* config clock */
+    bootloader_clock_configure();
+    /* initialize uart console, from now on, we can use ets_printf */
+    bootloader_init_uart_console();
+    /* read bootloader header */
+    if ((ret = bootloader_read_bootloader_header()) != ESP_OK) {
+        goto err;
+    }
+    /* initialize spi flash */
+    if ((ret = bootloader_init_spi_flash()) != ESP_OK) {
+        goto err;
+    }
+    /* config WDT */
+    bootloader_config_wdt();
+err:
+    return ret;
+}

--- a/boot/espressif/port/esp32s2/ld/bootloader.ld
+++ b/boot/espressif/port/esp32s2/ld/bootloader.ld
@@ -1,0 +1,141 @@
+/*
+ * Linker file used to link the bootloader.
+ */
+ 
+MEMORY
+{
+  iram_seg (RWX) :    org = 0x40048000, len = 0x8000
+  iram_loader_seg (RWX) : org = 0x40050000, len = 0x3000
+  dram_seg (RW) :     org = 0x3FFE6000, len = 0x8000
+}
+
+/*  Default entry point:  */
+ENTRY(main);
+
+
+SECTIONS
+{
+
+  .iram_loader.text :
+  {
+    . = ALIGN (16);
+    _loader_text_start = ABSOLUTE(.);
+    *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+    *(.iram1 .iram1.*) /* catch stray IRAM_ATTR */
+    *libhal.a:bootloader_flash.*(.literal .text .literal.* .text.*)
+    *libhal.a:bootloader_flash_config_esp32s2.*(.literal .text .literal.* .text.*)
+    *esp_mcuboot.*(.literal .text .literal.* .text.*)
+    *esp_loader.*(.literal .text .literal.* .text.*)
+    *(.fini.literal)
+    *(.fini)
+    *(.gnu.version)
+    _loader_text_end = ABSOLUTE(.);
+  } > iram_loader_seg
+
+  .iram.text :
+  {
+    . = ALIGN (16);
+    *(.entry.text)
+    *(.init.literal)
+    *(.init)
+  } > iram_seg
+
+
+  /* Shared RAM */
+  .dram0.bss (NOLOAD) :
+  {
+    . = ALIGN (8);
+    _dram_start = ABSOLUTE(.);
+    _bss_start = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(.bss.*)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN (8);
+    _bss_end = ABSOLUTE(.);
+  } >dram_seg
+
+  .dram0.data :
+  {
+    _data_start = ABSOLUTE(.);
+    *(.data)
+    *(.data.*)
+    *(.gnu.linkonce.d.*)
+    *(.data1)
+    *(.sdata)
+    *(.sdata.*)
+    *(.gnu.linkonce.s.*)
+    *(.sdata2)
+    *(.sdata2.*)
+    *(.gnu.linkonce.s2.*)
+    *(.jcr)
+    _data_end = ABSOLUTE(.);
+  } >dram_seg
+
+  .dram0.rodata :
+  {
+    _rodata_start = ABSOLUTE(.);
+    *(.rodata)
+    *(.rodata.*)
+    *(.gnu.linkonce.r.*)
+    *(.rodata1)
+    __XT_EXCEPTION_TABLE_ = ABSOLUTE(.);
+    *(.xt_except_table)
+    *(.gcc_except_table)
+    *(.gnu.linkonce.e.*)
+    *(.gnu.version_r)
+    *(.eh_frame)
+    . = (. + 3) & ~ 3;
+    /*  C++ constructor and destructor tables, properly ordered:  */
+    __init_array_start = ABSOLUTE(.);
+    KEEP (*crtbegin.*(.ctors))
+    KEEP (*(EXCLUDE_FILE (*crtend.*) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    __init_array_end = ABSOLUTE(.);
+    KEEP (*crtbegin.*(.dtors))
+    KEEP (*(EXCLUDE_FILE (*crtend.*) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    /*  C++ exception handlers table:  */
+    __XT_EXCEPTION_DESCS_ = ABSOLUTE(.);
+    *(.xt_except_desc)
+    *(.gnu.linkonce.h.*)
+    __XT_EXCEPTION_DESCS_END__ = ABSOLUTE(.);
+    *(.xt_except_desc_end)
+    *(.dynamic)
+    *(.gnu.version_d)
+    _rodata_end = ABSOLUTE(.);
+    /* Literals are also RO data. */
+    _lit4_start = ABSOLUTE(.);
+    *(*.lit4)
+    *(.lit4.*)
+    *(.gnu.linkonce.lit4.*)
+    _lit4_end = ABSOLUTE(.);
+    . = ALIGN(4);
+    _dram_end = ABSOLUTE(.);
+  } >dram_seg
+
+  .iram.text :
+  {
+    _stext = .;
+    _text_start = ABSOLUTE(.);
+    *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+    *(.iram .iram.*) /* catch stray IRAM_ATTR */
+    *(.fini.literal)
+    *(.fini)
+    *(.gnu.version)
+    _text_end = ABSOLUTE(.);
+    _etext = .;
+  } > iram_seg
+
+}

--- a/boot/espressif/port/esp_loader.c
+++ b/boot/espressif/port/esp_loader.c
@@ -11,14 +11,14 @@
 #include <bootloader_flash.h>
 #include <bootloader_flash_priv.h>
 
-#include "esp32/rom/cache.h"
-#include "esp32/rom/efuse.h"
-#include "esp32/rom/ets_sys.h"
-#include "esp32/rom/spi_flash.h"
-#include "esp32/rom/crc.h"
-#include "esp32/rom/rtc.h"
-#include "esp32/rom/gpio.h"
-#include "esp32/rom/uart.h"
+#include "rom/cache.h"
+#include "rom/efuse.h"
+#include "rom/ets_sys.h"
+#include "rom/spi_flash.h"
+#include "rom/crc.h"
+#include "rom/rtc.h"
+#include "rom/gpio.h"
+#include "rom/uart.h"
 
 #include <esp_loader.h>
 #include <bootutil/fault_injection_hardening.h>

--- a/boot/espressif/port/esp_mcuboot.c
+++ b/boot/espressif/port/esp_mcuboot.c
@@ -231,12 +231,12 @@ int flash_area_id_from_multi_image_slot(int image_index, int slot)
 
 int flash_area_id_from_image_slot(int slot)
 {
-  return flash_area_id_from_multi_image_slot(0, slot);
+    return flash_area_id_from_multi_image_slot(0, slot);
 }
 
 int flash_area_to_sectors(int idx, int *cnt, struct flash_area *fa)
 {
-	return -1;
+    return -1;
 }
 
 void mcuboot_assert_handler(const char *file, int line, const char *func)

--- a/boot/espressif/tools/toolchain-esp32s2.cmake
+++ b/boot/espressif/tools/toolchain-esp32s2.cmake
@@ -1,0 +1,10 @@
+set(CMAKE_SYSTEM_NAME Generic)
+
+set(CMAKE_C_COMPILER xtensa-esp32s2-elf-gcc)
+set(CMAKE_CXX_COMPILER xtensa-esp32s2-elf-g++)
+set(CMAKE_ASM_COMPILER xtensa-esp32s2-elf-gcc)
+
+set(CMAKE_C_FLAGS "-mlongcalls" CACHE STRING "C Compiler Base Flags")
+set(CMAKE_CXX_FLAGS "-mlongcalls" CACHE STRING "C++ Compiler Base Flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--gc-sections" CACHE STRING "Linker Base Flags")


### PR DESCRIPTION
This PR adds basic support for ESP32-S2 SoC from Espressif Systems.

**Notes:** 
- Both Zephyr and NuttX RTOSes for ESP32-S2 would be able to boot in the future, however the changes in their respective repositories still are WIP and aren't upstream yet. 

## Setting up the environment
- `git submodule update --init --recursive` (Update ESP-IDF submodule)
- `unset IDF_PATH` (Clear IDF_PATH variable if it is already set)
- `./boot/espressif/hal/esp-idf/install.sh` (Installs toolchain required to build application for ESP32)
- `. ./boot/espressif/hal/esp-idf/export.sh` (Adds required directories to PATH)

## Steps to build and flash MCUboot port for ESP32-S2

- `cd boot/espressif`
- `cmake -DCMAKE_TOOLCHAIN_FILE=tools/toolchain-esp32s2.cmake -DMCUBOOT_TARGET=esp32s2 -DIDF_PATH=$IDF_PATH -B build -GNinja`
- `cmake --build build/`
- `export ESPPORT=your-esp32-serial-port`
- `$IDF_PATH/components/esptool_py/esptool/esptool.py --chip esp32s2 elf2image --flash_mode dio --flash_freq 40m -o build/mcuboot_esp32s2.bin build/mcuboot_esp32s2.elf`
- `$IDF_PATH/components/esptool_py/esptool/esptool.py -p $ESPPORT -b 2000000 --before default_reset --after hard_reset --chip esp32s2 write_flash --flash_mode dio --flash_size detect --flash_freq 40m 0x1000 build/mcuboot_esp32s2.bin`

