### PR TITLE
bootutil: zephyr: Fix not linking with mbedtls when needed

### DIFF
--- a/boot/bootutil/zephyr/CMakeLists.txt
+++ b/boot/bootutil/zephyr/CMakeLists.txt
@@ -48,4 +48,8 @@ target_include_directories(MCUBOOT_BOOTUTIL INTERFACE
   ../../../ext/tinycrypt/lib/include
 )
 endif()
+
+if(CONFIG_BOOT_USE_MBEDTLS)
+  zephyr_link_libraries(mbedTLS)
+endif()
 endif()


### PR DESCRIPTION
    This fixes a build issue when building mcuboot for zephyr with RSA
    image encryption support enabled using mbedtls.

Fixes https://github.com/mcu-tools/mcuboot/issues/1355