### PR TITLE
boot_serial: cleanup max output size calculation

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -63,12 +63,8 @@
 
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
-#ifndef BOOT_IMAGE_NUMBER
-#define BOOT_IMAGE_NUMBER MCUBOOT_IMAGE_NUMBER
-#endif
-
 #define BOOT_SERIAL_INPUT_MAX   512
-#define BOOT_SERIAL_OUT_MAX     (128 * MCUBOOT_IMAGE_NUMBER)
+#define BOOT_SERIAL_OUT_MAX     (128 * BOOT_IMAGE_NUMBER)
 
 #ifdef __ZEPHYR__
 /* base64 lib encodes data to null-terminated string */

--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -36,6 +36,14 @@
 extern "C" {
 #endif
 
+#ifdef MCUBOOT_IMAGE_NUMBER
+#define BOOT_IMAGE_NUMBER          MCUBOOT_IMAGE_NUMBER
+#else
+#define BOOT_IMAGE_NUMBER          1
+#endif
+
+_Static_assert(BOOT_IMAGE_NUMBER > 0, "Invalid value for BOOT_IMAGE_NUMBER");
+
 struct image_header;
 /**
  * A response object provided by the boot loader code; indicates where to jump

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -130,14 +130,6 @@ struct boot_status {
 
 extern const uint32_t boot_img_magic[4];
 
-#ifdef MCUBOOT_IMAGE_NUMBER
-#define BOOT_IMAGE_NUMBER          MCUBOOT_IMAGE_NUMBER
-#else
-#define BOOT_IMAGE_NUMBER          1
-#endif
-
-_Static_assert(BOOT_IMAGE_NUMBER > 0, "Invalid value for BOOT_IMAGE_NUMBER");
-
 #if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)
 #define ARE_SLOTS_EQUIVALENT()    0
 #else


### PR DESCRIPTION
Calculation of BOOT_SERIAL_OUT_MAX was based on MCUBOOT_IMAGE_NUMBER
while in other places BOOT_IMAGE_NUMBER is taken int account as
images number. Let's align the calculation to use same literal value
as others.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>