### PR TITLE
espressif: Use "TAG" field from SOC_LOG* macros from IDF libraries

### DIFF
--- a/boot/espressif/hal/CMakeLists.txt
+++ b/boot/espressif/hal/CMakeLists.txt
@@ -155,16 +155,6 @@ if("${MCUBOOT_ARCH}" STREQUAL "xtensa")
         )
 endif()
 
-set_source_files_properties(
-    ${esp_idf_dir}/components/bootloader_support/src/bootloader_flash.c
-    ${esp_idf_dir}/components/esp_hw_support/port/${MCUBOOT_TARGET}/rtc_clk_init.c
-    ${esp_idf_dir}/components/esp_hw_support/port/${MCUBOOT_TARGET}/rtc_init.c
-    ${esp_idf_dir}/components/esp_hw_support/port/${MCUBOOT_TARGET}/rtc_clk.c
-    ${esp_idf_dir}/components/esp_hw_support/port/${MCUBOOT_TARGET}/rtc_time.c
-    PROPERTIES COMPILE_FLAGS
-    "-Wno-unused-variable"
-    )
-
 set(LINKER_SCRIPTS
     -T${esp_idf_dir}/components/esp_rom/${MCUBOOT_TARGET}/ld/${MCUBOOT_TARGET}.rom.ld
     -T${esp_idf_dir}/components/esp_rom/${MCUBOOT_TARGET}/ld/${MCUBOOT_TARGET}.rom.libgcc.ld

--- a/boot/espressif/hal/include/soc_log.h
+++ b/boot/espressif/hal/include/soc_log.h
@@ -9,7 +9,7 @@
 #include <mcuboot_config/mcuboot_logging.h>
 #include <esp_rom_sys.h>
 
-#define SOC_LOGE(tag, fmt, ...) MCUBOOT_LOG_ERR(fmt, ##__VA_ARGS__)
-#define SOC_LOGW(tag, fmt, ...) MCUBOOT_LOG_WRN(fmt, ##__VA_ARGS__)
-#define SOC_LOGI(tag, fmt, ...) MCUBOOT_LOG_INF(fmt, ##__VA_ARGS__)
-#define SOC_LOGD(tag, fmt, ...) MCUBOOT_LOG_DBG(fmt, ##__VA_ARGS__)
+#define SOC_LOGE(tag, fmt, ...) MCUBOOT_LOG_ERR("[%s] " fmt, tag, ##__VA_ARGS__)
+#define SOC_LOGW(tag, fmt, ...) MCUBOOT_LOG_WRN("[%s] " fmt, tag, ##__VA_ARGS__)
+#define SOC_LOGI(tag, fmt, ...) MCUBOOT_LOG_INF("[%s] " fmt, tag, ##__VA_ARGS__)
+#define SOC_LOGD(tag, fmt, ...) MCUBOOT_LOG_DBG("[%s] " fmt, tag, ##__VA_ARGS__)


### PR DESCRIPTION
This PR intends to make use of the TAG field from `SOC_LOG*` macros used by some IDF components.

Besides making the log messages more intuitive, it also brings the benefit of removing the need for passing `-Wno-unused-variable` compiler flag, since now TAG is being used as part of the log message.