### PR TITLE
[RFC] MCUboot's multi image and boot sequence with multi processors (multi boot)

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -59,6 +59,14 @@ struct boot_rsp {
      */
     uint8_t br_flash_dev_id;
     uint32_t br_image_off;
+
+#ifdef MCUBOOT_MULTI_BOOT
+    /**
+     * Indicates in which CPU the image must be executed.
+     */
+    uint8_t img_index;
+    uint8_t boot_cpu_index;
+#endif
 };
 
 /* This is not actually used by mcuboot's code but can be used by apps
@@ -80,6 +88,8 @@ struct image_trailer {
 /* you must have pre-allocated all the entries within this structure */
 fih_int boot_go(struct boot_rsp *rsp);
 fih_int boot_go_for_image_id(struct boot_rsp *rsp, uint32_t image_id);
+
+fih_int boot_rsp_by_image_id(struct boot_rsp *rsp, uint32_t image_id);
 
 struct boot_loader_state;
 void boot_state_clear(struct boot_loader_state *state);

--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -96,6 +96,7 @@ struct flash_area;
 #define IMAGE_TLV_DEPENDENCY        0x40   /* Image depends on other image */
 #define IMAGE_TLV_SEC_CNT           0x50   /* security counter */
 #define IMAGE_TLV_BOOT_RECORD       0x60   /* measured boot record */
+#define IMAGE_TLV_BOOT_CPU_INDEX    0x70   /* CPU in which the image will be executed */
 					   /*
 					    * vendor reserved TLVs at xxA0-xxFF,
 					    * where xx denotes the upper byte

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -217,6 +217,9 @@ struct boot_loader_state {
         const struct flash_area *area;
         boot_sector_t *sectors;
         uint32_t num_sectors;
+#ifdef MCUBOOT_MULTI_BOOT
+        uint8_t boot_cpu_index;
+#endif
     } imgs[BOOT_IMAGE_NUMBER][BOOT_NUM_SLOTS];
 
 #if MCUBOOT_SWAP_USING_SCRATCH
@@ -381,6 +384,14 @@ boot_img_num_sectors(const struct boot_loader_state *state, size_t slot)
 {
     return BOOT_IMG(state, slot).num_sectors;
 }
+
+#ifdef MCUBOOT_MULTI_BOOT
+static inline uint8_t
+boot_img_cpu_index(const struct boot_loader_state *state, size_t slot)
+{
+    return BOOT_IMG(state, slot).boot_cpu_index;
+}
+#endif
 
 /*
  * Offset of the slot from the beginning of the flash device.

--- a/samples/mcuboot_config/mcuboot_config.template.h
+++ b/samples/mcuboot_config/mcuboot_config.template.h
@@ -99,6 +99,8 @@
  * multiple images. */
 #define MCUBOOT_IMAGE_NUMBER 1
 
+/* #define MCUBOOT_MULTI_BOOT 1 */
+
 /*
  * Logging
  */
@@ -149,7 +151,7 @@
 /* If a OS ports support single thread mode or is bare-metal then:
  * This macro implements call that switches CPU to an idle state, from which
  * the CPU may be woken up by, for example, UART transmission event.
- * 
+ *
  * Otherwise this macro should be no-op.
  */
 #define MCUBOOT_CPU_IDLE() \

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -74,6 +74,7 @@ TLV_VALUES = {
         'DEPENDENCY': 0x40,
         'SEC_CNT': 0x50,
         'BOOT_RECORD': 0x60,
+        'BOOT_CPU_INDEX': 0x70
 }
 
 TLV_SIZE = 4
@@ -305,7 +306,8 @@ class Image():
         return cipherkey, ciphermac, pubk
 
     def create(self, key, public_key_format, enckey, dependencies=None,
-               sw_type=None, custom_tlvs=None, encrypt_keylen=128, clear=False):
+               sw_type=None, custom_tlvs=None, encrypt_keylen=128, clear=False,
+               cpu_index=None):
         self.enckey = enckey
 
         # Calculate the hash of the public key
@@ -480,6 +482,10 @@ class Image():
                 img = bytes(self.payload[self.header_size:])
                 self.payload[self.header_size:] = \
                     encryptor.update(img) + encryptor.finalize()
