### PR TITLE
Revert "ci: fix wget error downloading arm-gcc-embedded"

### DIFF
--- a/ci/mynewt_install.sh
+++ b/ci/mynewt_install.sh
@@ -45,7 +45,7 @@ arm_toolchain_install() {
     mkdir -p $TOOLCHAIN_PATH
 
     if [ ! -s ${TOOLCHAIN_PATH}/$GCC_BASE/bin/arm-none-eabi-gcc ]; then
-      wget --no-check-certificate -O ${TOOLCHAIN_PATH}/${GCC_BASE}.tar.bz2 $GCC_URL
+      wget -O ${TOOLCHAIN_PATH}/${GCC_BASE}.tar.bz2 $GCC_URL
       [[ $? -ne 0 ]] && exit 1
 
       tar xfj ${TOOLCHAIN_PATH}/${GCC_BASE}.tar.bz2 -C $TOOLCHAIN_PATH


### PR DESCRIPTION
This reverts commit 34f68ed67c0d1b1172f500808f42966c7b7d724b.

Re-enable certificate checking when downloading the Arm toolchain.
Although, this is probably not all that great of a risk, the certificate
issue was transient, and was fixed shortly after it was noticed.

Signed-off-by: David Brown <david.brown@linaro.org>