### PR TITLE
zephyr: allow the serial recovery without any GPIO defined

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -519,6 +519,7 @@ config MCUBOOT_LOG_THREAD_STACK_SIZE
 config MCUBOOT_INDICATION_LED
 	bool "Turns on LED indication when device is in DFU"
 	default n
+	select GPIO
 	help
 	  Device device activates the LED while in bootloader mode.
 	  bootloader-led0 alias must be set in the device's .dts

--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -9,7 +9,6 @@ menuconfig MCUBOOT_SERIAL
 	bool "MCUboot serial recovery"
 	default n
 	select REBOOT
-	select GPIO
 	select SERIAL
 	select UART_INTERRUPT_DRIVEN
 	select BASE64
@@ -19,6 +18,11 @@ menuconfig MCUBOOT_SERIAL
 	  If unsure, leave at the default value.
 
 if MCUBOOT_SERIAL
+
+config MCUBOOT_SERIAL_USE_GPIO
+	bool
+	default y if !BOOT_SERIAL_WAIT_FOR_DFU
+	select GPIO
 
 choice BOOT_SERIAL_DEVICE
 	prompt "Serial device"
@@ -56,6 +60,7 @@ config BOOT_MAX_LINE_INPUT_LEN
 	help
 	  Maximum length of commands transported over the serial port.
 
+if MCUBOOT_SERIAL_USE_GPIO
 config BOOT_SERIAL_DETECT_PORT
 	string "GPIO device to trigger serial recovery mode (DEPRECATED)"
 	default GPIO_0 if SOC_FAMILY_NRF
@@ -89,6 +94,7 @@ config BOOT_SERIAL_DETECT_DELAY
 	  Used to prevent the bootloader from loading on button press.
 	  Useful for powering on when using the same button as
 	  the one used to place the device in bootloader mode.
+endif # MCUBOOT_SERIAL_USE_GPIO
 
 config BOOT_ERASE_PROGRESSIVELY
 	bool "Erase flash progressively when receiving new firmware"

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -370,9 +370,9 @@ void zephyr_boot_log_stop(void)
         * !defined(CONFIG_LOG_PROCESS_THREAD) && !defined(ZEPHYR_LOG_MODE_MINIMAL)
         */
 
-#if defined(CONFIG_MCUBOOT_SERIAL) || defined(CONFIG_BOOT_USB_DFU_GPIO)
+#if defined(CONFIG_MCUBOOT_SERIAL_USE_GPIO) || defined(CONFIG_BOOT_USB_DFU_GPIO)
 
-#ifdef CONFIG_MCUBOOT_SERIAL
+#ifdef CONFIG_MCUBOOT_SERIAL_USE_GPIO
 #define BUTTON_0_DETECT_DELAY CONFIG_BOOT_SERIAL_DETECT_DELAY
 #else
 #define BUTTON_0_DETECT_DELAY CONFIG_BOOT_USB_DFU_DETECT_DELAY
@@ -387,7 +387,7 @@ static const struct gpio_dt_spec button0 = GPIO_DT_SPEC_GET(BUTTON_0_NODE, gpios
 
 #else /* fallback to legacy configuration */
 
-#if defined(CONFIG_MCUBOOT_SERIAL)
+#ifdef CONFIG_MCUBOOT_SERIAL_USE_GPIO
 
 /* The value of -1 is used by default. It must be properly specified for a board before used. */
 BUILD_ASSERT(CONFIG_BOOT_SERIAL_DETECT_PIN != -1);
@@ -483,7 +483,7 @@ static bool detect_pin(void)
 
     return (bool)pin_active;
 }
-#endif
+#endif /* defined(CONFIG_MCUBOOT_SERIAL_USE_GPIO) || defined(CONFIG_BOOT_USB_DFU_GPIO) */
 
 void main(void)
 {
@@ -512,7 +512,7 @@ void main(void)
 
     mcuboot_status_change(MCUBOOT_STATUS_STARTUP);
 
-#ifdef CONFIG_MCUBOOT_SERIAL
+#ifdef CONFIG_MCUBOOT_SERIAL_USE_GPIO
     if (detect_pin() &&
             !boot_skip_serial_recovery()) {
 #ifdef CONFIG_MCUBOOT_INDICATION_LED


### PR DESCRIPTION
Despite MCUBOOT support waiting on serial interface it always
requires GPIO pin which is a mistake.

Introduced intermediate CONFIG_MCUBOOT_SERIAL_USE_GPIO Kconfig
hidden option and used it for make code related to the pin-detection
excluded when CONFIG_BOOT_SERIAL_WAIT_FOR_DFU=y.

if someone will find out that usage of GPIO trigger and waiting on
DFU make any sens then CONFIG_MCUBOOT_SERIAL_USE_GPIO might be made
configurable. For now I don't see a sense in making that.