### PR TITLE
boot: zephyr: allow custom handler for indication LED

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -490,6 +490,18 @@ config MCUBOOT_INDICATION_LED
 	  bootloader-led0 alias must be set in the device's .dts
 	  definitions for this to work.
 
+config MCUBOOT_INDICATION_LED_CUSTOM
+	bool "Custom indication LED handler"
+	depends on MCUBOOT_INDICATION_LED
+	default n
+	help
+		Activate custom indiciation LED-implementation.
+		The custom library needs to implement the functions
+			- mcuboot_led_init
+			- mcuboot_led_active
+			- mcuboot_led_error
+			- mcuboot_led_finish
+
 rsource "Kconfig.serial_recovery"
 
 config BOOT_INTR_VEC_RELOC

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -501,7 +501,7 @@ config MCUBOOT_INDICATION_LED_CUSTOM
 			- mcuboot_led_active
 			- mcuboot_led_error
 			- mcuboot_led_finish
-                         - mcuboot_led_deinit
+			- mcuboot_led_deinit
 
 rsource "Kconfig.serial_recovery"
 

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -501,6 +501,7 @@ config MCUBOOT_INDICATION_LED_CUSTOM
 			- mcuboot_led_active
 			- mcuboot_led_error
 			- mcuboot_led_finish
+                         - mcuboot_led_deinit
 
 rsource "Kconfig.serial_recovery"
 

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -120,6 +120,7 @@ BOOT_LOG_MODULE_REGISTER(mcuboot);
  * Define these functions in your custom library
  */
 extern void mcuboot_led_init(void);
+extern void mcuboot_led_deinit(void);
 extern void mcuboot_led_active(void);
 extern void mcuboot_led_error(void);
 extern void mcuboot_led_finish(void);
@@ -164,6 +165,10 @@ static void mcuboot_led_init(void)
   gpio_pin_configure(led, LED0_GPIO_PIN, LED0_GPIO_FLAGS);
   gpio_pin_set(led, LED0_GPIO_PIN, 0);
 
+}
+
+static void mcuboot_led_deinit(void)
+{
 }
 
 static inline void mcuboot_led_active(void)
@@ -580,6 +585,10 @@ void main(void)
 
 #ifdef CONFIG_MCUBOOT_INDICATION_LED
     mcuboot_led_finish();
+#endif
+
+#ifdef CONFIG_BOOT_INDICATION_LED
+    mcuboot_led_deinit();
 #endif
 
 #if defined(MCUBOOT_DIRECT_XIP)

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -504,15 +504,16 @@ void main(void)
     }
 #endif
 
+#ifdef CONFIG_MCUBOOT_INDICATION_LED
+        mcuboot_led_active();
+#endif
+
 #ifdef CONFIG_MCUBOOT_SERIAL
     if (detect_pin(CONFIG_BOOT_SERIAL_DETECT_PORT,
                    CONFIG_BOOT_SERIAL_DETECT_PIN,
                    CONFIG_BOOT_SERIAL_DETECT_PIN_VAL,
                    CONFIG_BOOT_SERIAL_DETECT_DELAY) &&
             !boot_skip_serial_recovery()) {
-#ifdef CONFIG_MCUBOOT_INDICATION_LED
-        mcuboot_led_active();
-#endif
 
         BOOT_LOG_INF("Enter the serial recovery mode");
         rc = boot_console_init();
@@ -527,9 +528,6 @@ void main(void)
                    CONFIG_BOOT_USB_DFU_DETECT_PIN,
                    CONFIG_BOOT_USB_DFU_DETECT_PIN_VAL,
                    CONFIG_BOOT_USB_DFU_DETECT_DELAY)) {
-#ifdef CONFIG_MCUBOOT_INDICATION_LED
-        mcuboot_led_active();
-#endif
         rc = usb_enable(NULL);
         if (rc) {
             BOOT_LOG_ERR("Cannot enable USB");

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -585,9 +585,6 @@ void main(void)
 
 #ifdef CONFIG_MCUBOOT_INDICATION_LED
     mcuboot_led_finish();
-#endif
-
-#ifdef CONFIG_BOOT_INDICATION_LED
     mcuboot_led_deinit();
 #endif
 

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -511,7 +511,7 @@ void main(void)
                    CONFIG_BOOT_SERIAL_DETECT_DELAY) &&
             !boot_skip_serial_recovery()) {
 #ifdef CONFIG_MCUBOOT_INDICATION_LED
-        mcuboot_led_active(led, LED0_GPIO_PIN, 1);
+        mcuboot_led_active();
 #endif
 
         BOOT_LOG_INF("Enter the serial recovery mode");
@@ -528,7 +528,7 @@ void main(void)
                    CONFIG_BOOT_USB_DFU_DETECT_PIN_VAL,
                    CONFIG_BOOT_USB_DFU_DETECT_DELAY)) {
 #ifdef CONFIG_MCUBOOT_INDICATION_LED
-        mcuboot_led_active(led, LED0_GPIO_PIN, 1);
+        mcuboot_led_active();
 #endif
         rc = usb_enable(NULL);
         if (rc) {


### PR DESCRIPTION
Allows to provide a custom implementation for the indication LED.
This can be used enable more in-depth information about the boot state,
or use custom handlers for LEDs which are shared with the app firmware
(e.g. different blink states, PWM)

Signed-off-by: Robert Schulze <robert.schulze@deveritec.com>