### PR TITLE
zephyr: Add a bool Kconfig option for swap move

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -194,10 +194,21 @@ config BOOT_VALIDATE_SLOT0_ONCE
 	  low end devices with as a compromise lowering the security level.
 	  If unsure, leave at the default value.
 
+config BOOT_PREFER_SWAP_MOVE
+	bool "Prefer the newer swap move algorithm"
+	default y if SOC_FAMILY_NRF
+	default n
+	help
+	  If y, the BOOT_IMAGE_UPGRADE_MODE will default to using
+	  "move" instead of "scratch".  This is a separate bool config
+	  option, because Kconfig doesn't allow defaults to be
+	  overridden in choice options.  Most devices should be using
+	  swap move.
+
 if !SINGLE_APPLICATION_SLOT
 choice BOOT_IMAGE_UPGRADE_MODE
 	prompt "Image upgrade modes"
-	default BOOT_SWAP_USING_MOVE if SOC_FAMILY_NRF
+	default BOOT_SWAP_USING_MOVE if BOOT_PREFER_SWAP_MOVE
 	default BOOT_SWAP_USING_SCRATCH
 
 config BOOT_SWAP_USING_SCRATCH


### PR DESCRIPTION
The Kconfig system used by Zephyr does not allow the defaults for choice
options to be overridden.  To compensate for this, create a new boolean
config option that will determine what the default is for the boot mode.

This allows the kconfig override file for various Zephyr boards to
change the default to swap move.

Signed-off-by: David Brown <david.brown@linaro.org>