### PR TITLE
Add support for partial RAM_LOADING

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2017-2019 Linaro LTD
  * Copyright (c) 2016-2019 JUUL Labs
- * Copyright (c) 2019-2020 Arm Limited
+ * Copyright (c) 2019-2021 Arm Limited
  *
  * Original license:
  *
@@ -68,8 +68,10 @@ struct image_trailer {
 
 /* you must have pre-allocated all the entries within this structure */
 fih_int boot_go(struct boot_rsp *rsp);
+fih_int boot_go_for_image_id(struct boot_rsp *rsp, uint32_t image_id);
 
 struct boot_loader_state;
+void boot_state_clear(struct boot_loader_state *state);
 fih_int context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp);
 
 #define SPLIT_GO_OK                 (0)

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -225,6 +225,22 @@ struct boot_loader_state {
 #if (BOOT_IMAGE_NUMBER > 1)
     uint8_t curr_img_idx;
 #endif
+
+#if defined(MCUBOOT_DIRECT_XIP) || defined(MCUBOOT_RAM_LOAD)
+    struct slot_usage_t {
+        /* Index of the slot chosen to be loaded */
+        uint32_t active_slot;
+        bool slot_available[BOOT_NUM_SLOTS];
+#if defined(MCUBOOT_RAM_LOAD)
+        /* Image destination and size for the active slot */
+        uint32_t img_dst;
+        uint32_t img_sz;
+#elif defined(MCUBOOT_DIRECT_XIP_REVERT)
+        /* Swap status for the active slot */
+        struct boot_swap_state swap_state;
+#endif
+    } slot_usage[BOOT_IMAGE_NUMBER];
+#endif /* MCUBOOT_DIRECT_XIP || MCUBOOT_RAM_LOAD */
 };
 
 fih_int bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig,

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -224,6 +224,7 @@ struct boot_loader_state {
 
 #if (BOOT_IMAGE_NUMBER > 1)
     uint8_t curr_img_idx;
+    bool img_mask[BOOT_IMAGE_NUMBER];
 #endif
 
 #if defined(MCUBOOT_DIRECT_XIP) || defined(MCUBOOT_RAM_LOAD)

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -64,7 +64,8 @@ impl BootGoResult {
 
 /// Invoke the bootloader on this flash device.
 pub fn boot_go(multiflash: &mut SimMultiFlash, areadesc: &AreaDesc,
-               counter: Option<&mut i32>, catch_asserts: bool) -> BootGoResult {
+               counter: Option<&mut i32>, image_index: Option<i32>,
+               catch_asserts: bool) -> BootGoResult {
     for (&dev_id, flash) in multiflash.iter_mut() {
         api::set_flash(dev_id, flash);
     }
@@ -83,9 +84,16 @@ pub fn boot_go(multiflash: &mut SimMultiFlash, areadesc: &AreaDesc,
         flash_dev_id: 0,
         image_off: 0,
     };
-    let result = unsafe {
-        raw::invoke_boot_go(&mut sim_ctx as *mut _, &areadesc.get_c() as *const _,
-            &mut rsp as *mut _) as i32
+    let result: i32 = unsafe {
+        match image_index {
+            None => raw::invoke_boot_go(&mut sim_ctx as *mut _,
+                                        &areadesc.get_c() as *const _,
+                                        &mut rsp as *mut _, -1) as i32,
+            Some(i) => raw::invoke_boot_go(&mut sim_ctx as *mut _,
+                                           &areadesc.get_c() as *const _,
+                                           &mut rsp as *mut _,
+                                           i as i32) as i32
+        }
     };
     let asserts = sim_ctx.c_asserts;
     if let Some(c) = counter {
@@ -151,7 +159,7 @@ mod raw {
         // be any way to get rid of this warning.  See https://github.com/rust-lang/rust/issues/34798
         // for information and tracking.
         pub fn invoke_boot_go(sim_ctx: *mut CSimContext, areadesc: *const CAreaDesc,
-            rsp: *mut BootRsp) -> libc::c_int;
+            rsp: *mut BootRsp, image_index: libc::c_int) -> libc::c_int;
 
         pub fn boot_trailer_sz(min_write_sz: u32) -> u32;
         pub fn boot_status_sz(min_write_sz: u32) -> u32;

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -61,6 +61,7 @@ sim_test!(downgrade_prevention, make_image(&REV_DEPS, true), run_nodowngrade());
 
 sim_test!(direct_xip_first, make_no_upgrade_image(&NO_DEPS), run_direct_xip());
 sim_test!(ram_load_first, make_no_upgrade_image(&NO_DEPS), run_ram_load());
+sim_test!(ram_load_split, make_no_upgrade_image(&NO_DEPS), run_split_ram_load());
 
 // Test various combinations of incorrect dependencies.
 test_shell!(dependency_combos, r, {


### PR DESCRIPTION
Add new public API function to perform RAM_LOADING on a specific image. Designed to be used when only a subset of the images need to be loaded, or images need to be loaded in multiple stages.

In order to do this, change how `context_boot_go` handles state. It now doesn't clear the context when called. Add a new API function to clear this state so that external callers can still use `context_boot_go`. The semantics of `boot_go` are unchanged.

Also moves slot_usage into the bootloader state.