### PR TITLE
boot: zephyr: configure mimxrt1024_evk board

### DIFF
--- a/boot/zephyr/boards/mimxrt1024_evk.conf
+++ b/boot/zephyr/boards/mimxrt1024_evk.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2021 Prevas A/S
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BOOT_MAX_IMG_SECTORS=512


### PR DESCRIPTION
The mimxrt1024_evk board have a large slot so we need
to increase CONFIG_BOOT_MAX_IMG_SECTORS from the default.

Signed-off-by: Mikkel Jakobsen <mikkel.aunsbjerg@prevas.dk>