### PR TITLE
boot_serial: Fix compilation due to danling pointer

### DIFF
--- a/boot/boot_serial/src/zcbor_decode.c
+++ b/boot/boot_serial/src/zcbor_decode.c
@@ -321,8 +321,9 @@ static bool str_overflow_check(zcbor_state_t *state, struct zcbor_string *result
 
 bool zcbor_bstr_start_decode(zcbor_state_t *state, struct zcbor_string *result)
 {
+	struct zcbor_string dummy;
+
 	if (result == NULL) {
-		struct zcbor_string dummy;
 		result = &dummy;
 	}
 


### PR DESCRIPTION
repos/mcuboot/boot/boot_serial/src/zcbor_decode.c:341:52: error:
     dangling pointer ‘result’ to ‘dummy’ may be used
     [-Werror=dangling-pointer=]
  341 |         state->payload_end = result->value + result->len;
      |                                              ~~~~~~^~~~~
repos/mcuboot/boot/boot_serial/src/zcbor_decode.c:325:37: note: ‘dummy’
     declared here
  325 |                 struct zcbor_string dummy = {};
      |                                     ^~~~~
repos/mcuboot/boot/boot_serial/src/zcbor_decode.c:341:36: error:
     dangling pointer ‘result’ to ‘dummy’ may be used
     [-Werror=dangling-pointer=]
  341 |         state->payload_end = result->value + result->len;
      |                              ~~~~~~^~~~~~~
repos/mcuboot/boot/boot_serial/src/zcbor_decode.c:325:37: note: ‘dummy’
     declared here
  325 |                 struct zcbor_string dummy = {};
      |                                     ^~~~~
cc1: all warnings being treated as errors

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>