### PR TITLE
Include mcuboot_config.h from sign_key.h to fix MCUBOOT_HW_KEY option

### DIFF
--- a/boot/bootutil/include/bootutil/sign_key.h
+++ b/boot/bootutil/include/bootutil/sign_key.h
@@ -25,6 +25,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/* mcuboot_config.h is needed for MCUBOOT_HW_KEY to work */
+#include "mcuboot_config/mcuboot_config.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
`mcuboot_config.h` was not included from `sign_key.h`,
causing the wrong declaration of `bootutil_keys[]` to be used.

This caused:
```C
extern const struct bootutil_key bootutil_keys[];
```
to be used for the `MCUBOOT_HW_KEY` case, instead of:
```C
extern struct bootutil_key bootutil_keys[];
```

In the `MCUBOOT_HW_KEY` case, `bootutil_keys[]` cannot be const, because the pubkey loaded from the image TLV has to be stored in slot 0, after validating its SHA256 hash.
