### PR TITLE
zephyr: boards: add support for Telink tlsr9518adk80d board

### DIFF
--- a/boot/zephyr/boards/tlsr9518adk80d.conf
+++ b/boot/zephyr/boards/tlsr9518adk80d.conf
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2022 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+CONFIG_BOOT_MAX_IMG_SECTORS=4096


### PR DESCRIPTION
Add support for TLSR9518ADK80D board, which have large flash
sizes and require an increase to the value of BOOT_MAX_IMG_SECTORS

Signed-off-by: Alex Kolosov <rikorsev@gmail.com>