### PR TITLE
Add configuration parameter to enable internal MCUboot logging.

### DIFF
--- a/boot/mbed/mbed_lib.json
+++ b/boot/mbed/mbed_lib.json
@@ -64,6 +64,12 @@
             "accepted_values": [true, null],
             "value": null
         },
+        "enable-logging": {
+            "help": "Enables logging in MCUboot. Must also enable mbed-trace",
+            "macro_name": "MCUBOOT_HAVE_LOGGING",
+            "accepted_values": [true, null],
+            "value": null
+        },
         "log-level": {
             "help": "Verbosity of MCUboot logging.",
             "macro_name": "MCUBOOT_LOG_LEVEL",

--- a/boot/mbed/mcuboot_main.cpp
+++ b/boot/mbed/mcuboot_main.cpp
@@ -50,9 +50,11 @@ int main()
 {
     int rc;
 
+#ifdef MCUBOOT_HAVE_LOGGING
     mbed_trace_init();
 #if MCUBOOT_LOG_BOOTLOADER_ONLY
     mbed_trace_include_filters_set("MCUb,BL");
+#endif
 #endif
 
     tr_info("Starting MCUboot");


### PR DESCRIPTION
Prior to this commit, it was not possible for a user to enable `MCUBOOT_HAVE_LOGGING` through the existing Mbed-OS configuration parameters. This commit fixes this by adding an option: `mcuboot.enable-logging`. Now, logging that is performed by MCUboot's internal sources will be printed as well as logging that is part of the Mbed-OS port.

Signed-off-by: George Beckstein <george.beckstein@gmail.com>