### PR TITLE
[RFC] imgtool: change getpub exporting format parameter

### DIFF
--- a/docs/encrypted_images.md
+++ b/docs/encrypted_images.md
@@ -152,9 +152,9 @@ occurs and the information is spread across multiple areas.
 or `ed25519`. This will generate a keypair or private key.
 
 To extract the public key in source file form, use
-`imgtool getpub -k <input.pem> -l <lang>`, where lang can be one of `c` or
-`rust` (defaults to `c`). To extract a public key in PEM form, use
-`imgtool getpub -k <input.pem> -l pem`.
+`imgtool getpub -k <input.pem> -e <encoding>`, where `encoding` can be one of
+`lang-c` or `lang-rust` (defaults to `lang-c`). To extract a public key in PEM
+format, use `imgtool getpub -k <input.pem> -e pem`.
 
 If using AES-KW, follow the steps in the next section to generate the
 required keys.


### PR DESCRIPTION
Update a previous PR were PEM exporting was added to the `--lang` parameter, even though PEM is not a source code language per se.

This PR adds `--encoding/-e` to `getpub` command, for exporting in formats other than a language source code. `--lang` is left with a deprecation message, so it could be removed in a future version. The default behavior of exporting source code in C was preserved.