### PR TITLE
DO NOT MERGE: zephyr/../mcuboot_config: fix typo in MCUBOOT_WATCHDOG_FEED()

### DIFF
--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -289,7 +289,7 @@
         const struct device* wdt =                            \
             DEVICE_DT_GET(DT_ALIAS(watchdog0));               \
         if (device_is_ready(wdt)) {                           \
-                wdt_feed(wtd, 0);                             \
+                wdt_feed(wdt, 0);                             \
         }                                                     \
     } while (0)
 #else /* DT_NODE_HAS_STATUS(DT_ALIAS(watchdog0), okay) */


### PR DESCRIPTION
wdt -> wtd
typo causes build faliure non frdm_k64f

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>