### PR TITLE
ci: bump zephyr ci image and sdk

### DIFF
--- a/.github/workflows/zephyr_build.yaml
+++ b/.github/workflows/zephyr_build.yaml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     # Docker image from the zephyr upstream. Includes SDK and other required tools
     container:
-      image: zephyrprojectrtos/ci:v0.21.0
+      image: zephyrprojectrtos/ci:v0.24.2
       options: '--entrypoint /bin/bash'
       volumes:
         - /home/runners/zephyrproject:/github/cache/zephyrproject

--- a/.github/workflows/zephyr_build.yaml
+++ b/.github/workflows/zephyr_build.yaml
@@ -45,7 +45,7 @@ jobs:
       volumes:
         - /home/runners/zephyrproject:/github/cache/zephyrproject
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
 
     steps:
       - name: Set versions when workflow_dispatch


### PR DESCRIPTION
Updates the CI workflows to use the Zephyr SDK 0.15.0 and CI image 0.24.2 for building and testing Zephyr in the CI.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>