### PR TITLE
bootutil: loader: Add post copy hook to swap function

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1332,6 +1332,8 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
                      boot_status_fails);
     }
 #endif
+    rc = BOOT_HOOK_CALL(boot_copy_region_post_hook, 0, BOOT_CURR_IMG(state),
+                        BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT), size);
 
     return 0;
 }


### PR DESCRIPTION
Currently the post copy hook is only called from the `copy_region` function. However when another update method than `BOOT_UPGRADE_ONLY` is selected this function is not called. This adds post copy hook to the end of `boot_swap_image` when we know the swap is complete.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>