### PR TITLE
Sw version based downgrade prevention

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -487,7 +487,7 @@ out:
     flash_area_close(fap);
 
 #ifdef MCUBOOT_ENC_IMAGES
-    if (curr_off == img_size) {
+    if (curr_off == img_size && rc == MGMT_ERR_OK) {
         /* Last sector received, now start a decryption on the image if it is encrypted*/
         rc = boot_handle_enc_fw();
     }

--- a/boot/boot_serial/src/boot_serial_priv.h
+++ b/boot/boot_serial/src/boot_serial_priv.h
@@ -40,6 +40,7 @@ extern "C" {
 #define MGMT_ERR_EUNKNOWN       2
 #define MGMT_ERR_EINVAL         3
 #define MGMT_ERR_ENOTSUP        8
+#define MGMT_ERR_REJECTED_UPD  10
 
 #define NMGR_OP_READ            0
 #define NMGR_OP_WRITE           2

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -630,7 +630,7 @@ choice BOOT_DOWNGRADE_PREVENTION_CHOICE
 
 config MCUBOOT_DOWNGRADE_PREVENTION
 	bool "SW based downgrade prevention"
-	depends on BOOT_UPGRADE_ONLY
+	depends on BOOT_UPGRADE_ONLY || MCUBOOT_SERIAL
 	help
 	  Prevent downgrades by enforcing incrementing version numbers.
 	  When this option is set, any upgrade must have greater major version

--- a/boot/zephyr/include/serial_adapter/serial_adapter.h
+++ b/boot/zephyr/include/serial_adapter/serial_adapter.h
@@ -21,12 +21,12 @@ int
 console_out(int c);
 
 void
-console_write(const char *str, int cnt);
+console_write_boot(const char *str, int cnt);
 
 int
 boot_console_init(void);
 
 int
-console_read(char *str, int str_cnt, int *newline);
+console_read_boot(char *str, int str_cnt, int *newline);
 
 #endif // SERIAL_ADAPTER

--- a/boot/zephyr/include/single_loader.h
+++ b/boot/zephyr/include/single_loader.h
@@ -17,4 +17,14 @@ int boot_handle_enc_fw();
 
 fih_int boot_image_validate(const struct flash_area *fa_p,
                     struct image_header *hdr);
+
+/**
+ * Functions required for comparing version in a single slot configuration
+ */
+
+int boot_image_load_header(const struct flash_area *fa_p,
+                           struct image_header *hdr);
+
+int boot_version_cmp(const struct image_version *ver1,
+                     const struct image_version *ver2);
 #endif

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -39,8 +39,8 @@
 #include "serial_adapter/serial_adapter.h"
 
 const struct boot_uart_funcs boot_funcs = {
-    .read = console_read,
-    .write = console_write
+    .read = console_read_boot,
+    .write = console_write_boot
 };
 #endif
 

--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -22,8 +22,8 @@
 #include "bootutil/bootutil_log.h"
 #include <usb/usb_device.h>
 
-#if defined(CONFIG_BOOT_SERIAL_UART) && defined(CONFIG_UART_CONSOLE)
-#error Zephyr UART console must been disabled if serial_adapter module is used.
+#if DT_SAME_NODE(DT_CHOSEN(zephyr_uart_mcumgr), DT_CHOSEN(zephyr_console))
+#error Zephyr UART console and boot serial UART must be two different devices
 #endif
 
 BOOT_LOG_MODULE_REGISTER(serial_adapter);
@@ -61,7 +61,7 @@ console_out(int c)
 }
 
 void
-console_write(const char *str, int cnt)
+console_write_boot(const char *str, int cnt)
 {
 	int i;
 
@@ -73,7 +73,7 @@ console_write(const char *str, int cnt)
 }
 
 int
-console_read(char *str, int str_size, int *newline)
+console_read_boot(char *str, int str_size, int *newline)
 {
 	char *line;
 	int len;
@@ -192,7 +192,7 @@ static int
 boot_uart_fifo_init(void)
 {
 #ifdef CONFIG_BOOT_SERIAL_UART
-	uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_uart_mcumgr));
 #elif CONFIG_BOOT_SERIAL_CDC_ACM
 	uart_dev = DEVICE_DT_GET_ONE(zephyr_cdc_acm_uart);
 #endif

--- a/boot/zephyr/single_loader.c
+++ b/boot/zephyr/single_loader.c
@@ -66,7 +66,7 @@ boot_image_validate(const struct flash_area *fa_p,
  *
  * @return		0 on success, error code otherwise
  */
-static int
+int
 boot_image_load_header(const struct flash_area *fa_p,
                        struct image_header *hdr)
 {
@@ -395,6 +395,47 @@ out:
     return rc;
 }
 #endif
+
+#ifdef MCUBOOT_DOWNGRADE_PREVENTION
+/**
+ * Compare image version numbers not including the build number
+ *
+ * @param ver1           Pointer to the first image version to compare.
+ * @param ver2           Pointer to the second image version to compare.
+ *
+ * @retval -1           If ver1 is strictly less than ver2.
+ * @retval 0            If the image version numbers are equal,
+ *                      (not including the build number).
+ * @retval 1            If ver1 is strictly greater than ver2.
+ */
+int
+boot_version_cmp(const struct image_version *ver1,
+                 const struct image_version *ver2)
+{
+    if (ver1->iv_major > ver2->iv_major) {
+        return 1;
+    }
+    if (ver1->iv_major < ver2->iv_major) {
+        return -1;
+    }
+    /* The major version numbers are equal, continue comparison. */
+    if (ver1->iv_minor > ver2->iv_minor) {
+        return 1;
+    }
+    if (ver1->iv_minor < ver2->iv_minor) {
+        return -1;
+    }
+    /* The minor version numbers are equal, continue comparison. */
+    if (ver1->iv_revision > ver2->iv_revision) {
+        return 1;
+    }
+    if (ver1->iv_revision < ver2->iv_revision) {
+        return -1;
+    }
+
+    return 0;
+}
+#endif /* MCUBOOT_DOWNGRADE_PREVENTION */
 
 /**
  * Gather information on image and prepare for booting.


### PR DESCRIPTION
Hello everyone, 

This PR follow a [previous issue](https://github.com/mcu-tools/mcuboot/issues/1211)  where I express my need of having a software version comparison before loading a new firmware through **Recovery uart** in a **Single application slot** configuration. 

The firmware update will be monitored by **MCUmgr**, and in order to stop the update from it, I defined a new error type that will stop update process. This MCUmgr feature is the [following open PR](https://github.com/apache/mynewt-newtmgr/pull/187)

I also added a commit allowing to use 2 UART peripheral at the same time one for Logs and the other for MCUmgr communication. 
 
It's my first MCUBoot upload so don't hesitate to make feedbacks or suggestions, I will take them into account ! 