### PR TITLE
zephyr/main: configure DFU detection GPIO-pin using DTS

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -413,14 +413,14 @@ config BOOT_USB_DFU_WAIT_DELAY_MS
 if BOOT_USB_DFU_GPIO
 
 config BOOT_USB_DFU_DETECT_PORT
-	string "GPIO device to trigger USB DFU mode"
+	string "GPIO device to trigger USB DFU mode (DEPRECATED)"
 	default GPIO_0 if SOC_FAMILY_NRF
 	help
 	  Zephyr GPIO device that contains the pin used to trigger
 	  USB DFU.
 
 config BOOT_USB_DFU_DETECT_PIN
-	int "Pin to trigger USB DFU mode"
+	int "Pin to trigger USB DFU mode (DEPRECATED)"
 	default 6 if BOARD_NRF9160DK_NRF9160
 	default 11 if BOARD_NRF52840DK_NRF52840
 	default 13 if BOARD_NRF52DK_NRF52832
@@ -430,7 +430,7 @@ config BOOT_USB_DFU_DETECT_PIN
 	  Pin on the DFU detect port that triggers DFU mode.
 
 config BOOT_USB_DFU_DETECT_PIN_VAL
-	int "USB DFU detect pin trigger value"
+	int "USB DFU detect pin trigger value (DEPRECATED)"
 	default 0
 	range 0 1
 	help

--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -57,14 +57,14 @@ config BOOT_MAX_LINE_INPUT_LEN
 	  Maximum length of commands transported over the serial port.
 
 config BOOT_SERIAL_DETECT_PORT
-	string "GPIO device to trigger serial recovery mode"
+	string "GPIO device to trigger serial recovery mode (DEPRECATED)"
 	default GPIO_0 if SOC_FAMILY_NRF
 	help
 	  Zephyr GPIO device that contains the pin used to trigger
 	  serial recovery mode.
 
 config BOOT_SERIAL_DETECT_PIN
-	int "Pin to trigger serial recovery mode"
+	int "Pin to trigger serial recovery mode (DEPRECATED)"
 	default 6 if BOARD_NRF9160DK_NRF9160
 	default 11 if BOARD_NRF52840DK_NRF52840
 	default 13 if BOARD_NRF52DK_NRF52832 || BOARD_NRF52833DK_NRF52833
@@ -74,7 +74,7 @@ config BOOT_SERIAL_DETECT_PIN
 	  Pin on the serial detect port that triggers serial recovery mode.
 
 config BOOT_SERIAL_DETECT_PIN_VAL
-	int "Serial detect pin trigger value"
+	int "Serial detect pin trigger value (DEPRECATED)"
 	default 0
 	range 0 1
 	help


### PR DESCRIPTION
Added support for configure GPIO-pin used for triggering the
recovery DFU using DTS. That pin is assigned thanks to
`mcuboot-button0` pin-allias.

DTS configuration takes precedence over the Kconfig pin configurations.

Kconfig hw pin properties get deprecated.

This patch reduces technical debt against zephyr-rtos we have.

fixes #965

~~[PR for introduce bootloader-button0 alias to the zephyr-rtos](https://github.com/zephyrproject-rtos/zephyr/pull/44741)~~ [Merged]