### PR TITLE
Prevent compilation of Espressif files on Mbed build

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -2,6 +2,7 @@ boot/boot_serial/*
 boot/mynewt/*
 boot/zephyr/*
 boot/cypress/*
+boot/espressif/*
 ci/*
 docs/*
 ptest/*


### PR DESCRIPTION
The old mbed CLI 1 tool, currently used to compile the MCUboot port for Mbed™ OS, compiles all files unless otherwise specified in `.mbedignore`.   The espressif directory in the boot folder was added to the ignore file to prevent failed builds. 

@pan-