### PR TITLE
boot: mynewt: Add boot data sharing config

### DIFF
--- a/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_config.h
+++ b/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_config.h
@@ -86,6 +86,26 @@
 #define MCUBOOT_BOOTSTRAP 1
 #endif
 
+#if MYNEWT_VAL(MCUBOOT_MEASURED_BOOT)
+#define MCUBOOT_MEASURED_BOOT       1
+#endif
+
+#if MYNEWT_VAL(MCUBOOT_MEASURED_BOOT_MAX_RECORD_SZ)
+#define MAX_BOOT_RECORD_SZ          MYNEWT_VAL(MCUBOOT_MEASURED_BOOT_MAX_RECORD_SZ)
+#endif
+
+#if MYNEWT_VAL(MCUBOOT_DATA_SHARING)
+#define MCUBOOT_DATA_SHARING        1
+#endif
+
+#if MYNEWT_VAL(MCUBOOT_SHARED_DATA_BASE)
+#define MCUBOOT_SHARED_DATA_BASE    MYNEWT_VAL(MCUBOOT_SHARED_DATA_BASE)
+#endif
+
+#if MYNEWT_VAL(MCUBOOT_SHARED_DATA_SIZE)
+#define MCUBOOT_SHARED_DATA_SIZE    MYNEWT_VAL(MCUBOOT_SHARED_DATA_SIZE)
+#endif
+
 /*
  * Currently there is no configuration option, for this platform,
  * that enables the system specific mcumgr commands in mcuboot

--- a/boot/mynewt/mcuboot_config/syscfg.yml
+++ b/boot/mynewt/mcuboot_config/syscfg.yml
@@ -101,3 +101,23 @@ syscfg.defs:
     BOOTUTIL_FEED_WATCHDOG:
         description: 'Enable watchdog feeding while performing a swap upgrade'
         value: 0
+
+    MCUBOOT_MEASURED_BOOT:
+        description: >
+            Store the boot state/measurements in shared memory.
+            If enabled, the bootloader will store certain boot measurements such as
+            the hash of the firmware image in a shared memory area. This data can
+            be used later by runtime services (e.g. by a device attestation service).
+        value:
+    MCUBOOT_MEASURED_BOOT_MAX_RECORD_SZ:
+        description: the maximum size of the CBOR encoded boot record in bytes.
+        value:
+    MCUBOOT_DATA_SHARING:
+        description: Save application specific data in shared memory (RAM).
+        value:
+    MCUBOOT_SHARED_DATA_BASE:
+        description: RAM address of shared data
+        value:
+    MCUBOOT_SHARED_DATA_SIZE:
+        description: Shared data size.
+        value:


### PR DESCRIPTION
There is code for sharing data between booloader and application.
So far only zephyr had config flags to enable this.

This adds configuration that allows to turn on data sharing code
in mynewt version.

Signed-off-by: Jerzy Kasenberg <jerzy.kasenberg@codecoup.pl>