### PR TITLE
zephyr: support the hook file by MCUBOOT_BOOTUTIL library

### DIFF
--- a/boot/bootutil/zephyr/CMakeLists.txt
+++ b/boot/bootutil/zephyr/CMakeLists.txt
@@ -16,6 +16,30 @@ zephyr_library_named(mcuboot_util)
 zephyr_library_sources(
   ../src/bootutil_public.c
     )
+
+if(CONFIG_BOOT_IMAGE_ACCESS_HOOKS)
+  if(NOT CONFIG_BOOT_IMAGE_ACCESS_HOOKS_FILE STREQUAL "")
+    if(IS_ABSOLUTE ${CONFIG_BOOT_IMAGE_ACCESS_HOOKS_FILE})
+      if(EXISTS ${CONFIG_BOOT_IMAGE_ACCESS_HOOKS_FILE})
+        set(HOOKS_FILE ${CONFIG_BOOT_IMAGE_ACCESS_HOOKS_FILE})
+      endif()
+    elseif((DEFINED CONF_DIR) AND
+           (EXISTS ${CONF_DIR}/${CONFIG_BOOT_IMAGE_ACCESS_HOOKS_FILE}))
+      set(HOOKS_FILE ${CONF_DIR}/${CONFIG_BOOT_IMAGE_ACCESS_HOOKS_FILE})
+    else(EXISTS ${APPLICATION_SOURCE_DIR}/${CONFIG_BOOT_IMAGE_ACCESS_HOOKS_FILE})
+      set(HOOKS_FILE ${APPLICATION_SOURCE_DIR}/${CONFIG_BOOT_IMAGE_ACCESS_HOOKS_FILE})
+    endif()
+  endif()
+
+  if(DEFINED HOOKS_FILE)
+      zephyr_library_sources(
+        ${HOOKS_FILE}
+      )
+  else()
+    message(STATUS "No hooks implementation file.")
+  endif()
+endif()
+
 zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
 target_link_libraries(MCUBOOT_BOOTUTIL INTERFACE zephyr_interface)
 endif()

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -302,27 +302,3 @@ zephyr_library_sources(
   ${BOOT_DIR}/zephyr/arm_cleanup.c
 )
 endif()
-
-if(CONFIG_BOOT_IMAGE_ACCESS_HOOKS)
-
-  if(IS_ABSOLUTE ${CONFIG_BOOT_IMAGE_ACCESS_HOOKS_FILE})
-    if(EXISTS ${CONFIG_BOOT_IMAGE_ACCESS_HOOKS_FILE})
-      set(HOOKS_FILE ${CONFIG_BOOT_IMAGE_ACCESS_HOOKS_FILE})
-    endif()
-  elseif((DEFINED CONF_DIR) AND
-  (EXISTS ${CONF_DIR}/${CONFIG_BOOT_IMAGE_ACCESS_HOOKS_FILE}))
-    set(HOOKS_FILE ${CONF_DIR}/${CONFIG_BOOT_SIGNATURE_KEY_FILE})
-  else(EXISTS ${BOOT_DIR}/zephyr/${CONFIG_BOOT_IMAGE_ACCESS_HOOKS_FILE})
-    set(HOOKS_FILE ${BOOT_DIR}/zephyr/${CONFIG_BOOT_IMAGE_ACCESS_HOOKS_FILE})
-  endif()
-
-
-  if(DEFINED HOOKS_FILE)
-    zephyr_library_sources(
-      ${HOOKS_FILE}
-    )
-  else()
-    message(WARNING "Can't access hooks implementation file.")
-  endif()
-
-endif()


### PR DESCRIPTION
This patch make possible MCUBOOT_BOOTUTIL to integrate the
hook file on their own. This is intended to support hook while
the library is just part of the application.
The hooks file for the MCUboot build is now included in the same manner.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>