### PR TITLE
index.md: fix readme-espressif.md link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ The MCUboot documentation is composed of the following pages:
   - [Apache NuttX](readme-nuttx.md)
   - [RIOT](readme-riot.md)
   - [Mbed OS](readme-mbed.md)
-  - [Espressif](docs/readme-espressif.md)
+  - [Espressif](readme-espressif.md)
   - [Cypress/Infineon](../boot/cypress/readme.md)
   - [Simulator](../sim/README.rst)
 - Testing


### PR DESCRIPTION
Documentation index fix for Espressif readme.