### PR TITLE
Include stddef.h in boot_record

### DIFF
--- a/boot/bootutil/include/bootutil/boot_record.h
+++ b/boot/bootutil/include/bootutil/boot_record.h
@@ -18,6 +18,7 @@
 #define __BOOT_RECORD_H__
 
 #include <stdint.h>
+#include <stddef.h>
 #include "bootutil/image.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
Before adding the `#include <stddef.h>` I was getting "unknown type: size_t" errors when compiling for Mbed-OS.

Signed-off-by: George Beckstein <george.beckstein@gmail.com>