### PR TITLE
boot: serial: add missing Zephyr kernel.h include

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -33,6 +33,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/drivers/flash.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/crc.h>
 #include <zephyr/sys/base64.h>
 #include <hal/hal_flash.h>


### PR DESCRIPTION
boot_serial.c is using Zephyr Kernel APIs without including kernel.h.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>