### PR TITLE
espressif: Use BOOT_LOG_* macros instead of the MCUBOOT_LOG_*

### DIFF
--- a/boot/espressif/main.c
+++ b/boot/espressif/main.c
@@ -5,18 +5,19 @@
  */
 
 #include <bootutil/bootutil.h>
+#include <bootutil/bootutil_log.h>
+#include <bootutil/fault_injection_hardening.h>
 #include <bootutil/image.h>
 
-#include <mcuboot_config/mcuboot_logging.h>
+#include "bootloader_init.h"
 
-#include <os/os_malloc.h>
-#include <bootloader_init.h>
-#include <esp_loader.h>
+#include "esp_loader.h"
+#include "os/os_malloc.h"
 
 void do_boot(struct boot_rsp *rsp)
 {
-    MCUBOOT_LOG_INF("br_image_off = 0x%x", rsp->br_image_off);
-    MCUBOOT_LOG_INF("ih_hdr_size = 0x%x", rsp->br_hdr->ih_hdr_size);
+    BOOT_LOG_INF("br_image_off = 0x%x", rsp->br_image_off);
+    BOOT_LOG_INF("ih_hdr_size = 0x%x", rsp->br_hdr->ih_hdr_size);
     int slot = (rsp->br_image_off == CONFIG_ESP_APPLICATION_PRIMARY_START_ADDRESS) ? 0 : 1;
     esp_app_image_load(slot, rsp->br_hdr->ih_hdr_size);
 }
@@ -26,7 +27,7 @@ int main()
     bootloader_init();
     struct boot_rsp rsp;
 #ifdef MCUBOOT_VER
-    MCUBOOT_LOG_INF("*** Booting MCUBoot build %s  ***", MCUBOOT_VER);
+    BOOT_LOG_INF("*** Booting MCUBoot build %s  ***", MCUBOOT_VER);
 #endif
 
     os_heap_init();
@@ -34,7 +35,7 @@ int main()
     fih_int fih_rc = FIH_FAILURE;
     FIH_CALL(boot_go, fih_rc, &rsp);
     if (fih_not_eq(fih_rc, FIH_SUCCESS)) {
-        MCUBOOT_LOG_ERR("Unable to find bootable image");
+        BOOT_LOG_ERR("Unable to find bootable image");
         FIH_PANIC;
     }
     do_boot(&rsp);

--- a/boot/espressif/port/esp_loader.c
+++ b/boot/espressif/port/esp_loader.c
@@ -5,28 +5,23 @@
  */
 
 #include <string.h>
-#include <soc/soc.h>
-#include "soc/soc_memory_layout.h"
-#include <bootloader_flash.h>
-#include <bootloader_flash_priv.h>
 
-#if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2)
-#include <soc/dport_reg.h>
+#include <bootutil/bootutil_log.h>
+#include <bootutil/fault_injection_hardening.h>
+
+#include "bootloader_flash_priv.h"
+#include "soc/soc_memory_layout.h"
+
+#if CONFIG_IDF_TARGET_ESP32
+#include "esp32/rom/uart.h"
+#elif CONFIG_IDF_TARGET_ESP32S2
+#include "esp32s2/rom/uart.h"
+#elif CONFIG_IDF_TARGET_ESP32C3
+#include "esp32c3/rom/uart.h"
 #endif
 
-#include "rom/cache.h"
-#include "rom/efuse.h"
-#include "rom/ets_sys.h"
-#include "rom/spi_flash.h"
-#include "rom/crc.h"
-#include "rom/rtc.h"
-#include "rom/gpio.h"
-#include "rom/uart.h"
-
-#include <esp_loader.h>
-#include <bootutil/fault_injection_hardening.h>
-#include <flash_map_backend/flash_map_backend.h>
-#include <mcuboot_config/mcuboot_logging.h>
+#include "esp_loader.h"
+#include "flash_map_backend/flash_map_backend.h"
 
 #define ESP_LOAD_HEADER_MAGIC 0xace637d3   /* Magic is derived from sha256sum of espmcuboot */
 
