### PR TITLE
nuttx: solve referenciation error in memset call

### DIFF
--- a/boot/nuttx/src/flash_map_backend/flash_map_backend.c
+++ b/boot/nuttx/src/flash_map_backend/flash_map_backend.c
@@ -552,7 +552,7 @@ int flash_area_erase(const struct flash_area *fa, uint32_t off, uint32_t len)
       return ERROR;
     }
 
-  memset(buffer, erase_val, sizeof(buffer));
+  memset(buffer, erase_val, sector_size);
 
   i = 0;
 


### PR DESCRIPTION
**Solve:**
For GCC 4.9: 
error: argument to 'sizeof' in 'memset' call is the same expression as the destination; did you mean to dereference it? [-Werror=sizeof-pointer-memaccess]

