### PR TITLE
imgtool: Added support for providing the signature by 3rd party

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -447,12 +447,14 @@ class Image():
             else:
                 sig = key.sign_digest(digest)
             tlv.add(key.sig_tlv(), sig)
+            self.signature = sig
         elif fixed_sig is not None and key is None:
             if public_key_format == 'hash':
                 tlv.add('KEYHASH', pubbytes)
             else:
                 tlv.add('PUBKEY', pub)
             tlv.add(pub_key.sig_tlv(), fixed_sig['value'])
+            self.signature = fixed_sig['value']
         else:
             raise click.UsageError("Can not sign using key and provide fixed-signature at the same time")
 

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -305,7 +305,7 @@ class Image():
         return cipherkey, ciphermac, pubk
 
     def create(self, key, public_key_format, enckey, dependencies=None,
-               sw_type=None, custom_tlvs=None, encrypt_keylen=128, clear=False, fixed_sig=None, pub_key=None):
+               sw_type=None, custom_tlvs=None, encrypt_keylen=128, clear=False, fixed_sig=None, pub_key=None, vector_to_sign=None):
         self.enckey = enckey
 
         # Calculate the hash of the public key
@@ -315,6 +315,8 @@ class Image():
             sha.update(pub)
             pubbytes = sha.digest()
         elif pub_key is not None:
+            if hasattr(pub_key, 'sign'):
+                print("sign the payload")
             pub = pub_key.get_public_bytes()
             sha = hashlib.sha256()
             sha.update(pub)
@@ -433,26 +435,34 @@ class Image():
 
         tlv.add('SHA256', digest)
 
-        if key is not None and fixed_sig is None:
-            if public_key_format == 'hash':
-                tlv.add('KEYHASH', pubbytes)
-            else:
-                tlv.add('PUBKEY', pub)
+        if public_key_format == 'hash':
+            tlv.add('KEYHASH', pubbytes)
+        else:
+            tlv.add('PUBKEY', pub)
 
+        if vector_to_sign == 'payload':
+            # Stop amending data to the image
+            # Just keep data vector which is expected to be sigend
+            print('export payload')
+            return
+        elif vector_to_sign == 'digest':
+            self.payload = digest
+            print('export digest')
+            return
+
+        if key is not None and fixed_sig is None:
             # `sign` expects the full image payload (sha256 done internally),
             # while `sign_digest` expects only the digest of the payload
 
             if hasattr(key, 'sign'):
+                print("sign the payload")
                 sig = key.sign(bytes(self.payload))
             else:
+                print("sign the digest")
                 sig = key.sign_digest(digest)
             tlv.add(key.sig_tlv(), sig)
             self.signature = sig
         elif fixed_sig is not None and key is None:
-            if public_key_format == 'hash':
-                tlv.add('KEYHASH', pubbytes)
-            else:
-                tlv.add('PUBKEY', pub)
             tlv.add(pub_key.sig_tlv(), fixed_sig['value'])
             self.signature = fixed_sig['value']
         else:

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -321,6 +321,10 @@ class BasedIntParamType(click.ParamType):
 @click.option('--sig-out', metavar='filename',
               help='Path to the file to which signature will be written'
               'The image signature will be encoded as base64 formatted string')
+@click.option('--vector-to-sign', type=click.Choice(['payload', 'digest']),
+              help='send to OUTFILE the payload or payload''s digest instead of'
+              'complied image. These data can be used for external image'
+              'signing')
 @click.command(help='''Create a signed or unsigned image\n
                INFILE and OUTFILE are parsed as Intel HEX if the params have
                .hex extension, otherwise binary format is used''')
@@ -329,7 +333,7 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
          endian, encrypt_keylen, encrypt, infile, outfile, dependencies,
          load_addr, hex_addr, erased_val, save_enctlv, security_counter,
          boot_record, custom_tlv, rom_fixed, max_align, clear, fix_sig,
-         fix_sig_pubkey, sig_out):
+         fix_sig_pubkey, sig_out, vector_to_sign):
 
     if confirm:
         # Confirmed but non-padded images don't make much sense, because
