### PR TITLE
Enhance simulator to generate maximally sized images

### DIFF
--- a/sim/mcuboot-sys/Cargo.toml
+++ b/sim/mcuboot-sys/Cargo.toml
@@ -91,8 +91,3 @@ cc = "1.0.25"
 libc = "0.2"
 log = "0.4"
 simflash = { path = "../simflash" }
-
-# Optimize some, even when building for debugging, otherwise the tests
-# are too slow.
-[profile.test]
-opt-level = 1

--- a/sim/mcuboot-sys/src/api.rs
+++ b/sim/mcuboot-sys/src/api.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Linaro LTD
+// Copyright (c) 2017-2021 Linaro LTD
 // Copyright (c) 2018-2019 JUUL Labs
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/sim/mcuboot-sys/src/area.rs
+++ b/sim/mcuboot-sys/src/area.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Linaro LTD
+// Copyright (c) 2017-2021 Linaro LTD
 // Copyright (c) 2018-2019 JUUL Labs
 // Copyright (c) 2019 Arm Limited
 //

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Linaro LTD
+// Copyright (c) 2017-2021 Linaro LTD
 // Copyright (c) 2017-2019 JUUL Labs
 // Copyright (c) 2019-2021 Arm Limited
 //

--- a/sim/simflash/src/lib.rs
+++ b/sim/simflash/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Linaro LTD
+// Copyright (c) 2017-2021 Linaro LTD
 // Copyright (c) 2017-2018 JUUL Labs
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/sim/simflash/src/pdump.rs
+++ b/sim/simflash/src/pdump.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Linaro LTD
+// Copyright (c) 2017,2021 Linaro LTD
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sim/src/caps.rs
+++ b/sim/src/caps.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Linaro LTD
+// Copyright (c) 2017-2021 Linaro LTD
 // Copyright (c) 2019 JUUL Labs
 // Copyright (c) 2019-2021 Arm Limited
 //

--- a/sim/src/caps.rs
+++ b/sim/src/caps.rs
@@ -36,6 +36,11 @@ impl Caps {
         (caps as u32) & (self as u32) != 0
     }
 
+    /// Does this build have ECDSA of some type enabled for signatures.
+    pub fn has_ecdsa() -> bool {
+        Caps::EcdsaP256.present() || Caps::EcdsaP224.present()
+    }
+
     /// Query for the number of images that have been configured into this
     /// MCUboot build.
     pub fn get_num_images() -> usize {

--- a/sim/src/depends.rs
+++ b/sim/src/depends.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Linaro LTD
+// Copyright (c) 2019-2021 Linaro LTD
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1597,6 +1597,8 @@ fn install_no_image() -> ImageData {
     }
 }
 
