### PR TITLE
zephyr/Kconfig: fix deadlock on cryptolib selectors

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -30,7 +30,6 @@ config BOOT_USE_TINYCRYPT
 	# When building for ECDSA, we use our own copy of mbedTLS, so the
 	# Zephyr one must not be enabled or the MBEDTLS_CONFIG_FILE macros
 	# will collide.
-	depends on ! MBEDTLS
 	help
 	  Use TinyCrypt for crypto primitives.
 
@@ -41,7 +40,6 @@ config BOOT_USE_CC310
 	# When building for ECDSA, we use our own copy of mbedTLS, so the
 	# Zephyr one must not be enabled or the MBEDTLS_CONFIG_FILE macros
 	# will collide.
-	depends on ! MBEDTLS
 	help
 	  Use cc310 for crypto primitives.
 

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -34,6 +34,14 @@
 #define MCUBOOT_SIGN_ED25519
 #endif
 
+#if defined(CONFIG_BOOT_USE_TINYCRYPT)
+#  if defined(CONFIG_MBEDTLS) || defined(CONFIG_BOOT_USE_CC310)
+#     error "One crypto library implementation allowed at a time."
+#  endif
+#elif defined(CONFIG_MBEDTLS) && defined(CONFIG_BOOT_USE_CC310)
+#     error "One crypto library implementation allowed at a time."
+#endif
+
 #ifdef CONFIG_BOOT_USE_MBEDTLS
 #define MCUBOOT_USE_MBED_TLS
 #elif defined(CONFIG_BOOT_USE_TINYCRYPT)


### PR DESCRIPTION
If user generate project and the will try to switch signature type
then it is very likely that MBETLS will be enabled simultaneously when
tinycrypt has to be force-selected, which causes kconfig warning on
impossible configuration. Such configuration won't be possible to be
fixed using menuconfig etc.

This patch moves dependency check on !MBEDTLS from kconfig to preprocessor
which makes manual fixing using menuconfig possible.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>