### PR TITLE
bootutil: zephyr: Fix not including tinycrypt path when needed

### DIFF
--- a/boot/bootutil/zephyr/CMakeLists.txt
+++ b/boot/bootutil/zephyr/CMakeLists.txt
@@ -42,4 +42,10 @@ endif()
 
 zephyr_library_link_libraries(MCUBOOT_BOOTUTIL)
 target_link_libraries(MCUBOOT_BOOTUTIL INTERFACE zephyr_interface)
+
+if(CONFIG_BOOT_USE_TINYCRYPT)
+target_include_directories(MCUBOOT_BOOTUTIL INTERFACE
+  ../../../ext/tinycrypt/lib/include
+)
+endif()
 endif()


### PR DESCRIPTION
    This fixes a build issue when building mcuboot for zephyr with image
    encryption support enabled using tinycrypt.

Fixes https://github.com/mcu-tools/mcuboot/issues/1356
Note that the build will not succeed after this due to the `boot_nv_security_counter_update` function being unresolved, but it fixes the compilation error when searching for tinycrypt files.