### PR TITLE
zephyr: Remove BOOT_SERIAL_UART dependency from ENABLE_MGMT_PERUSER

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -553,7 +553,6 @@ config BOOT_ERASE_PROGRESSIVELY
 
 menuconfig ENABLE_MGMT_PERUSER
 	bool "Enable system specific mcumgr commands"
-	depends on BOOT_SERIAL_UART
 	help
 	  The option enables processing of system specific mcumgr commands;
 	  system specific commands are within group MGMT_GROUP_ID_PERUSER (64)


### PR DESCRIPTION
The dependency, in Kconfig,  blocked usage of the ENABLE_MGMT_PERUSER
with other BOOT_SERIAL_ device options.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>