### PR TITLE
zephyr/sample.yaml Limit allowed build platforms

### DIFF
--- a/boot/zephyr/sample.yaml
+++ b/boot/zephyr/sample.yaml
@@ -5,6 +5,7 @@ sample:
 tests:
   sample.bootloader.mcuboot:
     tags: bootloader_mcuboot
+    platform_allow:  nrf52840dk_nrf52840 frdm_k64f disco_l475_iot1
     integration_platforms:
       - nrf52840dk_nrf52840
       - frdm_k64f


### PR DESCRIPTION
Building sample.bootloader.mcuboot for many platforms is not possible (for instance a qemu). The limit is need as otherwise zephyr-rtos/zephyr CI is failing on any push to main branch or nightly CI run.

This patch is mirror of what went into `zephyr-rtos/mcuboot` yet. It is needed for consistency.