### PR TITLE
zephyr: flash: support 32byte block write size

### DIFF
--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -9,6 +9,8 @@
 #ifndef __MCUBOOT_CONFIG_H__
 #define __MCUBOOT_CONFIG_H__
 
+#include <zephyr/devicetree.h>
+
 #ifdef CONFIG_BOOT_SIGNATURE_TYPE_RSA
 #define MCUBOOT_SIGN_RSA
 #  if (CONFIG_BOOT_SIGNATURE_TYPE_RSA_LEN != 2048 && \
@@ -231,8 +233,15 @@
 #define MCUBOOT_MAX_IMG_SECTORS       128
 #endif
 
+/* Support 32-byte aligned flash sizes */
+#if DT_HAS_CHOSEN(zephyr_flash)
+    #if DT_PROP_OR(DT_CHOSEN(zephyr_flash), write_block_size, 0) > 8
+        #define MCUBOOT_BOOT_MAX_ALIGN \
+            DT_PROP(DT_CHOSEN(zephyr_flash), write_block_size)
+    #endif
+#endif
+
 #if CONFIG_BOOT_WATCHDOG_FEED
-#include <zephyr/devicetree.h>
 #if CONFIG_NRFX_WDT
 #include <nrfx_wdt.h>
 


### PR DESCRIPTION
This PR adds support STM32 devices with 32byte flash write alignment. Possible after [#1217](https://github.com/mcu-tools/mcuboot/pull/1217)

**Does it work**
Why yes! I tested with a `nucleo_h743zi` with the following steps:
 - Built and flashed the adapted bootloader. Built two
 - Built two demo applciations with bootloader support. Signed them by omitting `--align` so it automatically detects to use `32`.
 - Flash two demo applications. 
 - MCUBoot detects the correct magic in the second slot, and does a succesful swap.

**Old Behaviour:**
The STM32H7 device only supports writing to flash at a 32byte alignment. However, currently `BOOT_MAX_ALIGN` will always be set to `8` for a Zephyr build. This means the bootloader will not find the correctly signed image's magic number, because it's looking at the wrong location.

**New Behaviour:**
A Zephyr build will always look in the device tree if there's a chosen `zephyr,flash`, and if that node has a `write-block-size` property. If it exists, then it will set ultimately set the `BOOT_MAX_ALIGN` value to that `write-block-size`. It also checked that it's bigger that `8`.

**Typical STM32H7 DTS snippets**:
```
            chosen {
		zephyr,flash = &flash0;
```
```
			flash0: flash@8000000 {
				compatible = "st,stm32-nv-flash", "soc-nv-flash";
				label = "FLASH_STM32";
				write-block-size = < 0x20 >;
				erase-block-size = < 0x20000 >;
				max-erase-time = < 0xfa0 >;
				reg = < 0x8000000 0x200000 >;
				partitions {
```

**What about other Zephyr devices?**
- If the properties doesn't exist the default behaviour will be used.
- If the value is too small, like for example the `STM32F1`, then default behaviour will be used.