### PR TITLE
 espressif: update Espressif documentation regarding secure features

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Currently MCUboot works with the following operating systems and SoCs:
 - [Apache NuttX](https://nuttx.apache.org/)
 - [RIOT](https://www.riot-os.org/)
 - [Mbed OS](https://os.mbed.com/)
-- [Espressif IDF](https://idf.espressif.com/)
+- [Espressif](https://www.espressif.com/)
 - [Cypress/Infineon](https://www.cypress.com/)
 
 RIOT is supported only as a boot target. We will accept any new port
@@ -44,7 +44,7 @@ The MCUboot documentation is composed of the following pages:
   - [Apache NuttX](readme-nuttx.md)
   - [RIOT](readme-riot.md)
   - [Mbed OS](readme-mbed.md)
-  - [Espressif IDF](readme-espressif.md)
+  - [Espressif](docs/readme-espressif.md)
   - [Cypress/Infineon](../boot/cypress/readme.md)
   - [Simulator](../sim/README.rst)
 - Testing


### PR DESCRIPTION
This PR adds instructions on the readme-espressif.md on how to encrypt data on the host.
Adds configuration and instructions for disabling/switch UART ROM Download Mode, needed by host data encryption.
Also fix Espressif information on the docs index page to reflect the main readme.md.