### PR TITLE
imgtool: add option to export public PEM

### DIFF
--- a/docs/encrypted_images.md
+++ b/docs/encrypted_images.md
@@ -153,7 +153,8 @@ or `ed25519`. This will generate a keypair or private key.
 
 To extract the public key in source file form, use
 `imgtool getpub -k <input.pem> -l <lang>`, where lang can be one of `c` or
-`rust` (defaults to `c`).
+`rust` (defaults to `c`). To extract a public key in PEM form, use
+`imgtool getpub -k <input.pem> -l pem`.
 
 If using AES-KW, follow the steps in the next section to generate the
 required keys.

--- a/scripts/imgtool/keys/ecdsa.py
+++ b/scripts/imgtool/keys/ecdsa.py
@@ -33,6 +33,11 @@ class ECDSA256P1Public(KeyClass):
                 encoding=serialization.Encoding.DER,
                 format=serialization.PublicFormat.SubjectPublicKeyInfo)
 
+    def get_public_pem(self):
+        return self._get_public().public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo)
+
     def get_private_bytes(self, minimal):
         self._unsupported('get_private_bytes')
 

--- a/scripts/imgtool/keys/general.py
+++ b/scripts/imgtool/keys/general.py
@@ -37,6 +37,9 @@ class KeyClass(object):
                 indent="    ",
                 file=file)
 
+    def emit_public_pem(self, file=sys.stdout):
+        print(str(self.get_public_pem(), 'utf-8'), file=file, end='')
+
     def emit_private(self, minimal, file=sys.stdout):
         self._emit(
                 header="const unsigned char enc_priv_key[] = {",

--- a/scripts/imgtool/keys/rsa.py
+++ b/scripts/imgtool/keys/rsa.py
@@ -44,6 +44,11 @@ class RSAPublic(KeyClass):
                 encoding=serialization.Encoding.DER,
                 format=serialization.PublicFormat.PKCS1)
 
+    def get_public_pem(self):
+        return self._get_public().public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo)
+
     def get_private_bytes(self, minimal):
         self._unsupported('get_private_bytes')
 

--- a/scripts/imgtool/keys/x25519.py
+++ b/scripts/imgtool/keys/x25519.py
@@ -34,6 +34,11 @@ class X25519Public(KeyClass):
                 encoding=serialization.Encoding.DER,
                 format=serialization.PublicFormat.SubjectPublicKeyInfo)
 
+    def get_public_pem(self):
+        return self._get_public().public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo)
+
     def get_private_bytes(self, minimal):
         self._unsupported('get_private_bytes')
 

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -59,7 +59,7 @@ def gen_x25519(keyfile, passwd):
     keys.X25519.generate().export_private(path=keyfile, passwd=passwd)
 
 
-valid_langs = ['c', 'rust']
+valid_langs = ['c', 'rust', 'pem']
 keygens = {
     'rsa-2048':   gen_rsa2048,
     'rsa-3072':   gen_rsa3072,
@@ -125,6 +125,8 @@ def getpub(key, lang):
         key.emit_c_public()
     elif lang == 'rust':
         key.emit_rust_public()
+    elif lang == 'pem':
+        key.emit_public_pem()
     else:
         raise ValueError("BUG: should never get here!")
 


### PR DESCRIPTION
Update `getpub` with new `lang` option, "pem", which allows exporting a public key as a PEM file. This can later be distributed to be used for encrypting an image, and gets away with having to use openssl for this step.