### PR TITLE
mynewt: remove #error on ec256 with Mbed TLS

### DIFF
--- a/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_config.h
+++ b/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_config.h
@@ -40,9 +40,6 @@
 #endif
 #if MYNEWT_VAL(BOOTUTIL_SIGN_EC256)
 #define MCUBOOT_SIGN_EC256 1
-  #ifndef MCUBOOT_USE_TINYCRYPT
-  #error "EC256 requires the use of tinycrypt."
-  #endif
 #endif
 #if MYNEWT_VAL(BOOTUTIL_SIGN_RSA)
 #define MCUBOOT_SIGN_RSA 1


### PR DESCRIPTION
Allow building ec256 signature validation on Mynewt using Mbed TLS. Related to https://github.com/apache/mynewt-artifact/pull/33