### PR TITLE
boot: zephyr: Configure mimxrt685_evk board

### DIFF
--- a/boot/zephyr/boards/mimxrt685_evk_cm33.conf
+++ b/boot/zephyr/boards/mimxrt685_evk_cm33.conf
@@ -1,0 +1,4 @@
+# Copyright 2021 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BOOT_MAX_IMG_SECTORS=8192


### PR DESCRIPTION
The mimxrt685_evk board has large slots so we need to increase
CONFIG_BOOT_MAX_IMG_SECTORS from the default.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>