### PR TITLE
allow leading zeros in version number

### DIFF
--- a/scripts/imgtool/version.py
+++ b/scripts/imgtool/version.py
@@ -28,7 +28,7 @@ SemiSemVersion = namedtuple('SemiSemVersion', ['major', 'minor', 'revision',
                                                'build'])
 
 version_re = re.compile(
-    r"""^([1-9]\d*|0)(\.([1-9]\d*|0)(\.([1-9]\d*|0)(\+([1-9]\d*|0))?)?)?$""")
+    r"""^([0-9]\d*|0)(\.([0-9]\d*|0)(\.([0-9]\d*|0)(\+([0-9]\d*|0))?)?)?$""")
 
 
 def decode_version(text):


### PR DESCRIPTION
I could not find a reason why leading zeros in version numbers should be filtered out, so I changed that part of the checking regex. As a result I can now use version numbers like `01.01`, which lead to the same image header as `1.1` .