### PR TITLE
zephyr: boards: add support for RT1160 and RT1170 CM7 cores

### DIFF
--- a/boot/zephyr/boards/mimxrt1160_evk_cm7.conf
+++ b/boot/zephyr/boards/mimxrt1160_evk_cm7.conf
@@ -1,0 +1,7 @@
+# Copyright 2022 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BOOT_MAX_IMG_SECTORS=1024
+CONFIG_BOOT_ERASE_PROGRESSIVELY=y
+# Move swap provides better wear levelling, so use it by default
+CONFIG_BOOT_SWAP_USING_MOVE=y

--- a/boot/zephyr/boards/mimxrt1170_evk_cm7.conf
+++ b/boot/zephyr/boards/mimxrt1170_evk_cm7.conf
@@ -1,0 +1,7 @@
+# Copyright 2022 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BOOT_MAX_IMG_SECTORS=1024
+CONFIG_BOOT_ERASE_PROGRESSIVELY=y
+# Move swap provides better wear levelling, so use it by default
+CONFIG_BOOT_SWAP_USING_MOVE=y


### PR DESCRIPTION
add support for RT1170 and RT1160 CM7 cores, which have large flash
sizes and require an increase to the value of BOOT_MAX_IMG_SECTORS

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>