### PR TITLE
zephyr: Enable waiting for CDC ACM DFU

### DIFF
--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -139,8 +139,8 @@ config BOOT_SERIAL_ENCRYPT_EC256
 	  described under "ECIES-P256 encryption" in docs/encrypted_images.md.
 
 config BOOT_SERIAL_WAIT_FOR_DFU
-	bool "Wait for a prescribed duration to see if DFU is invoked by receiving a mcumgr comand"
-	depends on BOOT_SERIAL_UART
+	bool "Wait for a prescribed duration to see if DFU is invoked by receiving a mcumgr command"
+	depends on BOOT_SERIAL_UART || BOOT_SERIAL_CDC_ACM
 	help
 	  If y, MCUboot waits for a prescribed duration of time to allow
 	  for DFU to be invoked. The serial recovery can be entered by receiving any


### PR DESCRIPTION
Made BOOT_SERIAL_WAIT_FOR_DFU depend on BOOT_SERIAL_CDC_ACM,
such that wait feature can be used with CDC ACM DFU

Fixed a typo as well

Signed-off-by: Simon Iversen <simon.iversen@nordicsemi.no>