### PR TITLE
boot_serial: Fix incorrect format specifier for off_t

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -318,7 +318,8 @@ static off_t erase_range(const struct flash_area *fap, off_t start, off_t end)
     }
 
     size = flash_sector_get_off(&sect) + flash_sector_get_size(&sect) - start;
-    BOOT_LOG_INF("Erasing range 0x%x:0x%x", start, start + size - 1);
+    BOOT_LOG_INF("Erasing range 0x%jx:0x%jx", (intmax_t)start,
+		 (intmax_t)(start + size - 1));
 
     rc = flash_area_erase(fap, start, size);
     if (rc != 0) {


### PR DESCRIPTION
The `BOOT_LOG_INF` function, which uses the format specifiers defined
by the C standard, was incorrectly printing a variable with the type of
`off_t` using the `%x` format specifier, which is intended to be used
with the `int` type.

The `off_t` type, specified by the POSIX standard, is not guaranteed to
be `int`, and it may be defined as `long` or `long long` depending on
the toolchain and the target architecture.

This commit updates the print routine such that it casts the arguments
of the `off_t` type to `intmax_t` and prints them out using the
corresponding `%jx` format specifier.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>