### PR TITLE
add extra space or dot symbol to suite display.

### DIFF
--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -314,16 +314,16 @@ class BasedIntParamType(click.ParamType):
               'the image manifest: full key or hash of the key.')
 @click.option('-k', '--key', metavar='filename')
 @click.option('--fix-sig', metavar='filename',
-              help='fixed signature for the image. It will be used instead of'
+              help='fixed signature for the image. It will be used instead of '
               'the signature calculated using the public key')
 @click.option('--fix-sig-pubkey', metavar='filename',
               help='public key relevant to fixed signature')
 @click.option('--sig-out', metavar='filename',
-              help='Path to the file to which signature will be written'
+              help='Path to the file to which signature will be written. '
               'The image signature will be encoded as base64 formatted string')
 @click.option('--vector-to-sign', type=click.Choice(['payload', 'digest']),
-              help='send to OUTFILE the payload or payload''s digest instead of'
-              'complied image. These data can be used for external image'
+              help='send to OUTFILE the payload or payload''s digest instead of '
+              'complied image. These data can be used for external image '
               'signing')
 @click.command(help='''Create a signed or unsigned image\n
                INFILE and OUTFILE are parsed as Intel HEX if the params have


### PR DESCRIPTION
When I do command ``./imgtool.py sign -h``, there are some sentences display as below:
![](https://s3.bmp.ovh/imgs/2022/05/28/22edf9cf122fee5e.png)

So I add space and dot to suit the display as:
![](https://s3.bmp.ovh/imgs/2022/05/28/ee18e1aad439f649.png)