### PR TITLE
RFC: boot_serial: Post update, installation progress hook and usage

### DIFF
--- a/boot/bootutil/include/bootutil/boot_hooks.h
+++ b/boot/bootutil/include/bootutil/boot_hooks.h
@@ -179,6 +179,6 @@ int boot_img_install_stat_hook(int image_index, int slot,
  * with returning progress and then deciding to case providing such information
  * is considered an error.
  */
-int boot_img_install_progress_hook(int image_index, int slot)
+int boot_img_install_progress_hook(int image_index, int slot);
 
 #endif /*H_BOOTUTIL_HOOKS*/

--- a/boot/bootutil/include/bootutil/boot_hooks.h
+++ b/boot/bootutil/include/bootutil/boot_hooks.h
@@ -157,4 +157,28 @@ int boot_serial_uploaded_hook(int img_index, const struct flash_area *area,
 int boot_img_install_stat_hook(int image_index, int slot,
                                int *img_install_stat);
 
+
+/** Hook for getting installation progress.
+ *
+ * @param img_index the index of the image pair
+ * @param slot slot number
+ *
+ * @retval 0 when idle;
+ *         [1,99] when in progress;
+ *         100 when done;
+ *         [-100,-1] when failed, representing percentage at which
+ *             process has failed;
+ *          <= -101 when no status is available.
+ *
+ * Returning value below -100 means that hook does not want caller to
+ * process returned value. This is useful, for example, when boot logic
+ * has chosen path where there will be no installation performed and
+ * so no reporting is required.
+ * Within one upload session hook may start with returning value below -100
+ * and then change to returning progress, but it may not do opposite: starting
+ * with returning progress and then deciding to case providing such information
+ * is considered an error.
+ */
+int boot_img_install_progress_hook(int image_index, int slot)
+
 #endif /*H_BOOTUTIL_HOOKS*/

--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -35,6 +35,17 @@ config BOOT_SERIAL_CDC_ACM
 
 endchoice
 
+config BOOT_SERIAL_IMG_INSTALL_PROGRESS
+	bool "Post upload installation progress reported in SMP responses"
+	help
+	  The option allows SMP responses for image upload and image list to report
+	  progress of post upload processing of the uploaded image, in form of
+	  "install_progress" key.
+	  The additional key takes values: 0 when not yet started, [1,99] when in
+	  progress, 100 when completed and [-100, -1] as percentage where error
+	  has occurred, in case of error.
+
+
 config MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD
 	bool "Allow to select image number for DFU"
 	help

--- a/boot/zephyr/hooks_sample.c
+++ b/boot/zephyr/hooks_sample.c
@@ -93,3 +93,8 @@ int boot_img_install_stat_hook(int image_index, int slot, int *img_install_stat)
 {
     return BOOT_HOOK_REGULAR;
 }
+
+int boot_img_install_progress_hook(int image_index, int slot)
+{
+    return -101;     /* Not provided */
+}

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -196,6 +196,15 @@
 #endif
 
 /*
+ * The image list and image upload may report additional key in responses,
+ * "install_progress" that reflects percentage of post processing
+ * completed after image upload.
+ */
+#ifdef CONFIG_BOOT_SERIAL_IMG_INSTALL_PROGRESS
+#define MCUBOOT_BOOT_SERIAL_IMG_INSTALL_PROGRESS
+#endif
+
+/*
  * The option enables code, currently in boot_serial, that attempts
  * to erase flash progressively, as update fragments are received,
  * instead of erasing whole image size of flash area after receiving


### PR DESCRIPTION
The RFC PR consists of two commits:
 1) Adding specification for `boot_img_install_progress_hook` that allows to report post processing status of uploaded image (for example decryption or processing on another core);
 2) Invocation points in image list and image upload processing, implementing RFC change to SMP protocol: https://github.com/zephyrproject-rtos/zephyr/pull/47253