### PR TITLE
boot_serial: fix serial recovery mode with timeout

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -848,7 +848,9 @@ boot_serial_read_console(const struct boot_uart_funcs *f,int timeout_in_ms)
 
     off = 0;
     while (timeout_in_ms > 0 || bs_entry) {
+#ifndef MCUBOOT_SERIAL_WAIT_FOR_DFU
         MCUBOOT_CPU_IDLE();
+#endif
         MCUBOOT_WATCHDOG_FEED();
 #ifdef MCUBOOT_SERIAL_WAIT_FOR_DFU
         uint32_t start = k_uptime_get_32();


### PR DESCRIPTION
If `BOOT_SERIAL_WAIT_FOR_DFU` is selected, the CPU shouldn't enter idle state, waiting for interrupt from the console because we expect booting if no mcumgr command is received within a configured timeout (with the `CONFIG_BOOT_SERIAL_WAIT_FOR_DFU_TIMEOUT`). Without this fix, when using `BOOT_SERIAL_WAIT_FOR_DFU` the boot process hangs forever, waiting for input from console.

This fixes original commit where optional timeout support in serial recovery was included: e3822f8180ed.