### PR TITLE
Ignore nuttx files for Mbed-OS builds

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -3,6 +3,7 @@ boot/mynewt/*
 boot/zephyr/*
 boot/cypress/*
 boot/espressif/*
+boot/nuttx/*
 ci/*
 docs/*
 ptest/*


### PR DESCRIPTION
This commit simply adds the new nuttx files to the list of directories for Mbed's legacy build tools to ignore.

Signed-off-by: George Beckstein <george.beckstein@gmail.com>