### PR TITLE
boot:zephyr: should clear mpu config

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -183,6 +183,11 @@ static void do_boot(struct boot_rsp *rsp)
     /* Disable the USB to prevent it from firing interrupts */
     usb_disable();
 #endif
+
+#if CONFIG_CPU_HAS_ARM_MPU || CONFIG_CPU_HAS_NXP_MPU
+    z_arm_clear_arm_mpu_config();
+#endif
+
 #if CONFIG_MCUBOOT_CLEANUP_ARM_CORE
     cleanup_arm_nvic(); /* cleanup NVIC registers */
 
@@ -192,9 +197,6 @@ static void do_boot(struct boot_rsp *rsp)
     SCB_DisableICache();
 #endif
 
-#if CONFIG_CPU_HAS_ARM_MPU || CONFIG_CPU_HAS_NXP_MPU
-    z_arm_clear_arm_mpu_config();
-#endif
 
 #if defined(CONFIG_BUILTIN_STACK_GUARD) && \
     defined(CONFIG_CPU_CORTEX_M_HAS_SPLIM)


### PR DESCRIPTION
Hello , everyone. 

I use mcuboot those day, i met a very strange things that if not call `z_arm_clear_arm_mpu_config`, it will hard fault.
![image](https://user-images.githubusercontent.com/4686802/184865118-94e31fc4-4eec-49fd-9cf2-e02128085ac0.png)

I config SRAM MPU in zephyr
![image](https://user-images.githubusercontent.com/4686802/184865823-2fa1ec96-f746-45aa-8185-1fbe05cdf78d.png)

So , we should `z_arm_clear_arm_mpu_config` if `CONFIG_CPU_HAS_ARM_MPU` = y . 


Signed-off-by: honglin leng <a909204013@gmail.com>