### PR TITLE
boot_serial: Fix buffer overflow in boot_serial_out

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -614,8 +614,8 @@ boot_serial_output(void)
     uint16_t crc;
     uint16_t totlen;
     char pkt_start[2] = { SHELL_NLIP_PKT_START1, SHELL_NLIP_PKT_START2 };
-    char buf[BOOT_SERIAL_OUT_MAX];
-    char encoded_buf[BASE64_ENCODE_SIZE(BOOT_SERIAL_OUT_MAX)];
+    char buf[BOOT_SERIAL_OUT_MAX + sizeof(*bs_hdr) + sizeof(crc) + sizeof(totlen)];
+    char encoded_buf[BASE64_ENCODE_SIZE(sizeof(buf))];
 
     data = bs_obuf;
     len = (uint32_t)cbor_state.payload_mut - (uint32_t)bs_obuf;


### PR DESCRIPTION
The buf buffer set to collect total console payload consisting
of total size (two bytes), SMP header (eigth bytes), data payload
(bs_obuf, BOOT_SERIAL_OUT_MAX) and CRC (two bytes), pior to base64
encoding has been set to size of BOOT_SERIAL_OUT_MAX.
This means that if output data len, in bs_obuf, would be longer than
BOOT_SERIAL_OUT_MAX - 8 - 2 - 2, then composing of the output buffer
would overflow.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>