### PR TITLE
zephyr: dropped __BOOTSIM__ ifdef-ry from the port

### DIFF
--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -9,17 +9,6 @@
 #ifndef __MCUBOOT_CONFIG_H__
 #define __MCUBOOT_CONFIG_H__
 
-/*
- * This file is also included by the simulator, but we don't want to
- * define anything here in simulator builds.
- *
- * Instead of using mcuboot_config.h, the simulator adds MCUBOOT_xxx
- * configuration flags to the compiler command lines based on the
- * values of environment variables. However, the file still must
- * exist, or bootutil won't build.
- */
-#ifndef __BOOTSIM__
-
 #ifdef CONFIG_BOOT_SIGNATURE_TYPE_RSA
 #define MCUBOOT_SIGN_RSA
 #  if (CONFIG_BOOT_SIGNATURE_TYPE_RSA_LEN != 2048 && \
@@ -241,8 +230,6 @@
 #else
 #define MCUBOOT_MAX_IMG_SECTORS       128
 #endif
-
-#endif /* !__BOOTSIM__ */
 
 #if CONFIG_BOOT_WATCHDOG_FEED
 #if CONFIG_NRFX_WDT

--- a/boot/zephyr/include/mcuboot_config/mcuboot_logging.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_logging.h
@@ -7,8 +7,6 @@
 #ifndef __MCUBOOT_LOGGING_H__
 #define __MCUBOOT_LOGGING_H__
 
-#ifndef __BOOTSIM__
-
 /*
  * When building for targets running Zephyr, delegate to its native
  * logging subsystem.
@@ -28,7 +26,5 @@
 #define MCUBOOT_LOG_SIM(...) IGNORE(__VA_ARGS__)
 
 #include <zephyr/logging/log.h>
-
-#endif /* !__BOOTSIM__ */
 
 #endif /* __MCUBOOT_LOGGING_H__ */


### PR DESCRIPTION
Since #1383 the configuration translation header and
the logging translation header are not used by the simiulator.

Thanks to that __BOOTSIM__ dependence might be removed - what is done
in this patch.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>