### PR TITLE
Fix unknown type name "size_t" error in "boot_record.h"

### DIFF
--- a/boot/bootutil/include/bootutil/boot_record.h
+++ b/boot/bootutil/include/bootutil/boot_record.h
@@ -18,6 +18,7 @@
 #define __BOOT_RECORD_H__
 
 #include <stdint.h>
+#include <stddef.h>
 #include "bootutil/image.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
This commit adds an include clause to "boot_record.h" to include the stddef.h header that contains the declaration of the "size_t" type.

Attempting to include "boot_record.h" in a build for Mbed-OS would throw an error complaining "size_t" was unknown, adding a note to inculde "stddef.h"

Signed-off-by: George Beckstein <george.beckstein@gmail.com>