### PR TITLE
imgtool: change --max-align default value

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -132,7 +132,7 @@ class Image():
                  slot_size=0, max_sectors=DEFAULT_MAX_SECTORS,
                  overwrite_only=False, endian="little", load_addr=0,
                  rom_fixed=None, erased_val=None, save_enctlv=False,
-                 security_counter=None, max_align=DEFAULT_MAX_ALIGN):
+                 security_counter=None, max_align=None):
 
         if load_addr and rom_fixed:
             raise click.UsageError("Can not set rom_fixed and load_addr at the same time")
@@ -155,7 +155,7 @@ class Image():
         self.enckey = None
         self.save_enctlv = save_enctlv
         self.enctlv_len = 0
-        self.max_align = DEFAULT_MAX_ALIGN if max_align is None else int(max_align)
+        self.max_align = max(DEFAULT_MAX_ALIGN, align) if max_align is None else int(max_align)
 
         if self.max_align == DEFAULT_MAX_ALIGN:
             self.boot_magic = bytes([

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -295,7 +295,10 @@ class BasedIntParamType(click.ParamType):
 @click.option('--align', type=click.Choice(['1', '2', '4', '8', '16', '32']),
               required=True)
 @click.option('--max-align', type=click.Choice(['8', '16', '32']),
-              required=False)
+              required=False,
+              help='Maximum flash alignment. Set if flash alignment of the '
+              'primary and secondary slot differ and any of them is larger '
+              'than 8.')
 @click.option('--public-key-format', type=click.Choice(['hash', 'full']),
               default='hash', help='In what format to add the public key to '
               'the image manifest: full key or hash of the key.')


### PR DESCRIPTION
The value of `--max-align` parameter passed to imgtool can never be
less than the value of `--align` parameter. At present the default
value of `--max-align` is fixed at 8. This forces user to pass the
parameter even when its value can be safely inferred.

Change the default value of the `--max-align` parameter to the larger
of the two values: `--align` or 8. Consequently, the user is required
to pass the parameter only if the flash alignment of the primary and
secondary slot differ.