### PR TITLE
zephyr: prefer DTS mcuboot-led0 alias over bootloader-led0 alias

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -127,8 +127,12 @@ BOOT_LOG_MODULE_REGISTER(mcuboot);
  * The led0 devicetree alias is optional. If present, we'll use it
  * to turn on the LED whenever the button is pressed.
  */
-
+#if DT_NODE_EXISTS(DT_ALIAS(mcuboot_led0))
+#define LED0_NODE DT_ALIAS(mcuboot_led0))
+#elif DT_NODE_EXISTS(DT_ALIAS(bootloader_led0))
+#warning "bootloader-led0 alias is deprecated; use mcuboot-led0 instead"
 #define LED0_NODE DT_ALIAS(bootloader_led0)
+#endif
 
 #if DT_NODE_HAS_STATUS(LED0_NODE, okay) && DT_NODE_HAS_PROP(LED0_NODE, gpios)
 #define LED0_GPIO_LABEL DT_GPIO_LABEL(LED0_NODE, gpios)


### PR DESCRIPTION
bootloader-led0 alias will be deprecated and replaced by dedicated
mcuboot-led0 alias.

This is in response to suggestion for making MCUboot's DT aliases naming more consistient.
see: https://github.com/zephyrproject-rtos/zephyr/pull/44741#pullrequestreview-985471844

PR which introduces the `mcuboot-led0` alias: https://github.com/zephyrproject-rtos/zephyr/pull/44741

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>