### PR TITLE
zephyr: Check zephyr,uart-mcumgr as candidate for serial recovery

### DIFF
--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -30,10 +30,21 @@ choice BOOT_SERIAL_DEVICE
 config BOOT_SERIAL_UART
 	bool "UART"
 	# SERIAL and UART_INTERRUPT_DRIVEN already selected
+	help
+	  The serial device to use will be fist selected via chosen
+	  node "zephyr,uart-mcumgr", when such node does not exist
+	  the "zephyr,console" is used.  In case when
+	  the "zephyr,uart-mcumgr" points to the same device as
+	  the "zephyr,console" compilation error will be triggered.
 
 config BOOT_SERIAL_CDC_ACM
 	bool "CDC ACM"
 	select USB_DEVICE_STACK
+	help
+	  This setting will choose CDC ACM for serial recovery unless chosen
+	  "zephyr,uart-mcumgr" is present, in which case the chosen takes
+	  precedence and redirects serial recovery to uart pointed by
+	  the chosen, leaving console on CDC ACM.
 
 endchoice
 


### PR DESCRIPTION
The commit modifies selection of boot serial UART by first checking
the Zephyr chosen zephyr,uart-mcumgr and then reverting to the
zephyr,console, as a secondary candidate.
In case when both nodes are present and point to the same device,
error will be reported.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>