### PR TITLE
zephyr: Remove devicetree 'label' property

### DIFF
--- a/boot/zephyr/boards/nrf52840_big.overlay
+++ b/boot/zephyr/boards/nrf52840_big.overlay
@@ -32,6 +32,5 @@
 &zephyr_udc0 {
 	cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 };

--- a/boot/zephyr/usb_cdc_acm.overlay
+++ b/boot/zephyr/usb_cdc_acm.overlay
@@ -1,6 +1,5 @@
 &zephyr_udc0 {
 	cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 };


### PR DESCRIPTION
zephyr is transition away from devicetree label property for nodes
that are associated with devices.  So remove it from
"zephyr,cdc-acm-uart" nodes.

Signed-off-by: Kumar Gala <galak@kernel.org>