### PR TITLE
bootutil: Only include <os/malloc.h> if it going to be used

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -35,7 +35,6 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
-#include <os/os_malloc.h>
 #include "bootutil/bootutil.h"
 #include "bootutil/image.h"
 #include "bootutil_priv.h"
@@ -48,6 +47,10 @@
 
 #ifdef MCUBOOT_ENC_IMAGES
 #include "bootutil/enc_key.h"
+#endif
+
+#if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)
+#include <os/os_malloc.h>
 #endif
 
 #include "mcuboot_config/mcuboot_config.h"


### PR DESCRIPTION
When no dynamic memory is used, there is no need for include "os/malloc.h",
and do so will force the user to create an empty "os/malloc.h" file.

Signed-off-by: Carlos Falgueras García <carlos.falgueras@wslw.es>