### PR TITLE
boot/espressif: Remove toolchain libc linking

### DIFF
--- a/boot/espressif/CMakeLists.txt
+++ b/boot/espressif/CMakeLists.txt
@@ -131,8 +131,6 @@ set(LDFLAGS
     "-lm"
     "-lgcc"
     "-lgcov"
-    "-lstdc++"
-    "-lc"
     )
 
 add_subdirectory(hal)

--- a/boot/espressif/hal/CMakeLists.txt
+++ b/boot/espressif/hal/CMakeLists.txt
@@ -90,8 +90,6 @@ set(LDFLAGS
     "-lm"
     "-lgcc"
     "-lgcov"
-    "-lstdc++"
-    "-lc"
     )
 
 add_library(hal STATIC ${hal_srcs} ${INCLUDE_DIRS})


### PR DESCRIPTION
Fix unnecessary dependencies caused by toolchain's libc inclusion.

Signed-off-by: Almir Okato <almir.okato@espressif.com>