### PR TITLE
Mbed port improvements

### DIFF
--- a/boot/mbed/CMakeLists.txt
+++ b/boot/mbed/CMakeLists.txt
@@ -1,0 +1,61 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Mbed-MCUboot Port
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+get_filename_component(BOOT_UTIL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../bootutil REALPATH)
+
+set(LIB_TARGET mbed-mcuboot)
+set(LIB_BOOTUTIL bootutil)
+
+add_library(${LIB_TARGET} STATIC)
+
+target_include_directories(${LIB_TARGET}
+    PUBLIC
+        include
+        ${BOOT_UTIL_DIR}/include
+        ${BOOT_UTIL_DIR}/src
+)
+
+target_sources(${LIB_TARGET}
+    PRIVATE
+        mcuboot_main.cpp
+        app_enc_keys.c
+        src/flash_map_backend.cpp
+        src/secondary_bd.cpp
+)
+
+target_link_libraries(${LIB_TARGET}
+    PUBLIC
+        bootutil  # Cross-dependency
+        mbed-mbedtls
+        mbed-storage-flashiap
+        mbed-storage-blockdevice
+)
+
+if("_RTE_" IN_LIST MBED_CONFIG_DEFINITIONS)
+    target_link_libraries(${LIB_TARGET}
+    PUBLIC
+        mbed-os
+    )   
+else()
+    target_link_libraries(${LIB_TARGET}
+    PUBLIC
+        mbed-baremetal
+    )   
+endif()
+
+# The cross-dependency requires that bootutil have access to the mbed port's 
+# include directory and is linked with the appropriate mbed-specific libraries. 
+target_include_directories(${LIB_BOOTUTIL}
+    PUBLIC
+        include
+)
+
+target_link_libraries(${LIB_BOOTUTIL}
+    PUBLIC
+        mbed-mcuboot
+        mbed-mbedtls
+)

--- a/boot/mbed/include/mcuboot_config/mcuboot_logging.h
+++ b/boot/mbed/include/mcuboot_config/mcuboot_logging.h
@@ -36,13 +36,6 @@
 #define MCUBOOT_LOG_LEVEL MCUBOOT_LOG_LEVEL_OFF
 #endif
 
-#if MCUBOOT_LOG_LEVEL == MCUBOOT_LOG_LEVEL_OFF
-#define MBED_CONF_MBED_TRACE_ENABLE 0
-#else
-#define MBED_CONF_MBED_TRACE_ENABLE 1
-#define MCUBOOT_HAVE_LOGGING
-#endif
-
 #if MCUBOOT_LOG_LEVEL == MCUBOOT_LOG_LEVEL_ERROR
 #define MBED_TRACE_MAX_LEVEL TRACE_LEVEL_ERROR
 #elif MCUBOOT_LOG_LEVEL == MCUBOOT_LOG_LEVEL_WARNING
@@ -54,7 +47,7 @@
 #endif
 
 #define TRACE_GROUP "MCUb"
-#include "mbed_trace.h"
+#include "mbed-trace/mbed_trace.h"
 #include "bootutil/ignore.h"
 
 #define MCUBOOT_LOG_MODULE_DECLARE(domain)  /* ignore */

--- a/boot/mbed/mbed_lib.json
+++ b/boot/mbed/mbed_lib.json
@@ -17,6 +17,11 @@
             "macro_name": "MCUBOOT_SLOT_SIZE",
             "required": true
         },
+        "header-size": {
+            "help": "Size of the header info section, in bytes. Target-dependent, please set on a per-target basis.",
+            "macro_name": "MCUBOOT_HEADER_SIZE",
+            "value": "0x1000"
+        },
         "scratch-address": {
             "help": "Start address of the scratch area. If needed, please set on a per-target basis.",
             "macro_name": "MCUBOOT_SCRATCH_START_ADDR"
@@ -61,6 +66,12 @@
         "overwrite-only-fast": {
             "help": "Only erase and overwrite those primary slot sectors needed to install the new image, rather than the entire image slot.",
             "macro_name": "MCUBOOT_OVERWRITE_ONLY_FAST",
+            "accepted_values": [true, null],
+            "value": null
+        },
+        "log-enable": {
+            "help": "Enable MCUboot logging. Must also enable mbed-trace",
+            "macro_name": "MCUBOOT_HAVE_LOGGING",
             "accepted_values": [true, null],
             "value": null
         },

--- a/boot/mbed/mcuboot_main.cpp
+++ b/boot/mbed/mcuboot_main.cpp
@@ -22,7 +22,7 @@
 #include "bootutil/bootutil.h"
 #include "bootutil/image.h"
 #include "hal/serial_api.h"
-#include "mbed_application.h"
+#include "platform/mbed_application.h"
 
 #if (MCUBOOT_CRYPTO_BACKEND == MBEDTLS)
 #include "mbedtls/platform.h"
@@ -50,10 +50,12 @@ int main()
 {
     int rc;
 
+#ifdef MCUBOOT_HAVE_LOGGING
     mbed_trace_init();
 #if MCUBOOT_LOG_BOOTLOADER_ONLY
     mbed_trace_include_filters_set("MCUb,BL");
-#endif
+#endif //MCUBOOT_LOG_BOOTLOADER_ONLY
+#endif //MCUBOOT_HAVE_LOGGING
 
     tr_info("Starting MCUboot");
     

--- a/boot/mbed/src/flash_map_backend.cpp
+++ b/boot/mbed/src/flash_map_backend.cpp
@@ -91,15 +91,22 @@ int flash_area_open(uint8_t id, const struct flash_area** fapp) {
     fap->fa_device_id = 0; // not relevant
 
     mbed::BlockDevice* bd = flash_map_bd[id];
-    fap->fa_size = (uint32_t) bd->size();
-
+    
     /* Only initialize if this isn't a nested call to open the flash area */
     if (open_count[id] == 1) {
         MCUBOOT_LOG_DBG("initializing flash area %d...", id);
-        return bd->init();
+        int ret = bd->init();
+        if (ret)
+        {
+            MCUBOOT_LOG_ERR("initializing flash area failed %d", ret);
+            return ret;
+        }
     } else {
         return 0;
     }
+
+    fap->fa_size = (uint32_t) bd->size();
+    return 0;
 }
 
 void flash_area_close(const struct flash_area* fap) {

--- a/boot/mbed/src/secondary_bd.cpp
+++ b/boot/mbed/src/secondary_bd.cpp
@@ -21,7 +21,7 @@
 
 #include "flash_map_backend/secondary_bd.h"
 #include "platform/mbed_toolchain.h"
-#include "FlashIAPBlockDevice.h"
+#include "FlashIAP/FlashIAPBlockDevice.h"
 
 /**
  * For an XIP build, the secondary BD is provided by mcuboot by default.


### PR DESCRIPTION
These changes are important in the context of developing an application with the latest versions of mbed-os and mbed-tools.

Change list:
Add CMake support - compatible with a new command-line tool for MbedOS; `mbed-tools` (Mbed CLI 2)
Add logging enable parameter in mbed_lib.json - enable logging from .json configuration file
Add header size parameter in mbed_lib.json
Fix mbed files paths
Fix calling to BlockDevice::size before initialization - we need to initialize BlockDevice before getting its size. 

Signed-off-by: George Beckstein george.beckstein@gmail.com