### PR TITLE
Fix bug causing long swap times in certain cases

### DIFF
--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -700,20 +700,20 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
            primary_slot_size += boot_img_sector_size(state,
                                                      BOOT_PRIMARY_SLOT,
                                                      last_sector_idx);
+            last_sector_idx++;
         }
         if ((secondary_slot_size < copy_size) ||
             (secondary_slot_size < primary_slot_size)) {
            secondary_slot_size += boot_img_sector_size(state,
                                                        BOOT_SECONDARY_SLOT,
                                                        last_idx_secondary_slot);
+            last_idx_secondary_slot++;
         }
         if (primary_slot_size >= copy_size &&
                 secondary_slot_size >= copy_size &&
                 primary_slot_size == secondary_slot_size) {
             break;
         }
-        last_sector_idx++;
-        last_idx_secondary_slot++;
     }
 
     swap_idx = 0;


### PR DESCRIPTION
When the secondary slot is stored in a flash with smaller sector size than
the primary slot, MCUboot would swap more sectors than necessary.
This is an attempt to fix that.

This PR is related to #983.

More details in this Slack thread: https://mcuboot.slack.com/archives/C6CB5BXGC/p1627994014013400