+/// Construct a TLV generator based on how MCUboot is currently configured.  The returned
+/// ManifestGen will generate the appropriate entries based on this configuration.
 fn make_tlv() -> TlvGen {
     if Caps::EcdsaP224.present() {
         panic!("Ecdsa P224 not supported in Simulator");

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Linaro LTD
+// Copyright (c) 2019-2021 Linaro LTD
 // Copyright (c) 2019-2020 JUUL Labs
 // Copyright (c) 2019-2021 Arm Limited
 //

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -220,11 +220,11 @@ impl ImagesBuilder {
                 Box::new(BoringDep::new(image_num, deps))
             };
             let primaries = install_image(&mut flash, &slots[0],
-                ImageSize::Given(42784), &ram, &*dep, false);
+                maximal(42784), &ram, &*dep, false);
             let upgrades = match deps.depends[image_num] {
                 DepType::NoUpgrade => install_no_image(),
                 _ => install_image(&mut flash, &slots[1],
-                    ImageSize::Given(46928), &ram, &*dep, false)
+                    maximal(46928), &ram, &*dep, false)
             };
             OneImage {
                 slots,
@@ -273,9 +273,9 @@ impl ImagesBuilder {
         let images = self.slots.into_iter().enumerate().map(|(image_num, slots)| {
             let dep = BoringDep::new(image_num, &NO_DEPS);
             let primaries = install_image(&mut bad_flash, &slots[0],
-                ImageSize::Given(32784), &ram, &dep, false);
+                maximal(32784), &ram, &dep, false);
             let upgrades = install_image(&mut bad_flash, &slots[1],
-                ImageSize::Given(41928), &ram, &dep, true);
+                maximal(41928), &ram, &dep, true);
             OneImage {
                 slots,
                 primaries,
@@ -296,7 +296,7 @@ impl ImagesBuilder {
         let images = self.slots.into_iter().enumerate().map(|(image_num, slots)| {
             let dep = BoringDep::new(image_num, &NO_DEPS);
             let primaries = install_image(&mut flash, &slots[0],
-                ImageSize::Given(32784), &ram, &dep, false);
+                maximal(32784), &ram, &dep, false);
             let upgrades = install_no_image();
             OneImage {
                 slots,
@@ -319,7 +319,7 @@ impl ImagesBuilder {
             let dep = BoringDep::new(image_num, &NO_DEPS);
             let primaries = install_no_image();
             let upgrades = install_image(&mut flash, &slots[1],
-                ImageSize::Given(32784), &ram, &dep, false);
+                maximal(32784), &ram, &dep, false);
             OneImage {
                 slots,
                 primaries,
@@ -1435,6 +1435,7 @@ fn install_image(flash: &mut SimMultiFlash, slot: &SlotInfo, len: ImageSize,
     let offset = slot.base_off;
     let slot_len = slot.len;
     let dev_id = slot.dev_id;
+    let dev = flash.get_mut(&dev_id).unwrap();
 
     let mut tlv: Box<dyn ManifestGen> = Box::new(make_tlv());
 
@@ -1454,7 +1455,21 @@ fn install_image(flash: &mut SimMultiFlash, slot: &SlotInfo, len: ImageSize,
 
     let len = match len {
         ImageSize::Given(size) => size,
-        ImageSize::Largest => unimplemented!(),
+        ImageSize::Largest => {
+            // Using the header size we know, the trailer size, and the slot size, we can compute
+            // the largest image possible.
+            let trailer = if Caps::OverwriteUpgrade.present() {
+                // This computation is incorrect, and we need to figure out the correct size.
+                // c::boot_status_sz(dev.align() as u32) as usize
+                16 + 4 * dev.align()
+            } else {
+                c::boot_trailer_sz(dev.align() as u32) as usize
+            };
+            let tlv_len = tlv.estimate_size();
+            info!("slot: 0x{:x}, HDR: 0x{:x}, trailer: 0x{:x}",
+                slot_len, HDR_SIZE, trailer);
+            slot_len - HDR_SIZE - trailer - tlv_len
+        }
     };
 
     // Generate a boot header.  Note that the size doesn't include the header.
@@ -1520,8 +1535,6 @@ fn install_image(flash: &mut SimMultiFlash, slot: &SlotInfo, len: ImageSize,
         tlv.corrupt_sig();
     }
     let mut b_tlv = tlv.make_tlv();
-
-    let dev = flash.get_mut(&dev_id).unwrap();
 
     let mut buf = vec![];
     buf.append(&mut b_header.to_vec());
@@ -1926,6 +1939,18 @@ trait AsRaw : Sized {
     fn as_raw(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(self as *const _ as *const u8,
                                        mem::size_of::<Self>()) }
+    }
+}
+
+/// Determine whether it makes sense to test this configuration with a maximally-sized image.
+/// Returns an ImageSize representing the best size to test, possibly just with the given size.
+fn maximal(size: usize) -> ImageSize {
+    if Caps::OverwriteUpgrade.present() ||
+        Caps::SwapUsingMove.present()
+    {
+        ImageSize::Given(size)
+    } else {
+        ImageSize::Largest
     }
 }
 

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1603,10 +1603,7 @@ fn make_tlv() -> TlvGen {
     if Caps::EcdsaP224.present() {
         panic!("Ecdsa P224 not supported in Simulator");
     }
-    let mut aes_key_size = 128;
-    if Caps::Aes256.present() {
-        aes_key_size = 256;
-    }
+    let aes_key_size = if Caps::Aes256.present() { 256 } else { 128 };
 
     if Caps::EncKw.present() {
         if Caps::RSA2048.present() {

--- a/sim/src/tlv.rs
+++ b/sim/src/tlv.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Linaro LTD
+// Copyright (c) 2017-2021 Linaro LTD
 // Copyright (c) 2017-2020 JUUL Labs
 // Copyright (c) 2021 Arm Limited
 //

--- a/sim/src/tlv.rs
+++ b/sim/src/tlv.rs
@@ -67,8 +67,8 @@ pub enum TlvFlags {
     PIC = 0x01,
     NON_BOOTABLE = 0x02,
     ENCRYPTED_AES128 = 0x04,
-    RAM_LOAD = 0x20,
     ENCRYPTED_AES256 = 0x08,
+    RAM_LOAD = 0x20,
 }
 
 /// A generator for manifests.  The format of the manifest can be either a

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Linaro LTD
+// Copyright (c) 2017-2021 Linaro LTD
 // Copyright (c) 2017-2019 JUUL Labs
 //
 // SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
This allows boundary condition testing within the simulator, to make sure we handle the cases when the image is a large as it can possibly be.

This enables maximal images in those configurations where we are able to accurately determine what that image size is. For overwrite-only+large-write, the calculation is incorrect (and results in a negative image size), and for swap-move, it doesn't account for the padding sector needed for the move. For those, we just leave the current image sizes.