### PR TITLE
boot: Avoid overflow if header size is too big and encryption is used

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -920,6 +920,7 @@ boot_copy_region(struct boot_loader_state *state,
     uint8_t image_index;
 #endif
 
+    /* buffer size limits maximum header size. This affects IMAGE_HEADER_SIZE_MAX in imgtool.py */
     TARGET_STATIC uint8_t buf[1024] __attribute__((aligned(4)));
 
 #if !defined(MCUBOOT_ENC_IMAGES)
@@ -966,6 +967,10 @@ boot_copy_region(struct boot_loader_state *state,
                 if (off + bytes_copied < hdr->ih_hdr_size) {
                     /* do not decrypt header */
                     blk_off = 0;
+                    /* check for overflow */
+                    if (hdr->ih_hdr_size > chunk_sz) {
+                        return BOOT_EBADIMAGE;
+                    }
                     blk_sz = chunk_sz - hdr->ih_hdr_size;
                     idx = hdr->ih_hdr_size;
                 } else {

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -40,6 +40,7 @@ from cryptography.exceptions import InvalidSignature
 
 IMAGE_MAGIC = 0x96f3b83d
 IMAGE_HEADER_SIZE = 32
+IMAGE_HEADER_SIZE_MAX = 0x400 # limited by buffer size in loader.c:boot_copy_region
 BIN_EXT = "bin"
 INTEL_HEX_EXT = "hex"
 DEFAULT_MAX_SECTORS = 128

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -188,6 +188,10 @@ def validate_header_size(ctx, param, value):
     if value < min_hdr_size:
         raise click.BadParameter(
             "Minimum value for -H/--header-size is {}".format(min_hdr_size))
+    max_hdr_size = image.IMAGE_HEADER_SIZE_MAX
+    if value > max_hdr_size:
+        raise click.BadParameter(
+            "Maximum value for -H/--header-size is {}".format(max_hdr_size))
     return value
 
 


### PR DESCRIPTION
Fixes issue #1191.

This tries to prevent misconfiguration of the header size in the imgtool,
and also adds code which prevents the overflow if the (not encrypted) header
is skipped.