### PR TITLE
boot: zephyr: enable watchdog feed by default

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -556,10 +556,10 @@ endchoice
 
 config BOOT_WATCHDOG_FEED
 	bool "Feed the watchdog while doing swap"
-	default y if SOC_FAMILY_NRF
-	imply NRFX_WDT
-	imply NRFX_WDT0
-	imply NRFX_WDT1
+	default y
+	imply NRFX_WDT if SOC_FAMILY_NRF
+	imply NRFX_WDT0 if SOC_FAMILY_NRF
+	imply NRFX_WDT1 if SOC_FAMILY_NRF
 	help
 	  Enables implementation of MCUBOOT_WATCHDOG_FEED() macro which is
 	  used to feed watchdog while doing time consuming operations.

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -293,7 +293,6 @@
         }                                                     \
     } while (0)
 #else /* DT_NODE_HAS_STATUS(DT_ALIAS(watchdog0), okay) */
-#warning "MCUBOOT_WATCHDOG_FEED() is no-op"
 /* No vendor implementation, no-op for historical reasons */
 #define MCUBOOT_WATCHDOG_FEED()         \
     do {                                \


### PR DESCRIPTION
Since we have support for nRF and STM32 families, and non-vendor watchdog implementation let's enable this functionality by default. Imply NRFX_WDT && NRFX_WDT0 && NRFX_WDT1 only when SOC_FAMILY_NRF is being used.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>