### PR TITLE
boot: add precise check of the image size

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -387,3 +387,27 @@ boot_write_enc_key(const struct flash_area *fap, uint8_t slot,
     return 0;
 }
 #endif
+
+uint32_t bootutil_max_image_size(const struct flash_area *fap)
+{
+#if defined(MCUBOOT_SWAP_USING_SCRATCH)
+    return boot_status_off(fap);
+#elif defined(MCUBOOT_SWAP_USING_MOVE)
+    struct flash_sector sector;
+    /* get the last sector offset */
+    int rc = flash_area_sector_from_off(boot_status_off(fap), &sector);
+    if (rc) {
+        BOOT_LOG_ERR("Unable to determine flash sector of the image trailer");
+        return 0; /* Returning of zero here should cause any check which uses
+                   * this value to fail.
+                   */
+    }
+    return flash_sector_get_off(&sector);
+#elif defined(MCUBOOT_OVERWRITE_ONLY)
+    return boot_swap_info_off(fap);
+#elif defined(MCUBOOT_DIRECT_XIP)
+    return boot_swap_info_off(fap);
+#elif defined(MCUBOOT_RAM_LOAD)
+    return boot_swap_info_off(fap);
+#endif
+}

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -463,6 +463,8 @@ struct bootsim_ram_info *bootsim_get_ram_info(void);
     (flash_area_read((fap), (start), (output), (size)))
 #endif /* MCUBOOT_RAM_LOAD */
 
+uint32_t bootutil_max_image_size(const struct flash_area *fap);
+
 #ifdef __cplusplus
 }
 #endif

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -376,6 +376,11 @@ bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
         goto out;
     }
 
+    if (it.tlv_end > bootutil_max_image_size(fap)) {
+        rc = -1;
+        goto out;
+    }
+
     /*
      * Traverse through all of the TLVs, performing any checks we know
      * and are able to do.

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1522,14 +1522,19 @@ fn install_image(flash: &mut SimMultiFlash, slot: &SlotInfo, len: ImageSize,
                 // This computation is incorrect, and we need to figure out the correct size.
                 // c::boot_status_sz(dev.align() as u32) as usize
                 16 + 4 * dev.align()
-            } else {
+            } else if Caps::SwapUsingMove.present() {
                 let sector_size = dev.sector_iter().next().unwrap().size as u32;
                 align_up(c::boot_trailer_sz(dev.align() as u32), sector_size) as usize
+            } else if Caps::SwapUsingScratch.present() {
+                c::boot_trailer_sz(dev.align() as u32) as usize
+            } else {
+                panic!("The maximum image size can't be calculated.")
             };
             let tlv_len = tlv.estimate_size();
             info!("slot: 0x{:x}, HDR: 0x{:x}, trailer: 0x{:x}",
                 slot_len, HDR_SIZE, trailer);
             slot_len - HDR_SIZE - trailer - tlv_len
+
         }
     };
 

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -49,6 +49,7 @@ macro_rules! sim_test {
 sim_test!(bad_secondary_slot, make_bad_secondary_slot_image(), run_signfail_upgrade());
 sim_test!(secondary_trailer_leftover, make_erased_secondary_image(), run_secondary_leftover_trailer());
 sim_test!(bootstrap, make_bootstrap_image(), run_bootstrap());
+sim_test!(oversized_bootstrap, make_oversized_bootstrap_image(), run_oversized_bootstrap());
 sim_test!(norevert_newimage, make_no_upgrade_image(&NO_DEPS), run_norevert_newimage());
 sim_test!(basic_revert, make_image(&NO_DEPS, true), run_basic_revert());
 sim_test!(revert_with_fails, make_image(&NO_DEPS, false), run_revert_with_fails());

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -56,6 +56,10 @@ sim_test!(revert_with_fails, make_image(&NO_DEPS, false), run_revert_with_fails(
 sim_test!(perm_with_fails, make_image(&NO_DEPS, true), run_perm_with_fails());
 sim_test!(perm_with_random_fails, make_image(&NO_DEPS, true), run_perm_with_random_fails(5));
 sim_test!(norevert, make_image(&NO_DEPS, true), run_norevert());
+
+#[cfg(not(feature = "max-align-32"))]
+sim_test!(oversized_secondary_slot, make_oversized_secondary_slot_image(), run_oversizefail_upgrade());
+
 sim_test!(status_write_fails_complete, make_image(&NO_DEPS, true), run_with_status_fails_complete());
 sim_test!(status_write_fails_with_reset, make_image(&NO_DEPS, true), run_with_status_fails_with_reset());
 sim_test!(downgrade_prevention, make_image(&REV_DEPS, true), run_nodowngrade());


### PR DESCRIPTION
It is possible that image in the slot is so big
that MCUboot swap metadata will interfere with
its content during the swap operation.

This patch introduces additional check to the image
validation procedure.

added `oversized_bootstrap` test for ensure that too big image will be rejected while bootsraping
added `oversized_secondary_slot` test for ensure that too big image upgrade attempt will be rejected. I doesn't work for `max-align-32` feature due to not precise operations on flash image in sim code. Fixing of this problem is out of scope for this PR.

Objective is to fix issue signaled by #1146
this patch is also successor of #1140