### PR TITLE
boot_serial: explain disabled idle state in timeout based recovery

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -849,6 +849,11 @@ boot_serial_read_console(const struct boot_uart_funcs *f,int timeout_in_ms)
 
     off = 0;
     while (timeout_in_ms > 0 || bs_entry) {
+        /*
+         * Don't enter CPU idle state here if timeout based serial recovery is
+         * used as otherwise the boot process hangs forever, waiting for input
+         * from serial console (if single-thread mode is used).
+         */
 #ifndef MCUBOOT_SERIAL_WAIT_FOR_DFU
         MCUBOOT_CPU_IDLE();
 #endif


### PR DESCRIPTION
This is continuation of #1433 and only adds short explanation (in form of a comment) why CPU shouldn't enter idle state in timeout based serial recovery.

References:
- 3942e9bf8f60 ("boot_serial: fix serial recovery mode with timeout")
- #1433
- https://github.com/mcu-tools/mcuboot/pull/1433#issuecomment-1213043842

CC: @nvlsianpu 