### PR TITLE
sim: Remove unused variables

### DIFF
--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -52,8 +52,6 @@ Options:
 
 #[derive(Debug, Deserialize)]
 struct Args {
-    flag_help: bool,
-    flag_version: bool,
     flag_device: Option<DeviceName>,
     flag_align: Option<AlignArg>,
     cmd_sizes: bool,


### PR DESCRIPTION
Fix warning running the simulator due to variables that are not being used anymore.