### PR TITLE
docs: Fix case of Cypress readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ operating systems and SoCs:
 - [RIOT](docs/readme-riot.md)
 - [Mbed OS](docs/readme-mbed.md)
 - [Espressif](docs/readme-espressif.md)
-- [Cypress/Infineon](boot/cypress/readme.md)
+- [Cypress/Infineon](boot/cypress/README.md)
 
 There are also instructions for the [Simulator](sim/README.rst).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ The MCUboot documentation is composed of the following pages:
   - [RIOT](readme-riot.md)
   - [Mbed OS](readme-mbed.md)
   - [Espressif](readme-espressif.md)
-  - [Cypress/Infineon](../boot/cypress/readme.md)
+  - [Cypress/Infineon](../boot/cypress/README.md)
   - [Simulator](../sim/README.rst)
 - Testing
   - [Zephyr](testplan-zephyr.md) - Zephyr test plan


### PR DESCRIPTION
Fix the case of the cypress readme to fix dead links in the docs.

Signed-off-by: David Brown <david.brown@linaro.org>