### PR TITLE
single_loader: Fix hard coded buffer size in decryption function

### DIFF
--- a/boot/zephyr/single_loader.c
+++ b/boot/zephyr/single_loader.c
@@ -216,7 +216,7 @@ decrypt_region_inplace(struct boot_loader_state *state,
     uint32_t blk_sz;
     uint8_t image_index;
 
-    static uint8_t buf[1024] __attribute__((aligned));
+    uint8_t buf[sz] __attribute__((aligned));
     assert(sz <= sizeof buf);
 
     bytes_copied = 0;


### PR DESCRIPTION
Hello,
In https://github.com/mcu-tools/mcuboot/pull/1255, Buffer use to decrypt a flash section is hardcoded to a size of 1024. As far as I understood, as on some chip, erase can only be done per page (for instance on nordic nRF52840 which has flash pages of 4kB), buffer size should correspond to a page size. 
Signed-off-by: Mateo Ligne <mateo.ligne@netatmo.com>