### PR TITLE
zephyr: remove MBEDTLS_ECP_MAX_BITS from mbedTLS configs

### DIFF
--- a/boot/zephyr/include/config-ec.h
+++ b/boot/zephyr/include/config-ec.h
@@ -76,8 +76,6 @@
 #define MBEDTLS_X509_CRT_PARSE_C
 
 /* Save RAM by adjusting to our exact needs */
-#define MBEDTLS_ECP_MAX_BITS             256
-
 #define MBEDTLS_MPI_MAX_SIZE             32
 
 #define MBEDTLS_SSL_MAX_CONTENT_LEN      1024

--- a/boot/zephyr/include/config-ed25519.h
+++ b/boot/zephyr/include/config-ed25519.h
@@ -66,8 +66,6 @@
 #define MBEDTLS_AES_C
 
 /* Save RAM by adjusting to our exact needs */
-//#define MBEDTLS_ECP_MAX_BITS             2048
-
 #define MBEDTLS_MPI_MAX_SIZE              64
 
 //#define MBEDTLS_SSL_MAX_CONTENT_LEN 1024

--- a/boot/zephyr/include/config-rsa-kw.h
+++ b/boot/zephyr/include/config-rsa-kw.h
@@ -70,7 +70,6 @@
 #define MBEDTLS_NIST_KW_C
 
 /* Save RAM by adjusting to our exact needs */
-#define MBEDTLS_ECP_MAX_BITS             2048
 #define MBEDTLS_MPI_MAX_SIZE              256
 
 #define MBEDTLS_SSL_MAX_CONTENT_LEN 1024

--- a/boot/zephyr/include/config-rsa.h
+++ b/boot/zephyr/include/config-rsa.h
@@ -69,8 +69,6 @@
 #define MBEDTLS_AES_C
 
 /* Save RAM by adjusting to our exact needs */
-#define MBEDTLS_ECP_MAX_BITS             2048
-
 #if (CONFIG_BOOT_SIGNATURE_TYPE_RSA_LEN == 3072)
 #define MBEDTLS_MPI_MAX_SIZE              384
 #else


### PR DESCRIPTION
According to mbedTLS' Changelog "Mbed TLS 3.0.0 branch released
2021-07-07" -> "Removals":

```
   MBEDTLS_ECP_MAX_BITS is no longer a configuration option because it
   is now determined automatically based on supported curves.
```
Link: https://github.com/Mbed-TLS/mbedtls/blob/4ccd226cbf087ee78b443e452200dd0486527658/ChangeLog#L435

Hence remove MBEDTLS_ECP_MAX_BITS from configuration files to fix build
issues with Zephyr when there is unfortunate order of include
statements, like:

```
  /__w/zephyr/zephyr/modules/mbedtls/zephyr_init.c
  In file included from /__w/zephyr/modules/crypto/mbedtls/include/mbedtls/ssl.h:30,
                   from /__w/zephyr/modules/crypto/mbedtls/include/mbedtls/debug.h:27,
                   from /__w/zephyr/zephyr/modules/mbedtls/zephyr_init.c:16:
  /__w/zephyr/modules/crypto/mbedtls/include/mbedtls/ecp.h:314: error: "MBEDTLS_ECP_MAX_BITS" redefined [-Werror]
    314 | #define MBEDTLS_ECP_MAX_BITS 1
        |
  In file included from /__w/zephyr/bootloader/mcuboot/boot/zephyr/include/mcuboot-mbedtls-cfg.h:25,
                   from /__w/zephyr/modules/crypto/mbedtls/include/mbedtls/build_info.h:59,
                   from /__w/zephyr/modules/crypto/mbedtls/include/mbedtls/debug.h:25,
                   from /__w/zephyr/zephyr/modules/mbedtls/zephyr_init.c:16:
  /__w/zephyr/bootloader/mcuboot/boot/zephyr/include/config-rsa.h:72: note: this is the location of the previous definition
     72 | #define MBEDTLS_ECP_MAX_BITS             2048
        |
  cc1: all warnings being treated as errors
```
Link: https://github.com/zephyrproject-rtos/zephyr/runs/6902644058?check_suite_focus=true

Blocks: https://github.com/zephyrproject-rtos/zephyr/pull/46572