### PR TITLE
boot: zephyr: Do not use `irq_lock()` if using arm cleanup

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -183,7 +183,6 @@ static void do_boot(struct boot_rsp *rsp)
                                      rsp->br_image_off +
                                      rsp->br_hdr->ih_hdr_size);
 
-    irq_lock();
 #ifdef CONFIG_SYS_CLOCK_EXISTS
     sys_clock_disable();
 #endif
@@ -202,6 +201,8 @@ static void do_boot(struct boot_rsp *rsp)
 
 #if CONFIG_CPU_HAS_ARM_MPU || CONFIG_CPU_HAS_NXP_MPU
     z_arm_clear_arm_mpu_config();
+#else
+    irq_lock();
 #endif
 
 #if defined(CONFIG_BUILTIN_STACK_GUARD) && \


### PR DESCRIPTION
`irq_lock()` sets `BASEPRI_MAX` aka. the `BASEPRI` mask to whatever
zephyr has configured it to be by the value of `_EXC_IRQ_DEFAULT_PRIO`.

However by calling arm_cleanup() we also do the call to
`__disable_irq()` setting the PRIMASK to 1. Meaning the only exceptions
we can recive is fault exceptions. Masking out more exceptions does not
really make sense.

The rational behind this change is that sometimes applications booted by MCUBoot will not expect the `BASEPRI`
to be set to something other than 0(No effect). Meaning if they depend on
using some exception which now is masked out by `BASEPRI` they will
fail. 

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>