### PR TITLE
mynewt: Add call to custom pre-boot function

### DIFF
--- a/boot/mynewt/src/main.c
+++ b/boot/mynewt/src/main.c
@@ -51,6 +51,10 @@
 void boot_custom_start(uintptr_t flash_base, struct boot_rsp *rsp);
 #endif
 
+#if MYNEWT_VAL(BOOT_PREBOOT)
+void boot_preboot(void);
+#endif
+
 #if defined(MCUBOOT_SERIAL)
 #define BOOT_SERIAL_REPORT_DUR  \
     (MYNEWT_VAL(OS_CPUTIME_FREQ) / MYNEWT_VAL(BOOT_SERIAL_REPORT_FREQ))
@@ -239,6 +243,9 @@ main(void)
     flash_map_init();
 #endif
 
+#if MYNEWT_VAL(BOOT_PREBOOT)
+    boot_preboot();
+#endif
     FIH_CALL(boot_go, fih_rc, &rsp);
     if (fih_not_eq(fih_rc, FIH_SUCCESS)) {
         assert(fih_int_decode(fih_rc) == FIH_POSITIVE_VALUE);

--- a/boot/mynewt/syscfg.yml
+++ b/boot/mynewt/syscfg.yml
@@ -28,6 +28,9 @@ syscfg.defs:
     BOOT_CUSTOM_START:
         description: 'Override hal_system_start with a custom start routine'
         value: 0
+    BOOT_PREBOOT:
+        description: 'Call boot_preboot() function before booting application'
+        value:
 
 syscfg.vals:
     SYSINIT_CONSTRAIN_INIT: 0


### PR DESCRIPTION
Custom boot_preboot() function can be used to start
DFU in similar way as is already done in zephyr.

Proposed function name can be discussed if someone thinks it's inappropriate.
