### PR TITLE
loader: Allow image header bigger than 1 KB for encrypted images

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -961,14 +961,14 @@ boot_copy_region(struct boot_loader_state *state,
             }
 #endif
             if (IS_ENCRYPTED(hdr)) {
-                if (off + bytes_copied < hdr->ih_hdr_size) {
+                uint32_t abs_off = off + bytes_copied;
+                if (abs_off < hdr->ih_hdr_size) {
                     /* do not decrypt header */
-                    if (off + bytes_copied + chunk_sz > hdr->ih_hdr_size) {
+                    if (abs_off + chunk_sz > hdr->ih_hdr_size) {
                         /* The lower part of the chunk contains header data */
                         blk_off = 0;
-                        blk_sz = chunk_sz - (hdr->ih_hdr_size - off -
-                                 bytes_copied);
-                        idx = hdr->ih_hdr_size  - off - bytes_copied;
+                        blk_sz = chunk_sz - (hdr->ih_hdr_size - abs_off);
+                        idx = hdr->ih_hdr_size  - abs_off;
                     } else {
                         /* The chunk contains exclusively header data */
                         blk_sz = 0; /* nothing to decrypt */
@@ -976,22 +976,22 @@ boot_copy_region(struct boot_loader_state *state,
                 } else {
                     idx = 0;
                     blk_sz = chunk_sz;
-                    blk_off = ((off + bytes_copied) - hdr->ih_hdr_size) & 0xf;
+                    blk_off = (abs_off - hdr->ih_hdr_size) & 0xf;
                 }
 
                 if (blk_sz > 0)
                 {
                     tlv_off = BOOT_TLV_OFF(hdr);
-                    if (off + bytes_copied + chunk_sz > tlv_off) {
+                    if (abs_off + chunk_sz > tlv_off) {
                         /* do not decrypt TLVs */
-                        if (off + bytes_copied >= tlv_off) {
+                        if (abs_off >= tlv_off) {
                             blk_sz = 0;
                         } else {
-                            blk_sz = tlv_off - (off + bytes_copied);
+                            blk_sz = tlv_off - abs_off;
                         }
                     }
                     boot_encrypt(BOOT_CURR_ENC(state), image_index, fap_src,
-                            (off + bytes_copied + idx) - hdr->ih_hdr_size, blk_sz,
+                            (abs_off + idx) - hdr->ih_hdr_size, blk_sz,
                             blk_off, &buf[idx]);
                 }
             }

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -961,28 +961,39 @@ boot_copy_region(struct boot_loader_state *state,
             }
 #endif
             if (IS_ENCRYPTED(hdr)) {
-                blk_sz = chunk_sz;
-                idx = 0;
                 if (off + bytes_copied < hdr->ih_hdr_size) {
                     /* do not decrypt header */
-                    blk_off = 0;
-                    blk_sz = chunk_sz - hdr->ih_hdr_size;
-                    idx = hdr->ih_hdr_size;
+                    if (off + bytes_copied + chunk_sz > hdr->ih_hdr_size) {
+                        /* The lower part of the chunk contains header data */
+                        blk_off = 0;
+                        blk_sz = chunk_sz - (hdr->ih_hdr_size - off -
+                                 bytes_copied);
+                        idx = hdr->ih_hdr_size  - off - bytes_copied;
+                    } else {
+                        /* The chunk contains exclusively header data */
+                        blk_sz = 0; /* nothing to decrypt */
+                    }
                 } else {
+                    idx = 0;
+                    blk_sz = chunk_sz;
                     blk_off = ((off + bytes_copied) - hdr->ih_hdr_size) & 0xf;
                 }
-                tlv_off = BOOT_TLV_OFF(hdr);
-                if (off + bytes_copied + chunk_sz > tlv_off) {
-                    /* do not decrypt TLVs */
-                    if (off + bytes_copied >= tlv_off) {
-                        blk_sz = 0;
-                    } else {
-                        blk_sz = tlv_off - (off + bytes_copied);
+
+                if (blk_sz > 0)
+                {
+                    tlv_off = BOOT_TLV_OFF(hdr);
+                    if (off + bytes_copied + chunk_sz > tlv_off) {
+                        /* do not decrypt TLVs */
+                        if (off + bytes_copied >= tlv_off) {
+                            blk_sz = 0;
+                        } else {
+                            blk_sz = tlv_off - (off + bytes_copied);
+                        }
                     }
+                    boot_encrypt(BOOT_CURR_ENC(state), image_index, fap_src,
+                            (off + bytes_copied + idx) - hdr->ih_hdr_size, blk_sz,
+                            blk_off, &buf[idx]);
                 }
-                boot_encrypt(BOOT_CURR_ENC(state), image_index, fap_src,
-                        (off + bytes_copied + idx) - hdr->ih_hdr_size, blk_sz,
-                        blk_off, &buf[idx]);
             }
         }
 #endif

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -191,6 +191,13 @@ elseif(CONFIG_BOOT_SIGNATURE_TYPE_RSA)
   # Use mbedTLS provided by Zephyr for RSA signatures. (Its config file
   # is set using Kconfig.)
   zephyr_include_directories(include)
+  if(CONFIG_BOOT_ENCRYPT_RSA)
+    set_source_files_properties(
+      ${BOOT_DIR}/bootutil/src/encrypted.c
+      PROPERTIES
+      INCLUDE_DIRECTORIES ${ZEPHYR_MBEDTLS_MODULE_DIR}/library
+      )
+  endif()
 elseif(CONFIG_BOOT_SIGNATURE_TYPE_ED25519 OR CONFIG_BOOT_ENCRYPT_X25519)
   if(CONFIG_BOOT_USE_TINYCRYPT)
     zephyr_library_include_directories(

--- a/boot/zephyr/os.c
+++ b/boot/zephyr/os.c
@@ -41,7 +41,7 @@
 #define CRYPTO_HEAP_SIZE 6144
 #else
 #  if !defined(MBEDTLS_RSA_NO_CRT)
-#  define CRYPTO_HEAP_SIZE 10240
+#  define CRYPTO_HEAP_SIZE 12032
 #  else
 #  define CRYPTO_HEAP_SIZE 16384
 #  endif


### PR DESCRIPTION
boot_copy_region() was written so it assumes that the image header
must fit int the intermediary buffer of 1 KB size. A bigger header
will cause a overflow in calculation of size of data chunk to be
decrypted.

This patch allow to use header bigger than that buffer size and
mitigate the limitation described above.

This patch was tested on zephyr nrf52840dk_nrf52840 with image headed size increased to 0x600.
It was done by simple modification i zephyr's Kconfig.zephyr file:

```Kconfig
config ROM_START_OFFSET
	hex
	prompt "ROM start offset" if !BOOTLOADER_MCUBOOT
	default 0x600 if BOOTLOADER_MCUBOOT # <-was 0x200
	default 0
	help
```

fixes #1191
fixes #1200