### PR TITLE
imgtool: Fix output of confirmed image in HEX format

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -243,12 +243,11 @@ class Image():
                                                   self.enctlv_len)
                 trailer_addr = (self.base_addr + self.slot_size) - trailer_size
                 if self.confirm and not self.overwrite_only:
-                    magic_size = 16
-                    magic_align_size = align_up(magic_size, self.max_align)
+                    magic_align_size = align_up(len(self.boot_magic), self.max_align)
                     image_ok_idx = -(magic_align_size + self.max_align)
-                    flag = bytearray([self.erased_val] * magic_align_size)
+                    flag = bytearray([self.erased_val] * self.max_align)
                     flag[0] = 0x01 # image_ok = 0x01
-                    h.puts(trailer_addr + image_ok_idx, bytes(flag))
+                    h.puts(trailer_addr + trailer_size + image_ok_idx, bytes(flag))
                 h.puts(trailer_addr + (trailer_size - len(self.boot_magic)),
                        bytes(self.boot_magic))
             h.tofile(path, 'hex')


### PR DESCRIPTION
This PR fixes https://github.com/mcu-tools/mcuboot/issues/1444