### PR TITLE
bootutil: loader: Fix image header check

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -568,7 +568,7 @@ boot_is_header_valid(const struct image_header *hdr, const struct flash_area *fa
         return false;
     }
 
-    if (size >= flash_area_get_size(fap)) {
+    if (size > flash_area_get_size(fap)) {
         return false;
     }
 


### PR DESCRIPTION
Change fixes check for declared image size.

Signed-off-by: Marek Pieta <Marek.Pieta@nordicsemi.no>