### PR TITLE
ci: Enable build of espressif port for supported chips

### DIFF
--- a/.github/workflows/espressif.yaml
+++ b/.github/workflows/espressif.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2021 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+# For development, trigger this on any push.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+name: Espressif
+
+jobs:
+  environment:
+    strategy:
+      matrix:
+        targets: [esp32, esp32s2, esp32c3]
+    runs-on: ubuntu-latest
+    env:
+      MCUBOOT_TARGET: ${{ matrix.targets }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: recursive
+    - name: Print the environment
+      run: |
+        uname -a
+        lscpu
+        free
+        pwd
+    - name: Signed commit check
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        ./ci/check-signed-off-by.sh
+    - name: Espressif install
+      run: |
+        ./ci/espressif_install.sh
+    - name: Espressif run
+      run: |
+        ./ci/espressif_run.sh

--- a/ci/espressif_install.sh
+++ b/ci/espressif_install.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2021 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+SCRIPT_ROOTDIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+MCUBOOT_ROOTDIR=$(realpath "${SCRIPT_ROOTDIR}/..")
+ESPRESSIF_ROOT="${MCUBOOT_ROOTDIR}/boot/espressif"
+IDF_PATH="${ESPRESSIF_ROOT}/hal/esp-idf"
+
+set -eo pipefail
+
+install_idf() {
+    "${IDF_PATH}"/install.sh
+}
+
+install_idf

--- a/ci/espressif_run.sh
+++ b/ci/espressif_run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2021 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+SCRIPT_ROOTDIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+MCUBOOT_ROOTDIR=$(realpath "${SCRIPT_ROOTDIR}/..")
+ESPRESSIF_ROOT="${MCUBOOT_ROOTDIR}/boot/espressif"
+IDF_PATH="${ESPRESSIF_ROOT}/hal/esp-idf"
+
+set -eo pipefail
+
+build_mcuboot() {
+  local target=${MCUBOOT_TARGET}
+  local build_dir=".build-${target}"
+  local toolchain_file="${ESPRESSIF_ROOT}/tools/toolchain-${target}.cmake"
+  local mcuboot_config="${ESPRESSIF_ROOT}/bootloader.conf"
+
+  # Prepare the environment for ESP-IDF
+
+  . "${IDF_PATH}"/export.sh
+
+  # Build MCUboot for selected target
+
+  cd "${MCUBOOT_ROOTDIR}" &>/dev/null
+  cmake -DCMAKE_TOOLCHAIN_FILE="${toolchain_file}"  \
+        -DMCUBOOT_TARGET="${target}"                \
+        -DMCUBOOT_CONFIG_FILE="${mcuboot_config}"   \
+        -DIDF_PATH="${IDF_PATH}"                    \
+        -B "${build_dir}"                           \
+        "${ESPRESSIF_ROOT}"
+  cmake --build "${build_dir}"/
+}
+
+build_mcuboot


### PR DESCRIPTION
This PR intends to enable the CI build of the `espressif` port of MCUboot for the currently supported chips:
- ESP32
- ESP32-S2
- ESP32-C3