### PR TITLE
boot/bootutil/loader: fix comparison using fih_eq() in hook service

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -767,7 +767,7 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
 #endif
     BOOT_HOOK_CALL_FIH(boot_image_check_hook, fih_int_encode(BOOT_HOOK_REGULAR),
                        fih_rc, BOOT_CURR_IMG(state), slot);
-    if (fih_eq(fih_rc, BOOT_HOOK_REGULAR))
+    if (fih_eq(fih_rc, fih_int_encode(BOOT_HOOK_REGULAR)))
     {
         FIH_CALL(boot_image_check, fih_rc, state, hdr, fap, bs);
     }


### PR DESCRIPTION
This commit fixes following issue:
One of parameters in comparison using fih_eq() was not of fih_int
type which caused build error when medium or higher FIH mode is enabled.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>

To trigger issue:
set MCUBOOT_FIH_PROFILE=MEDIUM  this should trigger the build failure
``` C
11:42:56  In file included from /home/buildslave/workspace/tf-m-build-config/mcuboot/boot/bootutil/include/bootutil/bootutil.h:33:0,
11:42:56                   from /home/buildslave/workspace/tf-m-build-config/mcuboot/boot/bootutil/src/loader.c:38:
11:42:56  /home/buildslave/workspace/tf-m-build-config/mcuboot/boot/bootutil/src/loader.c: In function 'boot_validate_slot':
11:42:56  /home/buildslave/workspace/tf-m-build-config/mcuboot/boot/bootutil/include/bootutil/bootutil_public.h:102:27: error: incompatible type for argument 2 of 'fih_eq'
11:42:56   #define BOOT_HOOK_REGULAR 1
11:42:56                             ^
11:42:56  /home/buildslave/workspace/tf-m-build-config/mcuboot/boot/bootutil/src/loader.c:770:24: note: in expansion of macro 'BOOT_HOOK_REGULAR'
11:42:56       if (fih_eq(fih_rc, BOOT_HOOK_REGULAR))
```