### PR TITLE
boot: Check that hash TLV is sufficiently large

### DIFF
--- a/boot/bootutil/src/boot_record.c
+++ b/boot/bootutil/src/boot_record.c
@@ -196,6 +196,13 @@ boot_save_boot_status(uint8_t sw_module,
         return -1;
     }
 
+    /* Ensure that we have enough in the record for the hash.  This
+     * prevents an underflow in the calculation below.
+     */
+    if (record_len < sizeof(image_hash)) {
+	return -1;
+    }
+
     /* Update the measurement value (hash of the image) data item in the
      * boot record. It is always the last item in the structure to make
      * it easy to calculate its position.


### PR DESCRIPTION
Add a check for the size of the TLV entry for the boot record.
Although, this is in the protected area, and should be protected by a
signature, check that we don't induce an integer underflow if that entry
is somehow too short.

Signed-off-by: David Brown <david.brown@linaro.org>