### PR TITLE
boot_serial: Correct MGMT_ERR_EUNKNOWN value

### DIFF
--- a/boot/boot_serial/src/boot_serial_priv.h
+++ b/boot/boot_serial/src/boot_serial_priv.h
@@ -37,7 +37,7 @@ extern "C" {
  * From newtmgr.h
  */
 #define MGMT_ERR_OK             0
-#define MGMT_ERR_EUNKNOWN       2
+#define MGMT_ERR_EUNKNOWN       1
 #define MGMT_ERR_EINVAL         3
 #define MGMT_ERR_ENOTSUP        8
 


### PR DESCRIPTION
Should be 1, was 2.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>