### PR TITLE
boot_serial: Fix Zephyr include path for reboot.h

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -28,7 +28,7 @@
 #include "cbor_encode.h"
 
 #ifdef __ZEPHYR__
-#include <power/reboot.h>
+#include <sys/reboot.h>
 #include <sys/byteorder.h>
 #include <sys/__assert.h>
 #include <drivers/flash.h>


### PR DESCRIPTION
It is sys/reboot.h now.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>