### PR TITLE
Allow downgrade prevention without the need to overwrite the received…

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -615,7 +615,7 @@ boot_check_header_erased(struct boot_loader_state *state, int slot)
 #if (BOOT_IMAGE_NUMBER > 1) || \
     defined(MCUBOOT_DIRECT_XIP) || \
     defined(MCUBOOT_RAM_LOAD) || \
-    (defined(MCUBOOT_OVERWRITE_ONLY) && defined(MCUBOOT_DOWNGRADE_PREVENTION))
+    defined(MCUBOOT_DOWNGRADE_PREVENTION)
 /**
  * Compare image version numbers not including the build number
  *
@@ -742,7 +742,7 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
         goto out;
     }
 
-#if defined(MCUBOOT_OVERWRITE_ONLY) && defined(MCUBOOT_DOWNGRADE_PREVENTION)
+#if defined(MCUBOOT_DOWNGRADE_PREVENTION)
     if (slot != BOOT_PRIMARY_SLOT) {
         /* Check if version of secondary slot is sufficient */
         rc = boot_version_cmp(

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -514,7 +514,6 @@ choice BOOT_DOWNGRADE_PREVENTION_CHOICE
 
 config MCUBOOT_DOWNGRADE_PREVENTION
 	bool "SW based downgrade prevention"
-	depends on BOOT_UPGRADE_ONLY
 	help
 	  Prevent downgrades by enforcing incrementing version numbers.
 	  When this option is set, any upgrade must have greater major version

--- a/docs/design.md
+++ b/docs/design.md
@@ -1268,9 +1268,8 @@ vulnerable version of its firmware.
 
 During the software based downgrade prevention the image version numbers are
 compared. This feature is enabled with the `MCUBOOT_DOWNGRADE_PREVENTION`
-option. In this case downgrade prevention is only available when the
-overwrite-based image update strategy is used (i.e. `MCUBOOT_OVERWRITE_ONLY`
-is set).
+option. If the new image has a lower version number, it will be erased from
+the flash; otherwise the configured swapping method is used.
 
 ### [Hardware-based downgrade prevention](#hw-downgrade-prevention)
 


### PR DESCRIPTION
In certain scenarios, additional tests in the updated firmware are performed to determine the success of the update.
Nevertheless, in those cases also the downgrade prevention is of interest. 

This PR throws out the need activate the overwrite of the old image to avoid bricking of the device if a test run didn't work out.

The older image file will be deleted if the version is less than the current image version, to avoid more impact on the loader code (e.g. to deactivate the pending flag).