### PR TITLE
zephyr: fix typo in CONFIG_ERASE_PROGRESSIVELY conversion

### DIFF
--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -189,7 +189,7 @@
  * for the time needed to erase large chunk of flash.
  */
 #ifdef CONFIG_BOOT_ERASE_PROGRESSIVELY
-#define MCBOOT_ERASE_PROGRESSIVELY
+#define MCUBOOT_ERASE_PROGRESSIVELY
 #endif
 
 /*


### PR DESCRIPTION
Kconfig macro was converted with typo to not a MCUboot's
internal macro switch. It was MCBOOT_ERASE_PROGRESSIVELY instead
of MCUBOOT_ERASE_PROGRESSIVELY.
Bug was introduced in
https://github.com/mcu-tools/mcuboot/commit/42c985ceadecb61f77db016ebb64b21099c45f4a

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>