### PR TITLE
Explicitly set module name in `zephyr/module.yml`

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,4 @@
+name: mcuboot
 samples:
   - boot/zephyr
 build:


### PR DESCRIPTION
Follow Zephyr v3.2.0 new recommendation to explicitly set module names to enable usage of ZEPHYR_<module-name-upper>_MODULE_DIR by other modules.

Verification:

1. (Pass) west build -p always -b nrf52840dk_nrf52840 bootloader/mcuboot/boot/zephyr/
2. (Pass) ./zephyr/scripts/twister --testsuite-root zephyr/tests/subsys/dfu/
3. (Pass) ./zephyr/scripts/twister --testsuite-root zephyr/samples/subsys/mgmt/mcumgr/smp_svr/
4. (Pass) ./zephyr/scripts/twister --testsuite-root bootloader/mcuboot/boot/zephyr/

Fixes #1491

Signed-off-by: Gregory Shue <gregory.shue@legrand.com>