### PR TITLE
bootutil: miscellaneous improvements to code

### DIFF
--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -82,8 +82,10 @@ struct boot_status {
     uint8_t swap_type;    /* The type of swap in effect */
     uint32_t swap_size;   /* Total size of swapped image */
 #ifdef MCUBOOT_ENC_IMAGES
+#define BOOT_UNINITIALIZED_KEY_FILL 0xFF
     uint8_t enckey[BOOT_NUM_SLOTS][BOOT_ENC_KEY_ALIGN_SIZE];
 #if MCUBOOT_SWAP_SAVE_ENCTLV
+#define BOOT_UNINITIALIZED_TLV_FILL 0xFF
     uint8_t enctlv[BOOT_NUM_SLOTS][BOOT_ENC_TLV_ALIGN_SIZE];
 #endif
 #endif
@@ -261,7 +263,7 @@ fih_int bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig,
 
 fih_int boot_fih_memequal(const void *s1, const void *s2, size_t n);
 
-int boot_magic_compatible_check(uint8_t tbl_val, uint8_t val);
+bool boot_magic_compatible_check(uint8_t tbl_val, uint8_t val);
 uint32_t boot_status_sz(uint32_t min_write_sz);
 uint32_t boot_trailer_sz(uint32_t min_write_sz);
 int boot_status_entries(int image_index, const struct flash_area *fap);

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -187,15 +187,15 @@ boot_swap_info_off(const struct flash_area *fap)
  * @param val                   The magic value in a trailer, encoded as a
  *                                  BOOT_MAGIC_[...].
  *
- * @return                      1 if the two values are compatible;
- *                              0 otherwise.
+ * @return                      true - if the two values are compatible;
+ *                              false - otherwise.
  */
-int
+bool
 boot_magic_compatible_check(uint8_t tbl_val, uint8_t val)
 {
     switch (tbl_val) {
     case BOOT_MAGIC_ANY:
-        return 1;
+        return true;
 
     case BOOT_MAGIC_NOTGOOD:
         return val != BOOT_MAGIC_GOOD;
@@ -224,7 +224,7 @@ bool bootutil_buffer_is_erased(const struct flash_area *area,
     uint8_t *u8b;
     uint8_t erased_val;
 
-    if (buffer == NULL || len == 0) {
+    if ((area == NULL) || (buffer == NULL) || (len == 0)) {
         return false;
     }
 
@@ -244,10 +244,10 @@ boot_read_flag(const struct flash_area *fap, uint8_t *flag, uint32_t off)
     int rc;
 
     rc = flash_area_read(fap, off, flag, sizeof *flag);
-    if (rc < 0) {
+    if (rc != 0) {
         return BOOT_EFLASH;
     }
-    if (bootutil_buffer_is_erased(fap, flag, sizeof *flag)) {
+    if (*flag == flash_area_erased_val(fap)) {
         *flag = BOOT_FLAG_UNSET;
     } else {
         *flag = boot_flag_decode(*flag);
@@ -274,7 +274,7 @@ boot_read_swap_state(const struct flash_area *fap,
 
     off = boot_magic_off(fap);
     rc = flash_area_read(fap, off, magic, BOOT_MAGIC_SZ);
-    if (rc < 0) {
+    if (rc != 0) {
         return BOOT_EFLASH;
     }
     if (bootutil_buffer_is_erased(fap, magic, BOOT_MAGIC_SZ)) {
@@ -285,7 +285,7 @@ boot_read_swap_state(const struct flash_area *fap,
 
     off = boot_swap_info_off(fap);
     rc = flash_area_read(fap, off, &swap_info, sizeof swap_info);
-    if (rc < 0) {
+    if (rc != 0) {
         return BOOT_EFLASH;
     }
 
@@ -300,7 +300,7 @@ boot_read_swap_state(const struct flash_area *fap,
     }
 
     rc = boot_read_copy_done(fap, &state->copy_done);
-    if (rc) {
+    if (rc != 0) {
         return BOOT_EFLASH;
     }
 

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -79,15 +79,11 @@ key_unwrap(const uint8_t *wrapped, uint8_t *enckey)
 
     bootutil_aes_kw_init(&aes_kw);
     rc = bootutil_aes_kw_set_unwrap_key(&aes_kw, bootutil_enc_key.key, *bootutil_enc_key.len);
-    if (rc != 0) {
-        goto done;
-    }
-    rc = bootutil_aes_kw_unwrap(&aes_kw, wrapped, TLV_ENC_KW_SZ, enckey, BOOT_ENC_KEY_SIZE);
-    if (rc != 0) {
-        goto done;
+    
+    if (rc == 0) {
+        rc = bootutil_aes_kw_unwrap(&aes_kw, wrapped, TLV_ENC_KW_SZ, enckey, BOOT_ENC_KEY_SIZE);
     }
 
-done:
     bootutil_aes_kw_drop(&aes_kw);
     return rc;
 }
@@ -333,7 +329,7 @@ hkdf(uint8_t *ikm, uint16_t ikm_len, uint8_t *info, uint16_t info_len,
 
     bootutil_hmac_sha256_init(&hmac);
 
-    memset(salt, 0, BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
+    (void)memset(salt, 0, BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
     rc = bootutil_hmac_sha256_set_key(&hmac, salt, BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
     if (rc != 0) {
         goto error;
@@ -663,7 +659,7 @@ boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey)
         return -1;
     }
 
-    memset(counter, 0, BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE);
+    (void)memset(counter, 0, BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE);
     rc = bootutil_aes_ctr_decrypt(&aes_ctr, counter, &buf[EC_CIPHERKEY_INDEX], BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE, 0, enckey);
     if (rc != 0) {
         bootutil_aes_ctr_drop(&aes_ctr);
@@ -728,7 +724,7 @@ boot_enc_load(struct enc_key_data *enc_state, int image_index,
 
 #if MCUBOOT_SWAP_SAVE_ENCTLV
     buf = bs->enctlv[slot];
-    memset(buf, 0xff, BOOT_ENC_TLV_ALIGN_SIZE);
+    (void)memset(buf, BOOT_UNINITIALIZED_TLV_FILL, BOOT_ENC_TLV_ALIGN_SIZE);
 #endif
 
     rc = flash_area_read(fap, off, buf, EXPECTED_ENC_LEN);

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -209,9 +209,9 @@ bootutil_find_key(uint8_t *keyhash, uint8_t keyhash_len)
     bootutil_sha256_context sha256_ctx;
     int i;
     const struct bootutil_key *key;
-    uint8_t hash[32];
+    uint8_t hash[BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE];
 
-    if (keyhash_len > 32) {
+    if (keyhash_len != BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE) {
         return -1;
     }
 
@@ -416,7 +416,7 @@ bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
             /*
              * Determine which key we should be checking.
              */
-            if (len > 32) {
+            if (len != BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE) {
                 rc = -1;
                 goto out;
             }

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -386,9 +386,11 @@ void
 boot_status_reset(struct boot_status *bs)
 {
 #ifdef MCUBOOT_ENC_IMAGES
-    memset(&bs->enckey, 0xff, BOOT_NUM_SLOTS * BOOT_ENC_KEY_ALIGN_SIZE);
+    (void)memset(&bs->enckey, BOOT_UNINITIALIZED_KEY_FILL,
+                 BOOT_NUM_SLOTS * BOOT_ENC_KEY_SIZE);
 #if MCUBOOT_SWAP_SAVE_ENCTLV
-    memset(&bs->enctlv, 0xff, BOOT_NUM_SLOTS * BOOT_ENC_TLV_ALIGN_SIZE);
+    (void)memset(&bs->enctlv, BOOT_UNINITIALIZED_TLV_FILL,
+                 BOOT_NUM_SLOTS * BOOT_ENC_TLV_ALIGN_SIZE);
 #endif
 #endif /* MCUBOOT_ENC_IMAGES */
 

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -110,8 +110,7 @@ swap_read_status_bytes(const struct flash_area *fap,
         if (rc < 0) {
             return BOOT_EFLASH;
         }
-
-        if (bootutil_buffer_is_erased(fap, &status, 1)) {
+        if (status == flash_area_erased_val(fap)) {
             if (found && !found_idx) {
                 found_idx = i;
             }

--- a/boot/bootutil/src/tlv.c
+++ b/boot/bootutil/src/tlv.c
@@ -98,7 +98,9 @@ bootutil_tlv_iter_next(struct image_tlv_iter *it, uint32_t *off, uint16_t *len,
     struct image_tlv tlv;
     int rc;
 
-    if (it == NULL || it->hdr == NULL || it->fap == NULL) {
+    if (it == NULL || it->hdr == NULL || it->fap == NULL ||
+        off == NULL || len == NULL) {
+
         return -1;
     }
 


### PR DESCRIPTION
Recently we have had a code review of our bootloader project based on mcuboot.
Here are some fixed we made to common files as result of code review.

- add additional input params check
- introduce defines instead of hardcoded values
- refactor some excessive goto statements