### PR TITLE
boot_serial: Remove unneeded carriage return at the end of frame

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -655,7 +655,7 @@ boot_serial_output(void)
     totlen = base64_encode(buf, totlen, encoded_buf, 1);
 #endif
     boot_uf->write(encoded_buf, totlen);
-    boot_uf->write("\n\r", 2);
+    boot_uf->write("\n", 1);
     BOOT_LOG_INF("TX");
 }
 


### PR DESCRIPTION
The correct end of SMP frame, over console, is single '\n'.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

Details here: https://github.com/zephyrproject-rtos/zephyr/blob/main/subsys/mgmt/mcumgr/lib/transport/smp-console.md