### PR TITLE
boot: zephyr: stm32: watchdog support

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -667,6 +667,7 @@ boot_serial_start(const struct boot_uart_funcs *f)
     off = 0;
     while (1) {
         MCUBOOT_CPU_IDLE();
+        MCUBOOT_WATCHDOG_FEED();
         rc = f->read(in_buf + off, sizeof(in_buf) - off, &full_line);
         if (rc <= 0 && !full_line) {
             continue;

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -240,13 +240,24 @@
 #error "No NRFX WDT instances enabled"
 #endif /* defined(CONFIG_NRFX_WDT0) && defined(CONFIG_NRFX_WDT1) */
 
-#else /* CONFIG_NRFX_WDT */
+#elif CONFIG_IWDG_STM32 /* CONFIG_NRFX_WDT */
+#include <drivers/watchdog.h>
+
+#define MCUBOOT_WATCHDOG_FEED() \
+    do {                        \
+        const struct device* wdt =                          \
+            device_get_binding(                             \
+                DT_LABEL(DT_INST(0, st_stm32_watchdog)));   \
+        wdt_feed(wdt, 0);                                   \
+    } while (0)
+
+#else /* CONFIG_IWDG_STM32 */
 #warning "MCUBOOT_WATCHDOG_FEED() is no-op"
 /* No vendor implementation, no-op for historical reasons */
 #define MCUBOOT_WATCHDOG_FEED()         \
     do {                                \
     } while (0)
-#endif /* CONFIG_NRFX_WDT */
+#endif
 #else  /* CONFIG_BOOT_WATCHDOG_FEED */
 /* Not enabled, no feed activity */
 #define MCUBOOT_WATCHDOG_FEED()         \


### PR DESCRIPTION
**Implements:**
- Support for the STM32 Independent watchdog.
- Feeding of watchdog during serial recovery mode.

**Tested:**
- Tested with custom STM32L431KC board with and without watchdog enabled. Watchdog successfully kicks bootloader when in `FIH_PANIC`.
- Tested with serial communication. Watchdog is being fed and does not reset bootloader when in `boot_serial_start`, or while uploading new image.