### PR TITLE
boot_serial: add "zephyr/" prefix to __ZEPHYR__ includes

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -28,12 +28,12 @@
 #include "zcbor_encode.h"
 
 #ifdef __ZEPHYR__
-#include <sys/reboot.h>
-#include <sys/byteorder.h>
-#include <sys/__assert.h>
-#include <drivers/flash.h>
-#include <sys/crc.h>
-#include <sys/base64.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/sys/crc.h>
+#include <zephyr/sys/base64.h>
 #include <hal/hal_flash.h>
 #elif __ESPRESSIF__
 #include <bootloader_utility.h>


### PR DESCRIPTION
Hi, the Zephyr project moved all the headers into a "zephyr/" subdirectory some time ago, right now both works but we are in the process of deprecating the old format. This change makes mcuboot works with the new one.

--- 8< ---

Add relevant "zephyr/" prefixes to allow building with the Zephyr
option CONFIG_LEGACY_INCLUDE_PATH=n.
