### PR TITLE
ci: fix wget error downloading arm-gcc-embedded

### DIFF
--- a/ci/mynewt_install.sh
+++ b/ci/mynewt_install.sh
@@ -45,7 +45,7 @@ arm_toolchain_install() {
     mkdir -p $TOOLCHAIN_PATH
 
     if [ ! -s ${TOOLCHAIN_PATH}/$GCC_BASE/bin/arm-none-eabi-gcc ]; then
-      wget -O ${TOOLCHAIN_PATH}/${GCC_BASE}.tar.bz2 $GCC_URL
+      wget --no-check-certificate -O ${TOOLCHAIN_PATH}/${GCC_BASE}.tar.bz2 $GCC_URL
       [[ $? -ne 0 ]] && exit 1
 
       tar xfj ${TOOLCHAIN_PATH}/${GCC_BASE}.tar.bz2 -C $TOOLCHAIN_PATH


### PR DESCRIPTION
Disable certificate verification for developer.arm.com to avoid certificate issues when installing arm embedded tools to build Mynewt.