### PR TITLE
espressif: Improve CI script for easing local validation

### DIFF
--- a/.github/workflows/espressif.yaml
+++ b/.github/workflows/espressif.yaml
@@ -23,7 +23,7 @@ jobs:
         - "sign-rsa2048,sign-rsa3072,sign-ec256,sign-ed25519"
     runs-on: ubuntu-latest
     env:
-      MCUBOOT_TARGET: ${{ matrix.targets }}
+      MCUBOOT_TARGETS: ${{ matrix.targets }}
       MCUBOOT_FEATURES: ${{ matrix.features }}
     steps:
     - uses: actions/checkout@v2

--- a/ci/espressif_run.sh
+++ b/ci/espressif_run.sh
@@ -16,8 +16,8 @@ prepare_environment() {
 }
 
 build_mcuboot() {
-  local target=${MCUBOOT_TARGET}
-  local feature=${1}
+  local target=${1}
+  local feature=${2}
   local toolchain_file="${ESPRESSIF_ROOT}/tools/toolchain-${target}.cmake"
   local mcuboot_config="${ESPRESSIF_ROOT}/bootloader.conf"
   local build_dir=".build-${target}"
@@ -43,9 +43,12 @@ prepare_environment
 
 if [ -n "${MCUBOOT_FEATURES}" ]; then
   IFS=','
-  read -ra feature_list <<< "${MCUBOOT_FEATURES}"
-  for feature in "${feature_list[@]}"; do
-    echo "Building MCUboot with support for \"${feature}\""
-    build_mcuboot "${feature}"
+  read -ra target_list <<< "${MCUBOOT_TARGETS}"
+  for target in "${target_list[@]}"; do
+    read -ra feature_list <<< "${MCUBOOT_FEATURES}"
+    for feature in "${feature_list[@]}"; do
+      echo "Building MCUboot for \"${target}\" with support for \"${feature}\""
+      build_mcuboot "${target}" "${feature}"
+    done
   done
 fi


### PR DESCRIPTION
## Summary

This PR intends to improve the Espressif port CI script for enabling a quick local validation that the build passes for multiple Espressif targets.

## Impact

No impact to actual code, just for CI infra

## Testing
On the host PC, build the Espressif port for the currently supported chips with:
```bash
MCUBOOT_TARGETS="esp32,esp32c3,esp32s2" \
MCUBOOT_FEATURES="sign-rsa2048,sign-rsa3072,sign-ec256,sign-ed25519" \
./ci/espressif_run.sh
```