### PR TITLE
doc/design: fix typo in swap-using-scratch description

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -232,8 +232,8 @@ maximum-image-size = image-slot-size - image-trailer-size
 ```
 
 Where:  
-  `image-slot-size` is the size of the image slot.
-  `image-trailer-sectors-size` is the size of the image trailer.
+  `image-slot-size` is the size of the image slot.  
+  `image-trailer-size` is the size of the image trailer.
 
 ### [Swap without using scratch](#image-swap-no-scratch)
 


### PR DESCRIPTION
`image-trailer-size` should be mentioned instead
of `image-trailer-sectors-size` in the maximal-image-size
evaluation description.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>