### PR TITLE
readme.md: remove "IDF" from Espressif reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Currently, MCUboot works with the following operating systems and SoCs:
 - [Apache NuttX](https://nuttx.apache.org/)
 - [RIOT](https://www.riot-os.org/)
 - [Mbed OS](https://os.mbed.com/)
-- [Espressif IDF](https://idf.espressif.com/)
+- [Espressif](https://www.espressif.com/)
 - [Cypress/Infineon](https://www.cypress.com/)
 
 RIOT is supported only as a boot target. We will accept any new
@@ -46,7 +46,7 @@ operating systems and SoCs:
 - [Apache NuttX](docs/readme-nuttx.md)
 - [RIOT](docs/readme-riot.md)
 - [Mbed OS](docs/readme-mbed.md)
-- [Espressif IDF](docs/readme-espressif.md)
+- [Espressif](docs/readme-espressif.md)
 - [Cypress/Infineon](boot/cypress/readme.md)
 
 There are also instructions for the [Simulator](sim/README.rst).


### PR DESCRIPTION
This change is to avoid misunderstanding as IDF is not supported
on top of MCUboot.
The Espressif port acts as a bare metal bootloader that can be
used on Espressif chips to boot supported OSes (like Zephyr or NuttX).

Signed-off-by: Almir Okato <almir.okato@espressif.com>