### PR TITLE
boot/nuttx: Enable crypto backend according to configuration from NuttX

### DIFF
--- a/boot/nuttx/include/mcuboot_config/mcuboot_config.h
+++ b/boot/nuttx/include/mcuboot_config/mcuboot_config.h
@@ -24,6 +24,8 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/config.h>
+
 #ifdef CONFIG_MCUBOOT_WATCHDOG
 #include "watchdog/watchdog.h"
 #endif
@@ -85,13 +87,13 @@
  * available.
  */
 
-/* Uncomment to use ARM's mbedTLS cryptographic primitives */
-
+#ifdef CONFIG_MCUBOOT_USE_MBED_TLS
 #define MCUBOOT_USE_MBED_TLS
+#endif
 
-/* Uncomment to use Tinycrypt's. */
-
-/* #define MCUBOOT_USE_TINYCRYPT */
+#ifdef CONFIG_MCUBOOT_USE_TINYCRYPT
+#define MCUBOOT_USE_TINYCRYPT
+#endif
 
 /* Always check the signature of the image in the primary slot before
  * booting, even if no upgrade was performed. This is recommended if the boot


### PR DESCRIPTION
This PR intends to enable the NuttX port to select between Mbed TLS and TinyCrypt as the cryptographic backends.

The selection is achieved by means of NuttX `make menuconfig` command.