### PR TITLE
zephyr: add dropped sys_clock_disable definition

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -159,6 +159,8 @@ struct arm_vector_table {
     uint32_t reset;
 };
 
+extern void sys_clock_disable(void);
+
 static void do_boot(struct boot_rsp *rsp)
 {
     struct arm_vector_table *vt;


### PR DESCRIPTION
Missing extern definition will result in a warning during build.
Dropped in e9c6b4d7af7598fbd915868cf89383ff854d2241.

Signed-off-by: Robert Schulze <robert.schulze@deveritec.com>