### PR TITLE
ci: Define concurrency groups for cancelling duplicate jobs

### DIFF
--- a/.github/workflows/espressif.yaml
+++ b/.github/workflows/espressif.yaml
@@ -10,6 +10,10 @@ on:
 
 name: Espressif
 
+concurrency:
+  group: espressif-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   environment:
     strategy:

--- a/.github/workflows/fih_tests.yaml
+++ b/.github/workflows/fih_tests.yaml
@@ -6,6 +6,10 @@ on:
 
 name: FIH hardening
 
+concurrency:
+  group: fih-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   config:
     strategy:

--- a/.github/workflows/imgtool.yaml
+++ b/.github/workflows/imgtool.yaml
@@ -6,6 +6,10 @@ on:
 
 name: imgtool
 
+concurrency:
+  group: imgtool-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   environment:
     runs-on: ubuntu-latest

--- a/.github/workflows/mynewt.yaml
+++ b/.github/workflows/mynewt.yaml
@@ -7,6 +7,10 @@ on:
 
 name: Mynewt
 
+concurrency:
+  group: mynewt-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   environment:
     runs-on: ubuntu-latest

--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -7,6 +7,10 @@ on:
 
 name: Sim
 
+concurrency:
+  group: sim-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   environment:
     strategy:


### PR DESCRIPTION
This PR intends to add a new action to GitHub CI to force running jobs of a given PR to be cancelled once the same branch is updated, avoiding the CI wasting time testing outdated content.

https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency