### PR TITLE
boot_serial: Fix SMP echo sending incomplete CBOR container

### DIFF
--- a/boot/boot_serial/src/boot_serial_priv.h
+++ b/boot/boot_serial/src/boot_serial_priv.h
@@ -38,6 +38,7 @@ extern "C" {
  */
 #define MGMT_ERR_OK             0
 #define MGMT_ERR_EUNKNOWN       1
+#define MGMT_ERR_ENOMEM         2
 #define MGMT_ERR_EINVAL         3
 #define MGMT_ERR_ENOTSUP        8
 


### PR DESCRIPTION
In case when echo string would be too long to fit into buffer,
there would be no space left for container termination.
Due to lack of error checking such non-terminated container would
be sent out, where error response should be sent out instead.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

Depends on:
https://github.com/mcu-tools/mcuboot/pull/1321
https://github.com/mcu-tools/mcuboot/pull/1320