### PR TITLE
mynewt: Allow custom boot to be provided by pkg

### DIFF
--- a/boot/mynewt/syscfg.yml
+++ b/boot/mynewt/syscfg.yml
@@ -27,7 +27,7 @@ syscfg.defs:
         value: 0
     BOOT_CUSTOM_START:
         description: 'Override hal_system_start with a custom start routine'
-        value: 0
+        value:
     BOOT_PREBOOT:
         description: 'Call boot_preboot() function before booting application'
         value:


### PR DESCRIPTION
BOOT_CUSTOM_START is defined by APP package (here).
This changes default value from 0 to empty
to allow for constructing packege that provides function
boot_custom_start() and automatically sets BOOT_CUSTOM_START to 1
for easy setup.

Signed-off-by: Jerzy Kasenberg <jerzy.kasenberg@codecoup.pl>