### PR TITLE
ci: Add action for cancelling duplicate (and outdated) jobs

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2021 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+name: Cancelling Duplicates
+on:
+  workflow_run:
+    workflows: ["Espressif", "FIH hardening", "imgtool", "Mynewt", "Sim"]
+    types: ['requested']
+
+jobs:
+  cancel-duplicate-workflow-runs:
+    name: "Cancel duplicate workflow runs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: apache/airflow-cancel-workflow-runs@master
+        name: "Cancel duplicate workflow runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
This PR intends to add a new action to GitHub CI to force running jobs of a given PR to be cancelled once the same branch is updated, avoiding the CI wasting time testing outdated content.