### PR TITLE
boot: Fix IS_ENCRYPTED macro definition

### DIFF
--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -149,8 +149,8 @@ struct image_tlv {
     uint16_t it_len;    /* Data length (not including TLV header). */
 };
 
-#define IS_ENCRYPTED(hdr) (((hdr)->ih_flags && IMAGE_F_ENCRYPTED_AES128) \
-                        || ((hdr)->ih_flags && IMAGE_F_ENCRYPTED_AES256))
+#define IS_ENCRYPTED(hdr) (((hdr)->ih_flags & IMAGE_F_ENCRYPTED_AES128) \
+                        || ((hdr)->ih_flags & IMAGE_F_ENCRYPTED_AES256))
 #define MUST_DECRYPT(fap, idx, hdr) \
     (flash_area_get_id(fap) == FLASH_AREA_IMAGE_SECONDARY(idx) && IS_ENCRYPTED(hdr))
 


### PR DESCRIPTION
The previous definition did not work as setting any type of flag would
make IS_ENCRYPTED true.

Signed-off-by: Salome Thirot <salome.thirot@arm.com>