### PR TITLE
zephyr: Remove devicetree 'label' property from flash nodes

### DIFF
--- a/boot/zephyr/boards/nrf52840dk_ram.overlay
+++ b/boot/zephyr/boards/nrf52840dk_ram.overlay
@@ -31,12 +31,9 @@
 			#size-cells = <1>;
 			erase-value = <0xff>;
 
-			label = "flash_ctrl";
-
 			flash_sim0: flash_sim@0 {
 				status = "okay";
 				compatible = "soc-nv-flash";
-				label = "simulated_flash";
 				erase-block-size = <4096>;
 				write-block-size = <1>;
 				reg = <0x00000000 DT_SIZE_K(40)>;

--- a/boot/zephyr/boards/nrf52840dk_ram_multi.overlay
+++ b/boot/zephyr/boards/nrf52840dk_ram_multi.overlay
@@ -39,12 +39,9 @@
 			#size-cells = <1>;
 			erase-value = <0xff>;
 
-			label = "flash_ctrl";
-
 			flash_sim0: flash_sim@0 {
 				status = "okay";
 				compatible = "soc-nv-flash";
-				label = "simulated_flash";
 				erase-block-size = <4096>;
 				write-block-size = <1>;
 				reg = <0x00000000 DT_SIZE_K(40)>;


### PR DESCRIPTION
zephyr is transition away from devicetree label property for nodes
that are associated with devices.  So remove it from flash nodes.

Signed-off-by: Kumar Gala <galak@kernel.org>