### PR TITLE
boot_serial: Increase BOOT_SERIAL_OUT_MAX

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -64,7 +64,7 @@
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 #define BOOT_SERIAL_INPUT_MAX   512
-#define BOOT_SERIAL_OUT_MAX     128
+#define BOOT_SERIAL_OUT_MAX     (128 * MCUBOOT_IMAGE_NUMBER)
 
 #ifdef __ZEPHYR__
 /* base64 lib encodes data to null-terminated string */


### PR DESCRIPTION
Change increases BOOT_SERIAL_OUT_MAX. This is necessary to provide complete image list when multi-image DFU is enabled and four image slots are occupied.