### PR TITLE
boot: Fix log reporting magic from incorrect header

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -2024,7 +2024,7 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
          */
         if (BOOT_IMG(state, BOOT_PRIMARY_SLOT).hdr.ih_magic != IMAGE_MAGIC) {
             BOOT_LOG_ERR("bad image magic 0x%lx; Image=%u", (unsigned long)
-                         &boot_img_hdr(state,BOOT_PRIMARY_SLOT)->ih_magic,
+                         BOOT_IMG(state, BOOT_PRIMARY_SLOT).hdr.ih_magic,
                          BOOT_CURR_IMG(state));
             rc = BOOT_EBADIMAGE;
             goto out;


### PR DESCRIPTION
Magic for different header was reported than the one that had failed
the check.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>