### PR TITLE
boot: zephyr: return NULL if stm32 watchdog is not enabled

### DIFF
--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -273,11 +273,11 @@
 
 #define MCUBOOT_WATCHDOG_FEED() \
     do {                        \
-        const struct device* wdt =                            \
-            DEVICE_DT_GET(DT_INST(0, st_stm32_watchdog));     \
-        if (device_is_ready(wdt)) {                           \
-                wdt_feed(wtd, 0);                             \
-        }                                                     \
+        const struct device* wdt =                                  \
+            DEVICE_DT_GET_OR_NULL(DT_INST(0, st_stm32_watchdog));   \
+        if (device_is_ready(wdt)) {                                 \
+            wdt_feed(wtd, 0);                                       \
+        }                                                           \
     } while (0)
 
 #elif DT_NODE_HAS_STATUS(DT_ALIAS(watchdog0), okay) /* CONFIG_IWDG_STM32 */


### PR DESCRIPTION
Return the device pointer if the node identifier refers to a watchdog node with status “okay”, otherwise return NULL.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>