### PR TITLE
zephyr: do not set defaults for LOG_IMMEDIATE Kconfig

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -663,10 +663,6 @@ config MULTITHREADING
 	default n if SOC_FAMILY_NRF
 	default y
 
-config LOG_IMMEDIATE
-	default n if MULTITHREADING
-	default y
-
 config LOG_PROCESS_THREAD
 	default n # mcuboot has its own log processing thread
 


### PR DESCRIPTION
LOG_IMMEDIATE Kconfig option has been repurposed and is now a Zephyr's internal, non-visible symbol that should not be modified by the end user.

The option's default value has been added in the past to configure synchronous logging if multi-threading is disabled. At present it prevents the user from configuring synchronous logging mode when multi-threading is enabled.

Remove the defaults altogether as the logging mode used by MCUBoot is defined in prj.conf.