### PR TITLE
zephyr: Explicitly include cmsis.h

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -27,6 +27,12 @@
 #include <soc.h>
 #include <zephyr/linker/linker-defs.h>
 
+#if defined(CONFIG_CPU_AARCH32_CORTEX_A) || defined(CONFIG_CPU_AARCH32_CORTEX_R)
+#include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
+#elif defined(CONFIG_CPU_CORTEX_M)
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#endif
+
 #include "target.h"
 
 #include "bootutil/bootutil_log.h"


### PR DESCRIPTION
main.c uses CMSIS functions such as __set_MSP, which require
cmsis.h to be included. Up until now, that file was included
indirectly through other ARM headers. This patch explicitly
includes cmsis.h, for platforms on which those indirect includes
do not work.

Signed-off-by: Yonatan Schachter <yonatan.schachter@gmail.com>