### PR TITLE
Remove unused function

### DIFF
--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -46,9 +46,6 @@
 #include "bootutil/image.h"
 #include "bootutil/bootutil_public.h"
 #include "bootutil/bootutil_log.h"
-#ifdef MCUBOOT_ENC_IMAGES
-#include "bootutil/enc_key_public.h"
-#endif
 
 #include "bootutil/boot_public_hooks.h"
 #include "bootutil_priv.h"
@@ -167,12 +164,6 @@ boot_copy_done_off(const struct flash_area *fap)
     return boot_image_ok_off(fap) - BOOT_MAX_ALIGN;
 }
 
-static inline uint32_t
-boot_swap_size_off(const struct flash_area *fap)
-{
-    return boot_swap_info_off(fap) - BOOT_MAX_ALIGN;
-}
-
 uint32_t
 boot_swap_info_off(const struct flash_area *fap)
 {
@@ -204,18 +195,6 @@ boot_magic_compatible_check(uint8_t tbl_val, uint8_t val)
         return tbl_val == val;
     }
 }
-
-#ifdef MCUBOOT_ENC_IMAGES
-static inline uint32_t
-boot_enc_key_off(const struct flash_area *fap, uint8_t slot)
-{
-#if MCUBOOT_SWAP_SAVE_ENCTLV
-    return boot_swap_size_off(fap) - ((slot + 1) * BOOT_ENC_TLV_ALIGN_SIZE);
-#else
-    return boot_swap_size_off(fap) - ((slot + 1) * BOOT_ENC_KEY_ALIGN_SIZE);
-#endif
-}
-#endif
 
 bool bootutil_buffer_is_erased(const struct flash_area *area,
                                const void *buffer, size_t len)


### PR DESCRIPTION
Hi!

Thank you for your work!

While working with the project I found that `boot_enc_key_off`function is not used in boot/bootutil/src/bootutil_public.c. It seems code was move to bootutil_misc.c but this function was forgotten.