### PR TITLE
imgtool: prefer cbor2 over cbor

### DIFF
--- a/scripts/imgtool.nix
+++ b/scripts/imgtool.nix
@@ -20,7 +20,7 @@ let
       python37.pkgs.cryptography
       python37.pkgs.intelhex
       python37.pkgs.setuptools
-      python37.pkgs.cbor
+      python37.pkgs.cbor2
     ]
   );
 in

--- a/scripts/imgtool/boot_record.py
+++ b/scripts/imgtool/boot_record.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, Arm Limited.
+# Copyright (c) 2019-2021, Arm Limited.
 # Copyright (c) 2020, Linaro Limited
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -16,8 +16,11 @@
 # limitations under the License.
 
 from enum import Enum
-import cbor
 
+try:
+    from cbor2 import dumps
+except ImportError:
+    from cbor import dumps
 
 class SwComponent(int, Enum):
     """
@@ -46,4 +49,4 @@ def create_sw_component_data(sw_type, sw_version, sw_measurement_description,
     #       list because later it will be modified by the bootloader.
     properties[SwComponent.MEASUREMENT_VALUE] = sw_measurement_value
 
-    return cbor.dumps(properties)
+    return dumps(properties)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,4 @@
 cryptography>=2.6
 intelhex
 click
-cbor>=1.0.0
+cbor2

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         'cryptography>=2.4.2',
         'intelhex>=2.2.1',
         'click',
-        'cbor>=1.0.0',
+        'cbor2',
     ],
     entry_points={
         "console_scripts": ["imgtool=imgtool.main:imgtool"]


### PR DESCRIPTION
The cbor module is unmaintained, with the last release in 2016[1]. The
cbor2 module however is under active development and was last released
just last month[2].

As the APIs are identical, we can import cbor2 and if that fails fall
back to cbor.

[1] https://pypi.org/project/cbor/#history
[2] https://pypi.org/project/cbor2/#history

Closes #1189

Signed-off-by: Ross Burton <ross.burton@arm.com>
Change-Id: Iaf2d0df625a200a5cebf72dec4a89877a26194ea