### PR TITLE
boot/espressif: Clone ESP-IDF only when required

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,4 @@
 	path = boot/espressif/hal/esp-idf
 	url = https://github.com/espressif/esp-idf.git
 	branch = release/v4.3
+	update = none


### PR DESCRIPTION
Added `update = none` in .gitmodules to avoid unnecessary clone of ESP-IDF submodule.

The submodule will be cloned only when `--checkout` flag is passed when updating submodules.

This change will avoid maintaining two copies of IDF in Zephyr environment.