### PR TITLE
imgtool: Update version 1.8.1 after PR#1217 been merged.

### DIFF
--- a/scripts/imgtool/__init__.py
+++ b/scripts/imgtool/__init__.py
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-imgtool_version = "1.8.0"
+imgtool_version = "1.8.1"


### PR DESCRIPTION
Since imgtool supports larger align value, and align_max. Updating
https://pypi.org/project/imgtool is a must.

Signed-off-by: Michel Jaouen <michel.jaouen@st.com>