### PR TITLE
zephyr: remove deprecated DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -6,6 +6,7 @@
  */
 
 #include <zephyr.h>
+#include <devicetree.h>
 #include <drivers/flash.h>
 
 #include "target.h"
@@ -17,7 +18,7 @@
 
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
-#if (!defined(CONFIG_XTENSA) && defined(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL))
+#if (!defined(CONFIG_XTENSA) && DT_HAS_CHOSEN(zephyr_flash_controller))
 #define FLASH_DEVICE_ID SOC_FLASH_0_ID
 #define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS
 #elif (defined(CONFIG_XTENSA) && defined(DT_JEDEC_SPI_NOR_0_LABEL))

--- a/boot/zephyr/include/target.h
+++ b/boot/zephyr/include/target.h
@@ -19,6 +19,7 @@
  * Otherwise, the Zephyr SoC header and the DTS provide most
  * everything we need.
  */
+#include <devicetree.h>
 #include <soc.h>
 #include <storage/flash_map.h>
 
@@ -33,7 +34,7 @@
 /*
  * Sanity check the target support.
  */
-#if (!defined(CONFIG_XTENSA) && !defined(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL)) || \
+#if (!defined(CONFIG_XTENSA) && !DT_HAS_CHOSEN(zephyr_flash_controller)) || \
     (defined(CONFIG_XTENSA) && !defined(JEDEC_SPI_NOR_0_LABEL)) || \
     !defined(FLASH_ALIGN) ||                  \
     !(FLASH_AREA_LABEL_EXISTS(image_0)) || \

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -18,6 +18,7 @@
 
 #include <assert.h>
 #include <zephyr.h>
+#include <devicetree.h>
 #include <drivers/gpio.h>
 #include <sys/__assert.h>
 #include <drivers/flash.h>
@@ -455,10 +456,10 @@ void main(void)
 
     (void)rc;
 
-#if (!defined(CONFIG_XTENSA) && defined(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL))
-    if (!flash_device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL)) {
+#if (!defined(CONFIG_XTENSA) && DT_HAS_CHOSEN(zephyr_flash_controller))
+    if (!flash_device_get_binding(DT_LABEL(DT_CHOSEN(zephyr_flash_controller)))) {
         BOOT_LOG_ERR("Flash device %s not found",
-		     DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+		     DT_LABEL(DT_CHOSEN(zephyr_flash_controller)));
         while (1)
             ;
     }


### PR DESCRIPTION
DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL is going to be deprecated, so
remove its usages from the Zephyr port. Definition checks have been
replaced with DT_HAS_CHOSEN(zephyr_flash_controller), and the macro
itself has been replaced by
DT_LABEL(DT_CHOSEN(zephyr_flash_controller)). Note that the code could
likely be refactored to make use of compile time device references, ie
use DEVICE_DT_GET, but that task has been left for the maintainers.

Ref. https://github.com/zephyrproject-rtos/zephyr/pull/44129