### PR TITLE
boot/nuttx: Fix trivial compiler warnings emitted by NuttX port

### DIFF
--- a/boot/nuttx/include/sysflash/sysflash.h
+++ b/boot/nuttx/include/sysflash/sysflash.h
@@ -28,8 +28,12 @@
 #define SECONDARY_ID    1
 #define SCRATCH_ID      2
 
-#define FLASH_AREA_IMAGE_PRIMARY(x)    PRIMARY_ID
-#define FLASH_AREA_IMAGE_SECONDARY(x)  SECONDARY_ID
+#define FLASH_AREA_IMAGE_PRIMARY(x)    (((x) == 0) ?        \
+                                         PRIMARY_ID :       \
+                                         PRIMARY_ID)
+#define FLASH_AREA_IMAGE_SECONDARY(x)  (((x) == 0) ?        \
+                                         SECONDARY_ID :     \
+                                         SECONDARY_ID)
 #define FLASH_AREA_IMAGE_SCRATCH       SCRATCH_ID
 
 #endif /* __BOOT_NUTTX_INCLUDE_SYSFLASH_SYSFLASH_H */

--- a/boot/nuttx/main.c
+++ b/boot/nuttx/main.c
@@ -42,7 +42,7 @@
 
 static void do_boot(struct boot_rsp *rsp)
 {
-  struct flash_area *flash_area;
+  const struct flash_area *flash_area;
   struct boardioc_boot_info_s info;
   int area_id;
   int ret;
@@ -59,7 +59,7 @@ static void do_boot(struct boot_rsp *rsp)
 
   flash_area_close(flash_area);
 
-  if (boardctl(BOARDIOC_BOOT_IMAGE, &info) != OK)
+  if (boardctl(BOARDIOC_BOOT_IMAGE, (uintptr_t)&info) != OK)
     {
       fprintf(stderr, "Failed to load application image!\n");
       FIH_PANIC;


### PR DESCRIPTION
## Summary
This PR intends to provide minor fixes to the NuttX port to prevent compiler warnings.

## Impact
No functionality changes, should have no impact.