### PR TITLE
doc: Remove outdated IRC links

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ For more information in the source, here are some pointers:
 
 Developers welcome!
 
-* Our developer mailing list:
-  https://groups.io/g/mcuboot
-* Our Slack channel: https://mcuboot.slack.com/ <br />
-  Get your invite [here!](https://join.slack.com/t/mcuboot/shared_invite/MjE2NDcwMTQ2MTYyLTE1MDA4MTIzNTAtYzgyZTU0NjFkMg)
-* Our IRC channel: http://irc.freenode.net, #mcuboot
+* [Our developer mailing list](https://groups.io/g/MCUBoot)
+* [Our Slack channel](https://mcuboot.slack.com/) <br />
+  Get [your invite](https://join.slack.com/t/mcuboot/shared_invite/MjE2NDcwMTQ2MTYyLTE1MDA4MTIzNTAtYzgyZTU0NjFkMg)

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,9 +74,7 @@ For more information in the source, here are some pointers:
 Developers welcome!
 
 * [Our developer mailing list](https://groups.io/g/MCUBoot)
-* [Our Slack channel](https://mcuboot.slack.com/)<br />
-  Get your invite [here!](https://join.slack.com/t/mcuboot/shared_invite/MjE2NDcwMTQ2MTYyLTE1MDA4MTIzNTAtYzgyZTU0NjFkMg)
-* [Our IRC channel](http://irc.freenode.net), channel #mcuboot ([IRC
-  link](irc://chat.freenode.net/#mcuboot)
+* [Our Slack channel](https://mcuboot.slack.com/) <br />
+  Get [your invite](https://join.slack.com/t/mcuboot/shared_invite/MjE2NDcwMTQ2MTYyLTE1MDA4MTIzNTAtYzgyZTU0NjFkMg)
 * [Current members](https://github.com/mcu-tools/mcuboot/wiki/Members)
 * [Project charter](https://github.com/mcu-tools/mcuboot/wiki/MCUboot-Project-Charter)


### PR DESCRIPTION
Removed outdated IRC links from index.md and readme.md.
Slightly reformatted the final links in index.md and readme.md.

Signed-off-by: Francesco Servidio <francesco.servidio@nordicsemi.no>