@@ -48,7 +43,7 @@ static int load_segment(const struct flash_area *fap, uint32_t data_addr, uint32
 {
     const uint32_t *data = (const uint32_t *)bootloader_mmap((fap->fa_off + data_addr), data_len);
     if (!data) {
-        MCUBOOT_LOG_ERR("%s: Bootloader nmap failed", __func__);
+        BOOT_LOG_ERR("%s: Bootloader mmap failed", __func__);
         return -1;
     }
     memcpy((void *)load_addr, data, data_len);
@@ -67,7 +62,7 @@ void esp_app_image_load(int slot, unsigned int hdr_offset)
     area_id = flash_area_id_from_image_slot(slot);
     rc = flash_area_open(area_id, &fap);
     if (rc != 0) {
-        MCUBOOT_LOG_ERR("%s: flash_area_open failed with %d", __func__, rc);
+        BOOT_LOG_ERR("%s: flash_area_open failed with %d", __func__, rc);
     }
 
     const uint32_t *data = (const uint32_t *)bootloader_mmap((fap->fa_off + hdr_offset), sizeof(image_load_header_t));
@@ -75,32 +70,32 @@ void esp_app_image_load(int slot, unsigned int hdr_offset)
     bootloader_munmap(data);
 
     if (load_header.header_magic != ESP_LOAD_HEADER_MAGIC) {
-        MCUBOOT_LOG_ERR("Load header magic verification failed. Aborting");
+        BOOT_LOG_ERR("Load header magic verification failed. Aborting");
         FIH_PANIC;
     }
 
     if (!esp_ptr_in_iram((void *)load_header.iram_dest_addr) || !esp_ptr_in_iram((void *)(load_header.iram_dest_addr + load_header.iram_size))) {
-        MCUBOOT_LOG_ERR("IRAM region in load header is not valid. Aborting");
+        BOOT_LOG_ERR("IRAM region in load header is not valid. Aborting");
         FIH_PANIC;
     }
 
     if (!esp_ptr_in_dram((void *)load_header.dram_dest_addr) || !esp_ptr_in_dram((void *)load_header.dram_dest_addr + load_header.dram_size)) {
-        MCUBOOT_LOG_ERR("DRAM region in load header is not valid. Aborting");
+        BOOT_LOG_ERR("DRAM region in load header is not valid. Aborting");
         FIH_PANIC;
     }
 
     if (!esp_ptr_in_iram((void *)load_header.entry_addr)) {
-        MCUBOOT_LOG_ERR("Application entry point (0x%x) is not in IRAM. Aborting", load_header.entry_addr);
+        BOOT_LOG_ERR("Application entry point (0x%x) is not in IRAM. Aborting", load_header.entry_addr);
         FIH_PANIC;
     }
 
-    MCUBOOT_LOG_INF("DRAM segment: start=0x%x, size=0x%x, vaddr=0x%x", load_header.dram_flash_offset, load_header.dram_size, load_header.dram_dest_addr);
+    BOOT_LOG_INF("DRAM segment: start=0x%x, size=0x%x, vaddr=0x%x", load_header.dram_flash_offset, load_header.dram_size, load_header.dram_dest_addr);
     load_segment(fap, load_header.dram_flash_offset, load_header.dram_size, load_header.dram_dest_addr);
 
-    MCUBOOT_LOG_INF("IRAM segment: start=0x%x, size=0x%x, vaddr=0x%x", load_header.iram_flash_offset, load_header.iram_size, load_header.iram_dest_addr);
+    BOOT_LOG_INF("IRAM segment: start=0x%x, size=0x%x, vaddr=0x%x", load_header.iram_flash_offset, load_header.iram_size, load_header.iram_dest_addr);
     load_segment(fap, load_header.iram_flash_offset, load_header.iram_size, load_header.iram_dest_addr);
 
-    MCUBOOT_LOG_INF("start=0x%x", load_header.entry_addr);
+    BOOT_LOG_INF("start=0x%x", load_header.entry_addr);
     uart_tx_wait_idle(0);
     void *start = (void *) load_header.entry_addr;
     ((void (*)(void))start)(); /* Call to application entry address should not return */


### PR DESCRIPTION
## Summary

This PR intends to make the logging infra on the Espressif port uniform to the bootutil library.

This PR also refines the include directives, by removing unused headers and making the usage of brackets and quotes a bit more coherent.

## Impact
This PR brings no functional changes, so it shouldn't bring any impact.

## Testing

CI build pass.
Also tested in every board supported by the Espressif port:
- ESP32
- ESP32-S2
- ESP32-C3