### PR TITLE
zephyr/boards: increase bootloader size for nrf52840 big partition

### DIFF
--- a/boot/zephyr/boards/nrf52840_big.overlay
+++ b/boot/zephyr/boards/nrf52840_big.overlay
@@ -16,15 +16,15 @@
 
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x000000000 0x00010000>;
+				reg = <0x000000000 0x00011000>;
 			};
-			slot0_partition: partition@10000 {
+			slot0_partition: partition@11000 {
 				label = "image-0";
-				reg = <0x000010000 0x000074000>;
+				reg = <0x000011000 0x000074000>;
 			};
-			slot1_partition: partition@75000 {
+			slot1_partition: partition@85000 {
 				label = "image-1";
-				reg = <0x00084000 0x000074000>;
+				reg = <0x00085000 0x000074000>;
 			};
 	};
 };


### PR DESCRIPTION
sample.bootloader.mcuboot.usb_cdc_acm_recovery_log test build was
failing.

This particular configuration needs some more
flash that before.

This patch gives it 4 kB more, so build can pass

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>