### PR TITLE
zephyr: boards: fix license header for tlsr9518adk80d board

### DIFF
--- a/boot/zephyr/boards/tlsr9518adk80d.conf
+++ b/boot/zephyr/boards/tlsr9518adk80d.conf
@@ -1,7 +1,4 @@
-/*
- * Copyright (c) 2022 Telink Semiconductor
- *
- * SPDX-License-Identifier: Apache-2.0
- */
+# Copyright 2022 Telink Semiconductor
+# SPDX-License-Identifier: Apache-2.0
 
 CONFIG_BOOT_MAX_IMG_SECTORS=4096


### PR DESCRIPTION
License header has been written in wrong format. It is fixed in this commit.

Signed-off-by: Alexandr Kolosov <rikorsev@gmail.com>