### PR TITLE
imgtool: skip erased values in trailer generation

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -242,15 +242,15 @@ class Image():
                                                   self.save_enctlv,
                                                   self.enctlv_len)
                 trailer_addr = (self.base_addr + self.slot_size) - trailer_size
-                padding = bytearray([self.erased_val] * 
-                                    (trailer_size - len(self.boot_magic)))
-                padding += self.boot_magic
                 if self.confirm and not self.overwrite_only:
                     magic_size = 16
                     magic_align_size = align_up(magic_size, self.max_align)
                     image_ok_idx = -(magic_align_size + self.max_align)
-                    padding[image_ok_idx] = 0x01  # image_ok = 0x01
-                h.puts(trailer_addr, bytes(padding))
+                    flag = bytearray([self.erased_val] * magic_align_size)
+                    flag[0] = 0x01 # image_ok = 0x01
+                    h.puts(trailer_addr + image_ok_idx, bytes(flag))
+                h.puts(trailer_addr + (trailer_size - len(self.boot_magic)),
+                       bytes(self.boot_magic))
             h.tofile(path, 'hex')
         else:
             if self.pad:


### PR DESCRIPTION
When generating an image with trailer (--pad or --confirm), the
imgtool also adds the erased values into that area. This is not
wanted for flash drivers which use ECC and treat writing erased
values as a real write action, which cannot be overwritten anymore.
See issue #1288

For now the change in implementation is always to skip these in the trailer, but i'm not sure if this suits another purpose to still add these? I always can make an option in the tool not to change the current image generation. 

image trailer before change:
```
$ tail -n 4 zephyr/zephyr.encrypted.confirmed.signed.hex.original 
:020000040807EB
:10FFE000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF21
:10FFF00077C295F360D2EF7F3552500F2CB67980DF
:00000001FF
```
image trailer after change:
```
$ tail -n 4 zephyr/zephyr.encrypted.confirmed.signed.hex 
:0897800062AD74BDB5788A6387
:020000040807EB
:10FFF00077C295F360D2EF7F3552500F2CB67980DF
:00000001FF
```