### PR TITLE
boot: nuttx: main: add suport for board late initialization.

### DIFF
--- a/boot/nuttx/main.c
+++ b/boot/nuttx/main.c
@@ -33,6 +33,27 @@
 #include "flash_map_backend/flash_map_backend.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Should we perform board-specific driver initialization?  There are two
+ * ways that board initialization can occur:  1) automatically via
+ * board_late_initialize() during bootupif CONFIG_BOARD_LATE_INITIALIZE
+ * or 2).
+ * via a call to boardctl() if the interface is enabled
+ * (CONFIG_BOARDCTL=y).
+ * If this task is running as an NSH built-in application, then that
+ * initialization has probably already been performed otherwise we do it
+ * here.
+ */
+
+#undef NEED_BOARDINIT
+
+#if defined(CONFIG_BOARDCTL) && !defined(CONFIG_NSH_ARCHINIT)
+#  define NEED_BOARDINIT 1
+#endif
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -78,6 +99,17 @@ int main(int argc, FAR char *argv[])
 {
   struct boot_rsp rsp;
   fih_int fih_rc = FIH_FAILURE;
+
+#ifndef CONFIG_NSH_ARCHINIT
+  /* Perform architecture-specific initialization (if configured) */
+  boardctl(BOARDIOC_INIT, 0);
+
+#  ifdef CONFIG_BOARDCTL_FINALINIT
+  /* Perform architecture-specific final-initialization (if configured) */
+  boardctl(BOARDIOC_FINALINIT, 0);
+
+#  endif
+#endif
 
   syslog(LOG_INFO, "*** Booting MCUboot build %s ***\n", CONFIG_MCUBOOT_VERSION);
 


### PR DESCRIPTION
boot: nuttx: main: add suport for board late initialization.

When using nuttx MCUBoot app as a main entry point in place of nsh_main it is necesary to perform board-specific driver initialization through boardctl().

Signed-off-by: Andrés Sánchez Pascual <tito97_sp@hotmail.com>