### PR TITLE
zephyr: Add option for enabling the storage erase command

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -92,8 +92,13 @@ zephyr_library_sources(
   flash_map_extended.c
   os.c
   keys.c
-  boot_serial_extensions.c
   )
+
+if(DEFINED CONFIG_ENABLE_MGMT_PERUSER)
+  zephyr_library_sources(
+    boot_serial_extensions.c
+    )
+endif()
 
 if(NOT DEFINED CONFIG_FLASH_PAGE_LAYOUT)
   zephyr_library_sources(

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -578,6 +578,14 @@ menuconfig ENABLE_MGMT_PERUSER
 	  function is required to process these commands.
 
 if ENABLE_MGMT_PERUSER
+config BOOT_MGMT_CUSTOM_STORAGE_ERASE
+	bool "Enable storage erase command"
+	help
+	  The option enables mcumgr command that allows to erase storage
+	  partition.
+	  Note that the storage partition needs to be defined, in DTS, otherwise
+	  enabling the option will cause a compilation to fail.
+
 config BOOT_MGMT_CUSTOM_IMG_LIST
 	bool "Enable custom image list command"
 	help

--- a/boot/zephyr/boot_serial_extensions.c
+++ b/boot/zephyr/boot_serial_extensions.c
@@ -19,6 +19,7 @@
 
 MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
 
+#ifdef CONFIG_BOOT_MGMT_CUSTOM_STORAGE_ERASE
 static int bs_custom_storage_erase(cbor_state_t *cs)
 {
     int rc;
@@ -49,6 +50,7 @@ static int bs_custom_storage_erase(cbor_state_t *cs)
 
     return rc;
 }
+#endif
 
 #ifdef MCUBOOT_MGMT_CUSTOM_IMG_LIST
 static int custom_img_status(int image_index, uint32_t slot,char *buffer,
@@ -127,9 +129,11 @@ int bs_peruser_system_specific(const struct nmgr_hdr *hdr, const char *buffer,
 
     if (hdr->nh_group == ZEPHYR_MGMT_GRP_BASE) {
         if (hdr->nh_op == NMGR_OP_WRITE) {
+#ifdef CONFIG_BOOT_MGMT_CUSTOM_STORAGE_ERASE
             if (hdr->nh_id == ZEPHYR_MGMT_GRP_BASIC_CMD_ERASE_STORAGE) {
                 mgmt_rc = bs_custom_storage_erase(cs);
             }
+#endif
         } else if (hdr->nh_op == NMGR_OP_READ) {
 #ifdef MCUBOOT_MGMT_CUSTOM_IMG_LIST
             if (hdr->nh_id == ZEPHYR_MGMT_GRP_BASIC_CMD_IMAGE_LIST) {


### PR DESCRIPTION
**UPDATE 2021-08-17**
Made the extensions file conditional, via another commit added here.

The commit adds Kconfig option that enables the storage erase mgmt
command.
Addition of the Kconfig option fixes the problem where Zephyr spcyfic
mgmt commands support fails to compile when board does not define
a storage partition.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

fixes #1100