@@ -393,7 +397,8 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
         }
 
     img.create(key, public_key_format, enckey, dependencies, boot_record,
-               custom_tlvs, int(encrypt_keylen), clear, baked_signature, pub_key)
+               custom_tlvs, int(encrypt_keylen), clear, baked_signature, pub_key,
+               vector_to_sign)
     img.save(outfile, hex_addr)
 
     if sig_out is not None:

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -74,6 +74,11 @@ def load_signature(sigfile):
         signature = base64.b64decode(f.read())
         return signature
 
+def save_signature(sigfile, sig):
+    with open(sigfile, 'wb') as f:
+        signature = base64.b64encode(sig)
+        f.write(signature)
+
 def load_key(keyfile):
     # TODO: better handling of invalid pass-phrase
     key = keys.load(keyfile)
@@ -313,6 +318,9 @@ class BasedIntParamType(click.ParamType):
               'the signature calculated using the public key')
 @click.option('--fix-sig-pubkey', metavar='filename',
               help='public key relevant to fixed signature')
+@click.option('--sig-out', metavar='filename',
+              help='Path to the file to which signature will be written'
+              'The image signature will be encoded as base64 formatted string')
 @click.command(help='''Create a signed or unsigned image\n
                INFILE and OUTFILE are parsed as Intel HEX if the params have
                .hex extension, otherwise binary format is used''')
@@ -321,7 +329,7 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
          endian, encrypt_keylen, encrypt, infile, outfile, dependencies,
          load_addr, hex_addr, erased_val, save_enctlv, security_counter,
          boot_record, custom_tlv, rom_fixed, max_align, clear, fix_sig,
-         fix_sig_pubkey):
+         fix_sig_pubkey, sig_out):
 
     if confirm:
         # Confirmed but non-padded images don't make much sense, because
@@ -387,6 +395,10 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
     img.create(key, public_key_format, enckey, dependencies, boot_record,
                custom_tlvs, int(encrypt_keylen), clear, baked_signature, pub_key)
     img.save(outfile, hex_addr)
+
+    if sig_out is not None:
+        new_signature = img.get_signature()
+        save_signature(sig_out, new_signature)
 
 
 class AliasesGroup(click.Group):


### PR DESCRIPTION
The sign command was extended so it now allow to provide the signature
as base64 formatted RAW file using --fix-sig along with relevant public key
--fix-sig-pubkey.

This patch is added for support the case where the party which produces
the image dose not have access to the signing image key but must request
third party for the signature.

Possible steps for get an image sign are:

1. Generate the public key form the private key using openssl:
``` Console
openssl rsa -in ./bootloader/mcuboot/root-rsa-2048.pem -pubout -out root-rsa-2048-priv.pem -outform PEM -RSAPublicKey_out
```

2. Get the payload against to which the  signature should be generated:
``` console
./bootloader/mcuboot/scripts/imgtool.py sign -v 1.0.0 -H 0x200 -S 0x67000 --align 8  --fix-sig-pubkey ./root-rsa-2048-priv.pem --vector-to-sign payload  ./build/hellow/zephyr/zephyr.hex data_to_sign.bin
```
Worth to notice that all but ed25519 signature are generated using the payload. For ed25519 signature are generated basing only on the image digest (so need to use `--vector-to-sign digest`)

3. Generate the signature and save it as base64 string
``` console
openssl dgst -sha256  -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:32 -sigopt rsa_mgf1_md:sha256 -sign ./bootloader/mcuboot/root-rsa-2048.pem -out openssl_sig.sig data_to_sig.bin

openssl base64 -in openssl_sig.sig -out openssl_sig_base64.sig
```

4. Add the the signature generated remotely to the image.
``` console
./bootloader/mcuboot/scripts/imgtool.py sign -v 1.0.0  -H 0x200 -S 0x67000 --align 8 --fix-sig openssl_sig_base64.sig --fix-sig-pubkey ./root-rsa-2048-priv.pem --public-key-format full  ./build/hellow/zephyr/zephyr.hex signed_app_image.hex
```

------
------

Additionally this patch introduces a way for exporting the signature while signing the image in the standard manner.

It can b exported as fallow
``` console
 ./bootloader/mcuboot/scripts/imgtool.py sign -k ./bootloader/mcuboot/root-rsa-2048.pem -v 1.0.0 -H 0x200 -S 0x67000 --align 8 --public-key-format full --sig-out out_sig.sig ./build/hellow/zephyr/zephyr.hex normal_signed.hex```