+
+        if cpu_index is not None:
+            payload = struct.pack(e + 'I', cpu_index)
+            tlv.add('BOOT_CPU_INDEX', payload)
 
         self.payload += prot_tlv.get()
         self.payload += tlv.get()

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -228,6 +228,8 @@ class BasedIntParamType(click.ParamType):
 
 @click.argument('outfile')
 @click.argument('infile')
+@click.option('--cpu-index', type=int,
+              help='CPU on which the image must run')
 @click.option('--custom-tlv', required=False, nargs=2, default=[],
               multiple=True, metavar='[tag] [value]',
               help='Custom TLV that will be placed into protected area. '
@@ -310,7 +312,7 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
          pad_header, slot_size, pad, confirm, max_sectors, overwrite_only,
          endian, encrypt_keylen, encrypt, infile, outfile, dependencies,
          load_addr, hex_addr, erased_val, save_enctlv, security_counter,
-         boot_record, custom_tlv, rom_fixed, max_align, clear):
+         boot_record, custom_tlv, rom_fixed, max_align, clear, cpu_index):
 
     if confirm:
         # Confirmed but non-padded images don't make much sense, because
@@ -357,7 +359,7 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
             custom_tlvs[tag] = value.encode('utf-8')
 
     img.create(key, public_key_format, enckey, dependencies, boot_record,
-               custom_tlvs, int(encrypt_keylen), clear)
+               custom_tlvs, int(encrypt_keylen), clear, cpu_index)
     img.save(outfile, hex_addr)
 
 


### PR DESCRIPTION
**MCUboot's multi image and boot sequence with multi processors (multi boot)**

MCUboot bootloader is designed to boot a single image after `context_boot_go` verification is performed. This call returns the boot information exclusively for the referred single image that is required by `do_boot`, that loads it (if needed) and jumps to the entry point of the image. This happens even using multi images, where MCUboot can manage, however does not boot a second image, leaving this responsibility to the first application image.

MCUBoot Espressif's port can now handle multi image booting (PR https://github.com/mcu-tools/mcuboot/pull/1326), which allows both ESP32 CPUs (APP and PRO) to run different applications.

This RFC is intended to start a discussion to add multi boot feature (name open to suggestions) in order to handle both multi images and boot sequence if supported by the SoC.

The goal is:
- Transfer from OS to the bootloader the responsibility of starting the second image/processor.
- Have better support for AMP architecture, where images can run in stand-alone format.
- If chip design allows, separate/protect critical resources between the OSes before they start.

Possible drawbacks:
- Increase of boot time and size.
- More image and resources manual managing.

This PR presents an initial proposal of implementation:

a) Add a configuration for multi boot to `mcuboot_config.h`
```
#define MCUBOOT_MULTI_BOOT 1
```
b) Add information about the image index and the CPU index to `boot_rsp`.
```
struct boot_rsp {
    /** A pointer to the header of the image to be executed. */
    const struct image_header *br_hdr;

    /**
     * The flash offset of the image to execute.  Indicates the position of
     * the image header within its flash device.
     */
    uint8_t br_flash_dev_id;
    uint32_t br_image_off;

#ifdef MCUBOOT_MULTI_BOOT
    /**
     * Indicates in which CPU the image must be executed.
     */
    uint8_t img_index;
    uint8_t boot_cpu_index;
#endif
};
```
c) Add TLV to the image for indicating in which CPU it shall run.
```
#define IMAGE_TLV_BOOT_CPU_INDEX    0x70   /* CPU in which the image will be executed */
```
d) Add implementation to retrieve the boot information from other images. It would be used by the bootloader port if it supports the multi boot, so it can boot the referred image on the correct CPU.
```
fih_int boot_rsp_by_image_id(struct boot_rsp *rsp, uint32_t image_id);
```
As an alternative, `boot_go` could return the info instead of creating another function, however it would need changes on the APIs and its implementations (like in `context_boot_go` and `fill_boot_rsp`), which may not be desirable.

e) Each port would handle how to start the image.

What are your thoughts about that?

Thanks!