### PR TITLE
Adding new macro for region copy buffer size

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil_public.h
+++ b/boot/bootutil/include/bootutil/bootutil_public.h
@@ -93,6 +93,11 @@ _Static_assert(MCUBOOT_BOOT_MAX_ALIGN >= 8 && MCUBOOT_BOOT_MAX_ALIGN <= 32,
 #define BOOT_MAGIC_ALIGN_SIZE   BOOT_MAGIC_SZ
 #endif
 
+/** The size of buffer to use for copying regions */
+#ifdef MCUBOOT_BOOT_COPY_REGION_SIZE
+#define BOOT_COPY_REGION_SIZE   MCUBOOT_BOOT_COPY_REGION_SIZE
+#endif
+
 #define BOOT_MAGIC_GOOD     1
 #define BOOT_MAGIC_BAD      2
 #define BOOT_MAGIC_UNSET    3

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -81,8 +81,8 @@ static struct boot_loader_state boot_data;
 #define TARGET_STATIC
 #endif
 
-#if BOOT_MAX_ALIGN > 1024
-#define BUF_SZ BOOT_MAX_ALIGN
+#ifdef BOOT_COPY_REGION_SIZE
+#define BUF_SZ BOOT_COPY_REGION_SIZE
 #else
 #define BUF_SZ 1024
 #endif


### PR DESCRIPTION
This addresses the issue opened here: https://github.com/mcu-tools/mcuboot/issues/1407

## Background:
[This PR](https://github.com/mcu-tools/mcuboot/pull/1217) introduced a change which appeared to be intended to [allow the buffer size to be configurable](https://github.com/mcu-tools/mcuboot/pull/1217/files#diff-a004fdf5907914a360ce1e7da94221c0165d1c4c8ba7b8c4eaf67bd63af395c1R83).

That change, however, is frivolous because `MCUBOOT_BOOT_MAX_ALIGN` is guaranteed to be [between 8 and 32](https://github.com/mcu-tools/mcuboot/commit/73c38c6fde489746d5307a691dc7006234372279#diff-531d0cc2251e606642938c20aeec3920ad187962f69c8e231f93aee73d3277c2R86)

## This PR:
This PR adds a new configuration macro to allow the region copy buffer size to be a value other than 1024, which should allow for a more efficient use of block devices when the block size is a different value.

It is backwards compatible with all version, as the default when that macro is unset is still 1024

Signed-off-by: Mikhail Skobov <mskobov@lyft.com>