### PR TITLE
Fix bug: Potential call to `BlockDevice::size` when uninitialized

### DIFF
--- a/boot/mbed/src/flash_map_backend.cpp
+++ b/boot/mbed/src/flash_map_backend.cpp
@@ -97,6 +97,9 @@ int flash_area_open(uint8_t id, const struct flash_area** fapp) {
     if (open_count[id] == 1) {
         MCUBOOT_LOG_DBG("initializing flash area %d...", id);
         result = bd->init();
+        if(result) {
+            return result;
+        }
     }
 
     fap->fa_size = (uint32_t) bd->size();

--- a/boot/mbed/src/flash_map_backend.cpp
+++ b/boot/mbed/src/flash_map_backend.cpp
@@ -91,15 +91,17 @@ int flash_area_open(uint8_t id, const struct flash_area** fapp) {
     fap->fa_device_id = 0; // not relevant
 
     mbed::BlockDevice* bd = flash_map_bd[id];
-    fap->fa_size = (uint32_t) bd->size();
 
+    int result = 0;
     /* Only initialize if this isn't a nested call to open the flash area */
     if (open_count[id] == 1) {
         MCUBOOT_LOG_DBG("initializing flash area %d...", id);
-        return bd->init();
-    } else {
-        return 0;
+        result = bd->init();
     }
+
+    fap->fa_size = (uint32_t) bd->size();
+
+    return result;
 }
 
 void flash_area_close(const struct flash_area* fap) {


### PR DESCRIPTION
This commit fixes a bug that can cause an uninitialized BlockDevice to be queried for its size. In some cases, this can return unexpected results (eg: 0).

The check for initializing the BlockDevice is now made before any operations are made on it.

@LDong-Arm @boraozgen 

Signed-off-by: George Beckstein <george.beckstein@gmail.com>
