### PR TITLE
Feature/1494 add formal req mgmt

### DIFF
--- a/reqs/consrs/.doorstop.yml
+++ b/reqs/consrs/.doorstop.yml
@@ -1,0 +1,5 @@
+settings:
+  digits: 5
+  parent: MCUBOOT.SYAD
+  prefix: MCUBOOT.CONSRS
+  sep: '-'

--- a/reqs/logrs/.doorstop.yml
+++ b/reqs/logrs/.doorstop.yml
@@ -1,0 +1,5 @@
+settings:
+  digits: 5
+  parent: MCUBOOT.SYAD
+  prefix: MCUBOOT.LOGRS
+  sep: '-'

--- a/reqs/nvmrs/.doorstop.yml
+++ b/reqs/nvmrs/.doorstop.yml
@@ -1,0 +1,5 @@
+settings:
+  digits: 5
+  parent: MCUBOOT.SYAD
+  prefix: MCUBOOT.NVMRS
+  sep: '-'

--- a/reqs/osrs/.doorstop.yml
+++ b/reqs/osrs/.doorstop.yml
@@ -1,0 +1,5 @@
+settings:
+  digits: 5
+  parent: MCUBOOT.SYAD
+  prefix: MCUBOOT.OSRS
+  sep: '-'

--- a/reqs/osrs/MCUBOOT.OSRS-00001.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00001.yml
@@ -1,0 +1,21 @@
+active: true
+derived: false
+header: |
+  Introduction
+level: 1.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  This document contains the OS System Element Requirements Specification (OSRS) for the MCUboot Project.
+
+  It is organized based on ISO/IEC/IEEE 29148:2018 Systems and software engineering - Life cycle processes - Requirements engineering, section 8.4.2 SyRS example outline.
+
+  Section 1 provides an introduction to the purpose, scope, and context of the MCUboot Project and its deliverables.
+
+  Section 2 lists referenced material.
+
+  Section 3 captures the formal requirements on the operation of the system element (system element requirements) to meet the assigned system requirements and architecture definition constraints.
+
+  Section 4 captures how the resulting system element will be verified that it meets all the assigned system element requirements.

--- a/reqs/osrs/MCUBOOT.OSRS-00002.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00002.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Purpose
+level: 1.1.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  The Operating System (OS) system element provides basic abstractions for building executables, scheduling work, and sharing resources among different threads/interrupts.

--- a/reqs/osrs/MCUBOOT.OSRS-00003.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00003.yml
@@ -1,0 +1,17 @@
+active: true
+derived: false
+header: |
+  OS_System_Element_Scope
+level: 1.2.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  The OS System Element provides the following capabilities, as needed, to the MCUboot executable:
+
+  - Extensible build and linking system
+  - Extensible configuration system
+  - Extensible and replaceable toolchain
+  - Primitives supporting preemptive and/or cooperative multi-threading.
+  - Automated test framework and test runner

--- a/reqs/osrs/MCUBOOT.OSRS-00004.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00004.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  OS_System_Element_Overview
+level: 1.3.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  OS System Element Overview

--- a/reqs/osrs/MCUBOOT.OSRS-00005.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00005.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Context
+level: 1.3.1.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Context

--- a/reqs/osrs/MCUBOOT.OSRS-00006.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00006.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Functions
+level: 1.3.2.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Functions

--- a/reqs/osrs/MCUBOOT.OSRS-00007.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00007.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  User_Characteristics
+level: 1.3.3.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  User Characteristics

--- a/reqs/osrs/MCUBOOT.OSRS-00008.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00008.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Definitions
+level: 1.4.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Definitions

--- a/reqs/osrs/MCUBOOT.OSRS-00009.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00009.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  References
+level: 2.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  References

--- a/reqs/osrs/MCUBOOT.OSRS-00010.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00010.yml
@@ -1,0 +1,10 @@
+active: true
+derived: false
+header: |
+  Reference_1
+level: 2.1.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: ''

--- a/reqs/osrs/MCUBOOT.OSRS-00011.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00011.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements
+level: 3.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Requirements

--- a/reqs/osrs/MCUBOOT.OSRS-00012.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00012.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Functional
+level: 3.1.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Requirements - Functional

--- a/reqs/osrs/MCUBOOT.OSRS-00013.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00013.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Usability
+level: 3.2.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Requirements - Usability

--- a/reqs/osrs/MCUBOOT.OSRS-00014.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00014.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Performance
+level: 3.3.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Requirements - Performance

--- a/reqs/osrs/MCUBOOT.OSRS-00015.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00015.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Interface
+level: 3.4.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Requirements - Interface

--- a/reqs/osrs/MCUBOOT.OSRS-00016.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00016.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_System_Operations
+level: 3.5.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Requirements - System Operations

--- a/reqs/osrs/MCUBOOT.OSRS-00017.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00017.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_System_Modes_and_States
+level: 3.6.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Requirements - System Modes and States

--- a/reqs/osrs/MCUBOOT.OSRS-00018.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00018.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Physical_Characteristics
+level: 3.7.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Requirements - Physical Characteristics

--- a/reqs/osrs/MCUBOOT.OSRS-00019.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00019.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Environmental_Conditions
+level: 3.8.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Requirements - Environmental Conditions

--- a/reqs/osrs/MCUBOOT.OSRS-00020.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00020.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requriements_-_Security
+level: 3.9.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Requirements - Security

--- a/reqs/osrs/MCUBOOT.OSRS-00021.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00021.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Information_Management
+level: 3.10.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Requirements - Information Management

--- a/reqs/osrs/MCUBOOT.OSRS-00022.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00022.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Policy_and_Regulation
+level: 3.11.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Requirements - Policy and Regulation

--- a/reqs/osrs/MCUBOOT.OSRS-00023.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00023.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_System_Life_Cycle_Sustainment
+level: 3.12.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Requirements - System Life Cycle Sustainment

--- a/reqs/osrs/MCUBOOT.OSRS-00024.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00024.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Packaging,_Handling,_Shipping_and_Transportation
+level: 3.13.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Requirements - Packaging, Handling, Shipping and Transportation

--- a/reqs/osrs/MCUBOOT.OSRS-00025.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00025.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications
+level: 4.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Verifications

--- a/reqs/osrs/MCUBOOT.OSRS-00026.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00026.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Functional
+level: 4.1.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Verifications - Functional

--- a/reqs/osrs/MCUBOOT.OSRS-00027.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00027.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Usability
+level: 4.2.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Verifications - Usability

--- a/reqs/osrs/MCUBOOT.OSRS-00028.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00028.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Performance
+level: 4.3.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Verifications - Performance

--- a/reqs/osrs/MCUBOOT.OSRS-00029.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00029.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Interface
+level: 4.4.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Verifications - Interface

--- a/reqs/osrs/MCUBOOT.OSRS-00030.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00030.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_System_Operations
+level: 4.5.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Verifications - System Operations

--- a/reqs/osrs/MCUBOOT.OSRS-00031.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00031.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_System_Modes_and_States
+level: 4.6.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Verifications - System Modes and States

--- a/reqs/osrs/MCUBOOT.OSRS-00032.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00032.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Physical_Characteristics
+level: 4.7.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Verifications - Physical Characteristics

--- a/reqs/osrs/MCUBOOT.OSRS-00033.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00033.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Environmental_Conditions
+level: 4.8.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Verifications - Environmental Conditions

--- a/reqs/osrs/MCUBOOT.OSRS-00034.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00034.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Security
+level: 4.9.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Verifications - Security

--- a/reqs/osrs/MCUBOOT.OSRS-00035.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00035.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Information_Management
+level: 4.10.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Verifications - Information Management

--- a/reqs/osrs/MCUBOOT.OSRS-00036.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00036.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Policy_and_Regulation
+level: 4.11.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Verifications - Policy and Regulation

--- a/reqs/osrs/MCUBOOT.OSRS-00037.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00037.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_System_Life_Cycle_Sustainment
+level: 4.12.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Verifications - System Life Cycle Sustainment

--- a/reqs/osrs/MCUBOOT.OSRS-00038.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00038.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Packaging,_Handling,_Shipping_and_Transportation
+level: 4.13.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  Verifications - Packaging, Handling, Shipping and Transportation

--- a/reqs/osrs/MCUBOOT.OSRS-00039.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00039.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Appendices
+level: 5.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Appendices

--- a/reqs/osrs/MCUBOOT.OSRS-00040.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00040.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Assumptions_and_Dependencies
+level: 5.1.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Assumptions and Dependencies

--- a/reqs/osrs/MCUBOOT.OSRS-00041.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00041.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Acronyms_and_Abbreviations
+level: 5.2.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Acronyms and Abbreviations

--- a/reqs/osrs/MCUBOOT.OSRS-00042.yml
+++ b/reqs/osrs/MCUBOOT.OSRS-00042.yml
@@ -1,0 +1,14 @@
+active: true
+derived: false
+header: |
+  MCUboot_image_automated_source_license_compatibility_verification
+level: 3.1.1.0
+links:
+- MCUBOOT.SYRS-00060: null
+normative: true
+ref: ''
+reviewed: null
+text: |
+  Where automated verification of compatibility of source licensing is available,
+  when automated verification of compatibility of source licensing is requested,
+  the build system of the provided ported MCUboot solution shall verify the compatibility of source licensing of all source files needed in the resulting executable image.

--- a/reqs/strs/.doorstop.yml
+++ b/reqs/strs/.doorstop.yml
@@ -1,0 +1,4 @@
+settings:
+  digits: 5
+  prefix: MCUBOOT.STRS
+  sep: '-'

--- a/reqs/strs/MCUBOOT.STRS-00001.yml
+++ b/reqs/strs/MCUBOOT.STRS-00001.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Introduction
+level: 1.0
+links: []
+normative: false
+ref: ''
+reviewed: rpAY0yHt9j_Fksyngr_o1zvSDaBq1_0J0B-wCEeSEKM=
+text: |
+  Introduction

--- a/reqs/strs/MCUBOOT.STRS-00001.yml
+++ b/reqs/strs/MCUBOOT.STRS-00001.yml
@@ -2,10 +2,26 @@ active: true
 derived: false
 header: |
   Introduction
-level: 1.0
+level: 1
 links: []
 normative: false
 ref: ''
 reviewed: rpAY0yHt9j_Fksyngr_o1zvSDaBq1_0J0B-wCEeSEKM=
 text: |
-  Introduction
+  This document contains the Stakeholder Requirements Specification (StRS) for the MCUboot Project.
+
+  It is organized based on ISO/IEC/IEEE 29148:2018 Systems and software engineering - Life cycle processes - Requirements engineering, section 8.3.2 StRS example outline.
+
+  Section 1 provides an introduction to the purpose, scope, and context of the MCUboot Project and its deliverables.
+
+  Section 2 lists referenced material.
+
+  Section 3 provides a more detailed description of the business-imposed requirements on the MCUboot Project and its deliverables.
+
+  Section 4 captures the requirements on the operation of the MCUboot Project ant its deliverables.
+
+  Section 5 captures user needs and requirements users face within the problem domain.
+
+  Section 6 captures a _conceptual_ description of the proposed system.
+
+  Section 7 captures any further constraints imposed on performing the MCUboot Project (e.g., cost, schedule).

--- a/reqs/strs/MCUBOOT.STRS-00002.yml
+++ b/reqs/strs/MCUBOOT.STRS-00002.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Stakeholder_Purpose
+level: 1.1.0
+links: []
+normative: false
+ref: ''
+reviewed: PJ_5Zzc3jQkWsrJEqci1zMGKpMhCN65q7juX3TqHF-g=
+text: |
+  Stakeholder Purpose

--- a/reqs/strs/MCUBOOT.STRS-00003.yml
+++ b/reqs/strs/MCUBOOT.STRS-00003.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Stakeholder_Scope
+level: 1.2.0
+links: []
+normative: false
+ref: ''
+reviewed: 5PLJ0OMDfwfN_a-Nli1RXmW6GafoEdYnbVA4eopB6Wk=
+text: |
+  Stakeholder Scope

--- a/reqs/strs/MCUBOOT.STRS-00004.yml
+++ b/reqs/strs/MCUBOOT.STRS-00004.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Overview
+level: 1.3.0
+links: []
+normative: false
+ref: ''
+reviewed: DU2tkS2zUpKFwDZ5PJtkARq4D-E-18VMI-sLZdRy-0Q=
+text: |
+  Overview

--- a/reqs/strs/MCUBOOT.STRS-00005.yml
+++ b/reqs/strs/MCUBOOT.STRS-00005.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Stakeholders
+level: 1.4.0
+links: []
+normative: false
+ref: ''
+reviewed: R9FXlZPOF-1rKr1PwOZd3o131o1BIR_lQwrrkIvFf6o=
+text: |
+  Stakeholders

--- a/reqs/strs/MCUBOOT.STRS-00006.yml
+++ b/reqs/strs/MCUBOOT.STRS-00006.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Business_Roles
+level: 1.4.1.0
+links: []
+normative: false
+ref: ''
+reviewed: kFe5dMMuerP-kq8k5pYBdu8QQrJvrzU8aTMZN9cmDvo=
+text: |
+  Business Roles

--- a/reqs/strs/MCUBOOT.STRS-00007.yml
+++ b/reqs/strs/MCUBOOT.STRS-00007.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Marketing_Roles
+level: 1.4.2.0
+links: []
+normative: false
+ref: ''
+reviewed: OWBnZ7BFn0fBnJ52C6q2leu7-6ChdeASwJu4iNVurwA=
+text: |
+  Marketing Roles

--- a/reqs/strs/MCUBOOT.STRS-00008.yml
+++ b/reqs/strs/MCUBOOT.STRS-00008.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Regulatory_Authorities
+level: 1.4.3.0
+links: []
+normative: false
+ref: ''
+reviewed: ZIKc1sv431IdZ-pwQ2N5BpkF88djEc_L8iKkKs0HDX4=
+text: |
+  Regulatory Authorities

--- a/reqs/strs/MCUBOOT.STRS-00009.yml
+++ b/reqs/strs/MCUBOOT.STRS-00009.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Engineering_Personas
+level: 1.4.4.0
+links: []
+normative: false
+ref: ''
+reviewed: ckctqHVrSvK2FssSUWiqlAam3U9FLOFt-MvIa3c1Grg=
+text: |
+  Engineering Personas

--- a/reqs/strs/MCUBOOT.STRS-00010.yml
+++ b/reqs/strs/MCUBOOT.STRS-00010.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Manufacturing_Personas
+level: 1.4.5.0
+links: []
+normative: false
+ref: ''
+reviewed: Cy8hKUh5Bu7siPMuRt9FGZxxOkIrYs1u0d6ACEP4POk=
+text: |
+  Manufacturing Personas

--- a/reqs/strs/MCUBOOT.STRS-00011.yml
+++ b/reqs/strs/MCUBOOT.STRS-00011.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  User_Personas
+level: 1.4.6.0
+links: []
+normative: false
+ref: ''
+reviewed: VeWYkpIUAF1ff52cGORAS3GBrMzWzQtqFEiU78TDSOw=
+text: |
+  User Personas

--- a/reqs/strs/MCUBOOT.STRS-00012.yml
+++ b/reqs/strs/MCUBOOT.STRS-00012.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  References
+level: 2.0
+links: []
+normative: false
+ref: ''
+reviewed: of5zK7aW8DN7Q9TnqfNAnS_l_aymeLkXL2XZazxJq0I=
+text: |
+  References

--- a/reqs/strs/MCUBOOT.STRS-00013.yml
+++ b/reqs/strs/MCUBOOT.STRS-00013.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Business_Management_Requirements
+level: 3.0
+links: []
+normative: false
+ref: ''
+reviewed: krz2TP6GnQkXBN6lCxhgF6Bq2IYG3q88jrUoTZi9z3k=
+text: |
+  Business Management Requirements

--- a/reqs/strs/MCUBOOT.STRS-00014.yml
+++ b/reqs/strs/MCUBOOT.STRS-00014.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Business_Environment
+level: 3.1.0
+links: []
+normative: false
+ref: ''
+reviewed: 9GCyu2FjhDWnjyCTUA_6_aTQxkGy6VlKR7kLQfXLWaE=
+text: |
+  Business Environment

--- a/reqs/strs/MCUBOOT.STRS-00015.yml
+++ b/reqs/strs/MCUBOOT.STRS-00015.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Mission,_Goals,_and_Objective
+level: 3.2.0
+links: []
+normative: false
+ref: ''
+reviewed: 2xvOck_Jl8Q6CJyZzc9beJn3fErTbEnKOlc4qa8Df84=
+text: |
+  Mission, Goals and Objective

--- a/reqs/strs/MCUBOOT.STRS-00016.yml
+++ b/reqs/strs/MCUBOOT.STRS-00016.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Business_Model
+level: 3.3.0
+links: []
+normative: false
+ref: ''
+reviewed: pM_3mi7gnPzINoEHp0zRmo7fWeZzW6kOvgjdRbO1DH0=
+text: |
+  Business Model

--- a/reqs/strs/MCUBOOT.STRS-00017.yml
+++ b/reqs/strs/MCUBOOT.STRS-00017.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Information_Environment
+level: 3.4.0
+links: []
+normative: false
+ref: ''
+reviewed: vR-c_H2lohqzbtZlom3PUQHWfZFU7V2j4sX--y-sZmg=
+text: |
+  Information Environment

--- a/reqs/strs/MCUBOOT.STRS-00018.yml
+++ b/reqs/strs/MCUBOOT.STRS-00018.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  System_Operation_Requirements
+level: 4.0
+links: []
+normative: false
+ref: ''
+reviewed: XcymxJD6XkL_csqT7NjkOw-vlDL1gkDBfZPMb9Vd6VE=
+text: |
+  System Operation Requirements

--- a/reqs/strs/MCUBOOT.STRS-00019.yml
+++ b/reqs/strs/MCUBOOT.STRS-00019.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  System_Processes
+level: 4.1.0
+links: []
+normative: false
+ref: ''
+reviewed: 5lS0yphMcXwauj9ODKBMAQj_84AwcBehwsQkjYGyRJE=
+text: |
+  System Processes

--- a/reqs/strs/MCUBOOT.STRS-00020.yml
+++ b/reqs/strs/MCUBOOT.STRS-00020.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  System_Operational_Policies_and_Rules
+level: 4.2.0
+links: []
+normative: false
+ref: ''
+reviewed: UP8E-fSIj1BWTWmASgkDFRw0CuqEKEBXxSfwVbmb4wM=
+text: |
+  System Operational Policies and Rules

--- a/reqs/strs/MCUBOOT.STRS-00021.yml
+++ b/reqs/strs/MCUBOOT.STRS-00021.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  System_Operational_Constraints
+level: 4.3.0
+links: []
+normative: false
+ref: ''
+reviewed: Zdqk6UG9pzLjJJHwMWpiVJWS07yIRdD7GYw3a8vlvQA=
+text: |
+  System Operational Constraints

--- a/reqs/strs/MCUBOOT.STRS-00022.yml
+++ b/reqs/strs/MCUBOOT.STRS-00022.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  System_Operational_Modes_and_States
+level: 4.4.0
+links: []
+normative: false
+ref: ''
+reviewed: kxvFplNnOCU7TE1g9ATvdvdEkS1g-LM-7Au5A8_IrX8=
+text: |
+  System Operational Modes and States

--- a/reqs/strs/MCUBOOT.STRS-00023.yml
+++ b/reqs/strs/MCUBOOT.STRS-00023.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  User_Requirements
+level: 5.0
+links: []
+normative: false
+ref: ''
+reviewed: fIuhtLd9hfy7PkHZbeDWgGkzpKIrPfUq5KQv2GSUi0Q=
+text: |
+  User Requirements

--- a/reqs/strs/MCUBOOT.STRS-00024.yml
+++ b/reqs/strs/MCUBOOT.STRS-00024.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Persona_1
+level: 5.1.0
+links: []
+normative: false
+ref: ''
+reviewed: gL25TEPpyReMQgqShcr28VpFqc_dWFoKy9U2l254SWU=
+text: |
+  Persona 1

--- a/reqs/strs/MCUBOOT.STRS-00024.yml
+++ b/reqs/strs/MCUBOOT.STRS-00024.yml
@@ -1,11 +1,11 @@
 active: true
 derived: false
 header: |
-  Persona_1
+  Persona_Template
 level: 5.1.0
 links: []
 normative: false
 ref: ''
 reviewed: gL25TEPpyReMQgqShcr28VpFqc_dWFoKy9U2l254SWU=
 text: |
-  Persona 1
+  Persona Template

--- a/reqs/strs/MCUBOOT.STRS-00025.yml
+++ b/reqs/strs/MCUBOOT.STRS-00025.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Persona_1
+level: 1.4.6.1.0
+links: []
+normative: false
+ref: ''
+reviewed: jNoYCnxXRo9x8jJtBQjr1C01PeIOqkk6_eTwhkZYIvk=
+text: |
+  Persona 1

--- a/reqs/strs/MCUBOOT.STRS-00025.yml
+++ b/reqs/strs/MCUBOOT.STRS-00025.yml
@@ -1,11 +1,49 @@
 active: true
 derived: false
 header: |
-  Persona_1
-level: 1.4.6.1.0
+  Persona_Template
+level: 1.4.6.1
 links: []
 normative: false
 ref: ''
 reviewed: jNoYCnxXRo9x8jJtBQjr1C01PeIOqkk6_eTwhkZYIvk=
 text: |
-  Persona 1
+  Name:  Given name, job title
+
+  Description:
+
+  - "Optional quote"
+  - Age:
+  - Job:
+  - Income:
+  - Education:
+  - Family:
+  - Location:
+  - Hobbies/Interests
+
+  Confidence Rating:
+
+  Responsibilities:
+
+  - Responsibility 1
+  - Responsibility 2
+
+  Pain Points:
+
+  - Pain point 1
+  - Pain point 2
+
+  Goals:
+
+  - Goal 1
+
+  Influences:
+
+  - Influence 1
+  - Influence 2
+
+  Technology:
+
+  - Technical Level
+  - Tech Used 1
+  - Tech Used 2

--- a/reqs/strs/MCUBOOT.STRS-00026.yml
+++ b/reqs/strs/MCUBOOT.STRS-00026.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Detailed_Life-cycle_Concepts_of_Proposed_System
+level: 6.0
+links: []
+normative: false
+ref: ''
+reviewed: jWy1-SDmGbQ_CuxYA1qbnh8gVmk948wRimrb3Dj_7yU=
+text: |
+  Detailed Life-cycle Concepts of Proposed System

--- a/reqs/strs/MCUBOOT.STRS-00027.yml
+++ b/reqs/strs/MCUBOOT.STRS-00027.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Operational_Concept
+level: 6.1.0
+links: []
+normative: false
+ref: ''
+reviewed: W9ADkr_T1K0LfE5GyoFJsmcsGv3nkP89amxIOumNHJo=
+text: |
+  Operational Concept

--- a/reqs/strs/MCUBOOT.STRS-00028.yml
+++ b/reqs/strs/MCUBOOT.STRS-00028.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Operational_Scenarios
+level: 6.2.0
+links: []
+normative: false
+ref: ''
+reviewed: UKRPAtefi2DS1gjzCQJZnqu5VXtb8ygJbADSYNUdFUs=
+text: |
+  Operational Scenarios

--- a/reqs/strs/MCUBOOT.STRS-00029.yml
+++ b/reqs/strs/MCUBOOT.STRS-00029.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Acquisition_Concept
+level: 6.3.0
+links: []
+normative: false
+ref: ''
+reviewed: Z71pfeBQGTZLQXCgXs7LewQhdl8H-LiFiPsYjF-1ktU=
+text: |
+  Acquisition Concept

--- a/reqs/strs/MCUBOOT.STRS-00030.yml
+++ b/reqs/strs/MCUBOOT.STRS-00030.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Deployment_Concept
+level: 6.4.0
+links: []
+normative: false
+ref: ''
+reviewed: ZIEls1DoSBP4tbVjDa9bxI3z2vzQeCKS976HLV7ZVyg=
+text: |
+  Deployment Concept

--- a/reqs/strs/MCUBOOT.STRS-00031.yml
+++ b/reqs/strs/MCUBOOT.STRS-00031.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Support_Concept
+level: 6.5.0
+links: []
+normative: false
+ref: ''
+reviewed: l0Ym-w7lEmxZ543hCk8ClFOxvyDjbgcnP4Ox_19IAms=
+text: |
+  Support Concept

--- a/reqs/strs/MCUBOOT.STRS-00032.yml
+++ b/reqs/strs/MCUBOOT.STRS-00032.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Retirement_Concept
+level: 6.6.0
+links: []
+normative: false
+ref: ''
+reviewed: fNjWZhKi3wDA_-kqo8WR4k8pbua99uF469CKkXsVRpM=
+text: |
+  Retirement Concept

--- a/reqs/strs/MCUBOOT.STRS-00033.yml
+++ b/reqs/strs/MCUBOOT.STRS-00033.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Project_Constraints
+level: 7.0
+links: []
+normative: false
+ref: ''
+reviewed: bbtdZGKYJrKWHz4xD9odh6XjRJDttWMr1JcVYAmkgX0=
+text: |
+  Project Constraints

--- a/reqs/strs/MCUBOOT.STRS-00034.yml
+++ b/reqs/strs/MCUBOOT.STRS-00034.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Constraints_-_Area_1
+level: 7.1.0
+links: []
+normative: false
+ref: ''
+reviewed: bC-Mct6SoTezJAWXgiIjLS61EI3cl6xoyo4qcdS_XxU=
+text: |
+  Constraints - Area 1

--- a/reqs/strs/MCUBOOT.STRS-00035.yml
+++ b/reqs/strs/MCUBOOT.STRS-00035.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Validations
+level: 8.0
+links: []
+normative: false
+ref: ''
+reviewed: aQOlSunEiGPN3JbOMag5k_NKMPp6hLp2mt-lb0Kg9vw=
+text: |
+  Validations

--- a/reqs/strs/MCUBOOT.STRS-00036.yml
+++ b/reqs/strs/MCUBOOT.STRS-00036.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Validations_-_Area_1
+level: 8.1.0
+links: []
+normative: false
+ref: ''
+reviewed: SqF1Wn7lDv3Hmude5u9o83dlkPuh5yAqtBX3PfEsyJs=
+text: |
+  Validations - Area 1

--- a/reqs/strs/MCUBOOT.STRS-00037.yml
+++ b/reqs/strs/MCUBOOT.STRS-00037.yml
@@ -2,9 +2,9 @@ active: true
 derived: false
 header: |
   Reference_1
-level: 2.1.0
+level: 2.1
 links: []
-normative: false
+normative: true
 ref: ''
 reviewed: wJYwFDdhA5r1dbqRCKpxC8SoiPoOH0U60juBlEeFlU4=
 text: |

--- a/reqs/strs/MCUBOOT.STRS-00037.yml
+++ b/reqs/strs/MCUBOOT.STRS-00037.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Reference_1
+level: 2.1.0
+links: []
+normative: false
+ref: ''
+reviewed: wJYwFDdhA5r1dbqRCKpxC8SoiPoOH0U60juBlEeFlU4=
+text: |
+  Reference 1

--- a/reqs/strs/MCUBOOT.STRS-00038.yml
+++ b/reqs/strs/MCUBOOT.STRS-00038.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Stakeholder_Purpose_Background
+level: 1.1.1
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  TBD

--- a/reqs/strs/MCUBOOT.STRS-00039.yml
+++ b/reqs/strs/MCUBOOT.STRS-00039.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Scope_of_MCUboot_Project
+level: 1.2.1
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  The MCUboot Project seeks to produce, develop and maintain an open-source reference secure bootloader for microcontroller-based systems.
+
+  The scope of the MCUboot Project is a secure boot for 32-bit Microcontrollers.

--- a/reqs/strs/MCUBOOT.STRS-00040.yml
+++ b/reqs/strs/MCUBOOT.STRS-00040.yml
@@ -1,0 +1,26 @@
+active: true
+derived: false
+header: |
+  Overview_Project_Context
+level: 1.3.1
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  The scope of the MCUboot Project includes usage in the following domains:
+
+    - RTOS ecosystem providers
+      - OSS Projects
+      - Commercial Vendors
+        - MCU/SOC chip vendors
+        - Commercial RTOS providers
+    - MCU-based Product integrators
+      - Commercial
+      - Education
+      - FOSS
+
+  Additional stakeholders are introduced with the focus on secure boot:
+
+    - Regulatory Agencies (including safety-critical agencies)
+    - Standards Certification Businesses

--- a/reqs/strs/MCUBOOT.STRS-00041.yml
+++ b/reqs/strs/MCUBOOT.STRS-00041.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Roadmap
+level: 3.3.1
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  The issues being planned and worked on are tracked using GitHub issues. To participate please visit MCUboot Issues on github.

--- a/reqs/strs/MCUBOOT.STRS-00042.yml
+++ b/reqs/strs/MCUBOOT.STRS-00042.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  About_membership_and_how_to_join
+level: 3.3.2
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Companies and other organisations who adopt, deploy or contribute to MCUboot are invited to join the MCUboot community project. Membership of the project is open to all and governance is overseen by a board of Member representatives.
+
+  To join the project, a company needs to sign and return a copy of the Membership Agreement and pay an annual fee.

--- a/reqs/strs/MCUBOOT.STRS-00043.yml
+++ b/reqs/strs/MCUBOOT.STRS-00043.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  MCUboot_and_Linaro
+level: 3.3.3
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Memberhsip of the project is independent of membership of Linaro. Linaro provides governance, hosting and other services.

--- a/reqs/strs/MCUBOOT.STRS-00044.yml
+++ b/reqs/strs/MCUBOOT.STRS-00044.yml
@@ -1,0 +1,10 @@
+active: true
+derived: false
+header: ''
+level: 3.2.1
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  The goal of MCUboot is to define a common infrastructure for the bootloader, system flash layout on microcontroller systems, and to provide a secure bootloader that enables easy software upgrade.

--- a/reqs/strs/MCUBOOT.STRS-00045.yml
+++ b/reqs/strs/MCUBOOT.STRS-00045.yml
@@ -1,0 +1,10 @@
+active: true
+derived: false
+header: ''
+level: 3.2.2
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  The misssion of the MCUboot Project is to produce, develop amdn maintin an open-source reference for secure bootloader for microcontroller-based systems.

--- a/reqs/strs/MCUBOOT.STRS-00046.yml
+++ b/reqs/strs/MCUBOOT.STRS-00046.yml
@@ -1,0 +1,23 @@
+active: true
+derived: false
+header: |
+  Project_Charter
+level: 3.3.4
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  The MCUboot Project Charter is located at https://www.mcuboot.com/project-charter. It covers the following items:
+
+  1. Mission of the MCUboot Project.
+  2. Membership
+  3. Project Governing Board
+  4. Conduct of Board Meetings
+  5. Quorum and Voting
+  6. Antitrust Guidelines
+  7. Budget
+  8. Treasury and Project Expenses
+  9. Project IP Policy and Licensing
+  10. Technical Steering Committee("TSC")
+  11: Amendments

--- a/reqs/strs/MCUBOOT.STRS-00047.yml
+++ b/reqs/strs/MCUBOOT.STRS-00047.yml
@@ -1,0 +1,52 @@
+active: true
+derived: false
+header: |
+  Inaya,_Firmware_Integration_Engineer
+level: 1.4.6.2
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Name:  Inaya, Firmware Integration Engineer
+
+  Description:
+
+  - "Optional quote"
+  - Age: 31
+  - Job: IoT Device Firmware Developer
+  - Income:
+  - Education: College
+  - Family:
+  - Location:
+  - Hobbies/Interests:
+
+  Confidence Rating: Medium
+
+  Responsibilities:
+
+  A typical day for Inaya is spent integrating and sustaining integration of 10+ closely related products developed over the last 5 years. Each product requires an immutable boot loader and an application image. Some may require multi-stage boot. She is responsible for the integration of each of these, and for sustainment of integrations as security issues are discovered and addressed, and application features are enhanced.
+
+  Pain Points:
+
+  - Instability of interfaces and configuration points.
+  - Finding and resolving feature enhancements bundled with necessary security fixes.
+  - Having to use a different integration/verification process or tools for different sets of products.
+  - Having to integrate, verify and release security fixes for the entire set of products within a couple weeks.
+
+  Goals:
+
+  - Getting the job done right the first time so security, safety, and/or feature issues do not escape to the field.
+  - Having thorough objective evidence that immutable boot code is complete, correct, and meets the security standard chosen by her business.
+
+  Influences:
+
+  - The Engineering architect setting technical direction for the business.
+  - The open source projects being integrated into her product.
+
+
+  Technology:
+
+  - Technical Level: Proficient
+  - Uses Linux and Windows for development
+  - Uses JTAG-based tools for device firmware debugging

--- a/reqs/strs/MCUBOOT.STRS-00048.yml
+++ b/reqs/strs/MCUBOOT.STRS-00048.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Inaya,_Firmware_Integration
+level: 5.2.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Inaya, Firmware Integration

--- a/reqs/strs/MCUBOOT.STRS-00049.yml
+++ b/reqs/strs/MCUBOOT.STRS-00049.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Executable_image_source_licensing_check
+level: 5.2.2.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer,
+  I need to verify the compatibility of source licensing of all source files needed in the resulting executable image,
+  so that my business is not exposed to unknown licensing liabilities.

--- a/reqs/strs/MCUBOOT.STRS-00050.yml
+++ b/reqs/strs/MCUBOOT.STRS-00050.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Safety-certifiable_bootloaders
+level: 5.2.3.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer for a safety-critical device,
+  I need to configure and generate a bootloader image with all the auditable artifacts needed for the safety certification chosen by my business,
+  so that I can sell my product.

--- a/reqs/strs/MCUBOOT.STRS-00051.yml
+++ b/reqs/strs/MCUBOOT.STRS-00051.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Security-certifiable_bootloaders
+level: 5.2.4.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer for a regulated secure device,
+  I need to configure and generate a bootloader image with all the auditable artifacts needed for the security certification chosen by my business,
+  so that I can sell my product.

--- a/reqs/strs/MCUBOOT.STRS-00052.yml
+++ b/reqs/strs/MCUBOOT.STRS-00052.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Re-verifiable_with_replacable_toolchains
+level: 5.2.5.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer for a regulated device,
+  I need to re-verify all used open source implementations with my replacement qualified toolchain,
+  so that my product can meet certification criteria.

--- a/reqs/strs/MCUBOOT.STRS-00053.yml
+++ b/reqs/strs/MCUBOOT.STRS-00053.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Easily_retargetable
+level: 5.2.6.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer,
+  I need to quickly and easily retarget my bootloader feature configuration at replacement hardware,
+  so I can rapidly and predictably deliver a bootloader to the manufacturing line for the replacement MCU.

--- a/reqs/strs/MCUBOOT.STRS-00054.yml
+++ b/reqs/strs/MCUBOOT.STRS-00054.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Resilient_to_power_outages
+level: 5.2.12.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer for inaccessibly located devices,
+  I need the bootloader to be resilient to power outages,
+  so that my device does not die due to an untimely power loss.

--- a/reqs/strs/MCUBOOT.STRS-00055.yml
+++ b/reqs/strs/MCUBOOT.STRS-00055.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Configurable_crypto_algorithm
+level: 5.2.15.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer for devices secured with cryptography,
+  I need the bootloader to be configurable to use the standard cryptographic algorithms of my choosing,
+  so that my device uses algorithms appropriate to my product domain.

--- a/reqs/strs/MCUBOOT.STRS-00056.yml
+++ b/reqs/strs/MCUBOOT.STRS-00056.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Composable_UI
+level: 5.2.18.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer for devices in visble locations,
+  I need the bootloader to drive a User Interface of my specification,
+  so that I can visually distinguish between a device with no valid application image, a device that has finished booting and hung in the application, and a device that is applying an update.

--- a/reqs/strs/MCUBOOT.STRS-00057.yml
+++ b/reqs/strs/MCUBOOT.STRS-00057.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Persistent_security_event_logs
+level: 5.2.19.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer,
+  I need the bootloader to persistently log security events,
+  so I can perform boot and update failure analysis on a returned device.

--- a/reqs/strs/MCUBOOT.STRS-00058.yml
+++ b/reqs/strs/MCUBOOT.STRS-00058.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  FW_downgrade_prevention
+level: 5.2.20.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer of consumer devices,
+  I need the bootloader to prevent downgrading the version of application firmware,
+  so the device will prevent re-opening security holes discovered in downgraded versions.

--- a/reqs/strs/MCUBOOT.STRS-00059.yml
+++ b/reqs/strs/MCUBOOT.STRS-00059.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  FW_downgrade_allowance
+level: 5.2.21.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer of commercial/industrial devices,
+  I need the bootloader to allow downgrading the version of application firmware,
+  so the existing devices at the customer installation used in system update evaluations can be returned to their prior condition.

--- a/reqs/strs/MCUBOOT.STRS-00060.yml
+++ b/reqs/strs/MCUBOOT.STRS-00060.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Boot_image_metadata
+level: 5.2.7.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer,
+  I need the bootloader to expose metadata and status about itself to the loaded image,
+  so that the loaded image can report this data out for diagnostics.

--- a/reqs/strs/MCUBOOT.STRS-00061.yml
+++ b/reqs/strs/MCUBOOT.STRS-00061.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Well-defined_HW_state_on_image_handoff
+level: 5.2.8.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer,
+  I need the bootloader to have the MCU hardware in a well-defined condition upon handoff to the loaded image,
+  so the loaded image can avoid unnecessary and/or undesirable hardware reconfiguration.

--- a/reqs/strs/MCUBOOT.STRS-00062.yml
+++ b/reqs/strs/MCUBOOT.STRS-00062.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Shared_candidate_image_validation_specs
+level: 5.2.9.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer,
+  I need the application image to validate candidate FW updates in the same way as the boot image will,
+  so that candidate images can be invalidated without having to reboot.

--- a/reqs/strs/MCUBOOT.STRS-00063.yml
+++ b/reqs/strs/MCUBOOT.STRS-00063.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Configurable_as_bootloader_in_RAM
+level: 5.2.13.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer using MCUs that do not support overlapped execution from the flash being programmed,
+  I need to configure the bootloader to run from RAM,
+  so the bootloader can apply the update.

--- a/reqs/strs/MCUBOOT.STRS-00064.yml
+++ b/reqs/strs/MCUBOOT.STRS-00064.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Configurable_as_second-stage_bootloader
+level: 5.2.14.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer using MCU with a lockable boot flash partition too small for my full set of boot functionality,
+  I need the bootloader source to be configurable as a minimal, immutable first stage image and configurable as a full-featured second-stage bootloader image,
+  so the MCU constraint can boot my application.

--- a/reqs/strs/MCUBOOT.STRS-00065.yml
+++ b/reqs/strs/MCUBOOT.STRS-00065.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Multi-partition_image_support
+level: 5.2.10.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer of a FW image spread across multiple flash parts (e.g., executable, discontiguous file system),
+  I need the bootloader to atomically update and validate an image spread across discontiguous flash partitions,
+  so the entire application image can be updated.

--- a/reqs/strs/MCUBOOT.STRS-00066.yml
+++ b/reqs/strs/MCUBOOT.STRS-00066.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Image_partition_dependency_checking
+level: 5.2.11.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer of a FW image spread across multiple flash parts (e.g., executable, discontiguous file system),
+  I need the bootloader to only update image partitions based on dependencies,
+  so that update time can be reduced by skipping unnecessary partition updates.

--- a/reqs/strs/MCUBOOT.STRS-00067.yml
+++ b/reqs/strs/MCUBOOT.STRS-00067.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Configurable_serial_upgrade_interface
+level: 5.2.16.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer,
+  I need to configure the bootloader with a serial upgrade capability,
+  so I can more easily diagnose integration issues on new MCUs and board designs.

--- a/reqs/strs/MCUBOOT.STRS-00068.yml
+++ b/reqs/strs/MCUBOOT.STRS-00068.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Executable_image_SPDX_BOM_generation_support
+level: 5.2.1.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer,
+  I need the bootloader build system to generate a BOM for the boot image,
+  so that I have a publicizable artifact for security investigations.

--- a/reqs/strs/MCUBOOT.STRS-00069.yml
+++ b/reqs/strs/MCUBOOT.STRS-00069.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Configurable_as_single_threaded_image
+level: 5.2.22.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer,
+  I need to configure the bootloader so the boot image is single-threaded,
+  so that the image is as simple (and small) as possible.

--- a/reqs/strs/MCUBOOT.STRS-00070.yml
+++ b/reqs/strs/MCUBOOT.STRS-00070.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Configurable_as_multi_threaded_image
+level: 5.2.23.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer,
+  I need to configure the bootloader so the boot image is multi-threaded,
+  so that the image can reuse RTOS drivers for complex subsystems (e.g., USB UART device).

--- a/reqs/strs/MCUBOOT.STRS-00071.yml
+++ b/reqs/strs/MCUBOOT.STRS-00071.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Composable_serial_recovery_driver
+level: 5.2.17.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer,
+  I need the bootloader to drive a serial interface of my choice,
+  so I can perform serial recovery over the available hardware.

--- a/reqs/strs/MCUBOOT.STRS-00072.yml
+++ b/reqs/strs/MCUBOOT.STRS-00072.yml
@@ -1,0 +1,14 @@
+active: true
+derived: false
+header: |
+  Documentation_of_Qualified_Development_Process
+level: 5.2.24.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  As a Firmware Integration Engineer for a regulated device,
+  I need to produce process documentation that demonstrates that the product
+  was developed according to a qualified process,
+  so that the product can pass a process audit.

--- a/reqs/syad/.doorstop.yml
+++ b/reqs/syad/.doorstop.yml
@@ -1,0 +1,5 @@
+settings:
+  digits: 5
+  parent: MCUBOOT.SYRS
+  prefix: MCUBOOT.SYAD
+  sep: '-'

--- a/reqs/syad/MCUBOOT.SYAD-00001.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00001.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Introduction
+level: 1.0
+links: []
+normative: false
+ref: ''
+reviewed: 6rItfcZslIEsRPkXhE5jfCzsBK78DWRH-QGf_ZWOq2w=
+text: |
+  Introduction

--- a/reqs/syad/MCUBOOT.SYAD-00002.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00002.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Purpose
+level: 1.1.0
+links: []
+normative: false
+ref: ''
+reviewed: dnxXrbyvdR6LNo2L9ZxgIHAzHIoZCM152otkrtREpSA=
+text: |
+  Purpose

--- a/reqs/syad/MCUBOOT.SYAD-00003.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00003.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Scope
+level: 1.2.0
+links: []
+normative: false
+ref: ''
+reviewed: _qqMaFDTCjFDo7ILXsefH95f4w1Ur-StxrubCyQaboE=
+text: |
+  Scope

--- a/reqs/syad/MCUBOOT.SYAD-00004.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00004.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Overview
+level: 1.3.0
+links: []
+normative: false
+ref: ''
+reviewed: nnNLNlTcRZ6d1DGrxip3Ur6rK0-BMX7L2JmKtE43xHE=
+text: |
+  Overview

--- a/reqs/syad/MCUBOOT.SYAD-00005.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00005.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Definitions
+level: 1.4.0
+links: []
+normative: false
+ref: ''
+reviewed: WvG822KvlOeS6rymuNY2rPaCUIHk2KWALa0HAuEB_Zo=
+text: |
+  Definitions

--- a/reqs/syad/MCUBOOT.SYAD-00006.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00006.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  References
+level: 2.0
+links: []
+normative: false
+ref: ''
+reviewed: 0-1q18XiwNqhKfcS_I1wefs2LRWAWaq1Qb2VkAvs5jI=
+text: |
+  References

--- a/reqs/syad/MCUBOOT.SYAD-00007.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00007.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  System_Overview
+level: 3.0
+links: []
+normative: false
+ref: ''
+reviewed: 9uZ_uhmu_g2arYb8X5EvXZcFKlOeuFDlAEUBlpVriUY=
+text: |
+  System Overview

--- a/reqs/syad/MCUBOOT.SYAD-00008.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00008.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Logical_View
+level: 4.0
+links: []
+normative: false
+ref: ''
+reviewed: MFfYyU7VVhC_SUhy2sUXzZiGH7el2zoZBiCfLerpmFU=
+text: |
+  Logical View

--- a/reqs/syad/MCUBOOT.SYAD-00009.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00009.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Process_View
+level: 5.0
+links: []
+normative: false
+ref: ''
+reviewed: 9f6IHQ1oX_NcdJUjn8jORQuPH4wietoGAM1oAac_cj0=
+text: |
+  Process View

--- a/reqs/syad/MCUBOOT.SYAD-00010.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00010.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Development_View
+level: 6.0
+links: []
+normative: false
+ref: ''
+reviewed: lxr5_oUeNPI__Yqxw7HPV_HbInqco2k9GYT535fqk7A=
+text: |
+  Development View

--- a/reqs/syad/MCUBOOT.SYAD-00011.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00011.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Physical_View
+level: 7.0
+links: []
+normative: false
+ref: ''
+reviewed: dmnDA_1Udc-cMqMfSYos-xclCj4RXotZuA1ueF8DIaA=
+text: |
+  Physical View

--- a/reqs/syad/MCUBOOT.SYAD-00012.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00012.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Scenarios
+level: 8.0
+links: []
+normative: false
+ref: ''
+reviewed: HfHjfOvyezlV5RBENQ69LuwaM9FJSIrjgbrgxl0ASnQ=
+text: |
+  Scenarios

--- a/reqs/syad/MCUBOOT.SYAD-00013.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00013.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Reference_1
+level: 2.1.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Reference 1

--- a/reqs/syad/MCUBOOT.SYAD-00014.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00014.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Overview_Area_1
+level: 3.1.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Overview Area 1

--- a/reqs/syad/MCUBOOT.SYAD-00015.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00015.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Logical_View_Area_1
+level: 4.1.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Logical View Area 1

--- a/reqs/syad/MCUBOOT.SYAD-00016.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00016.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Process_View_Area_1
+level: 5.1.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Process View Area 1

--- a/reqs/syad/MCUBOOT.SYAD-00017.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00017.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Development_View_Area_1
+level: 6.1.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Development View Area 1

--- a/reqs/syad/MCUBOOT.SYAD-00018.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00018.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Physical_View_Area_1
+level: 7.1.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Physical View Area 1

--- a/reqs/syad/MCUBOOT.SYAD-00019.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00019.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Scenario_1
+level: 8.1.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Scenario 1

--- a/reqs/syad/MCUBOOT.SYAD-00020.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00020.yml
@@ -1,11 +1,11 @@
 active: true
 derived: false
 header: |
-  MCUboot-to-Loaded_Executable_Interface
-level: 4.1.0
+  Measured_boot
+level: 4.1.1.0
 links: []
 normative: false
 ref: ''
 reviewed: null
 text: |
-  MCUboot-to-Loaded Executable Interface
+  Measured boot

--- a/reqs/syad/MCUBOOT.SYAD-00021.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00021.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Measured_Boot_Shared_Data_single_fixed_memory_block
+level: 4.1.2.1.0
+links:
+- MCUBOOT.SYRS-00058: null
+- MCUBOOT.SYRS-00059: null
+normative: true
+ref: ''
+reviewed: null
+text: |
+  The MCUboot executable shall report data shared with the loaded image in one memory block of fixed location and size.

--- a/reqs/syad/MCUBOOT.SYAD-00022.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00022.yml
@@ -1,0 +1,16 @@
+active: true
+derived: false
+header: |
+  Measured_Boot_Shared_Data_in_TLV
+level: 4.1.2.2.0
+links:
+- MCUBOOT.SYRS-00058: null
+- MCUBOOT.SYRS-00059: null
+normative: true
+ref: ''
+reviewed: null
+text: |
+  The MCUboot executable shall encode content in the Shared Data area using a type-length-value format with:
+
+  - An unsigned 16-bit entry type field
+  - An unsigned 16-bit entry length field

--- a/reqs/syad/MCUBOOT.SYAD-00023.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00023.yml
@@ -1,0 +1,16 @@
+active: true
+derived: false
+header: |
+  Measured_Boot_Shared_Data_block_header
+level: 4.1.2.3.0
+links:
+- MCUBOOT.SYRS-00058: null
+- MCUBOOT.SYRS-00059: null
+normative: true
+ref: ''
+reviewed: null
+text: |
+  The MCUboot executable shall begin the Shared Data with a TLV header where:
+
+  - the TLV header type is a specified, reserved value indicating the beginning of the Shared Data block
+  - the TLV header length indicates the byte length of valid data within the Shared Data block.

--- a/reqs/syad/MCUBOOT.SYAD-00024.yml
+++ b/reqs/syad/MCUBOOT.SYAD-00024.yml
@@ -1,0 +1,14 @@
+active: true
+derived: false
+header: |
+  Measured_Boot_Shared_Data_block_initialization
+level: 4.1.2.4.0
+links:
+- MCUBOOT.SYRS-00058: null
+- MCUBOOT.SYRS-00059: null
+normative: true
+ref: ''
+reviewed: null
+text: |
+  When the MCUboot executable transitions execution to the loaded image,
+  the MCUboot shared data block pading and unused memory shall be zeros.

--- a/reqs/syrs/.doorstop.yml
+++ b/reqs/syrs/.doorstop.yml
@@ -1,0 +1,5 @@
+settings:
+  digits: 5
+  parent: MCUBOOT.STRS
+  prefix: MCUBOOT.SYRS
+  sep: '-'

--- a/reqs/syrs/MCUBOOT.SYRS-00001.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00001.yml
@@ -2,10 +2,20 @@ active: true
 derived: false
 header: |
   Introduction
-level: 1.0
+level: 1
 links: []
 normative: false
 ref: ''
 reviewed: Ghu1smwzjBUGf796hVijvZs_QYt5FSCl_4ve5lYIyQs=
 text: |
-  Introduction
+  This document contains the System Requirements Specification (SyRS) for the MCUboot Project.
+
+  It is organized based on ISO/IEC/IEEE 29148:2018 Systems and software engineering - Life cycle processes - Requirements engineering, section 8.4.2 SyRS example outline.
+
+  Section 1 provides an introduction to the purpose, scope, and context of the MCUboot Project and its deliverables.
+
+  Section 2 lists referenced material.
+
+  Section 3 captures the formal requirements on the operation of the system (system requirements) to meet the subset stakeholder needs agreed upon by the representative stakeholders.
+
+  Section 4 captures how the resulting system will be verified that it meets all the system requirements.

--- a/reqs/syrs/MCUBOOT.SYRS-00001.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00001.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Introduction
+level: 1.0
+links: []
+normative: false
+ref: ''
+reviewed: Ghu1smwzjBUGf796hVijvZs_QYt5FSCl_4ve5lYIyQs=
+text: |
+  Introduction

--- a/reqs/syrs/MCUBOOT.SYRS-00002.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00002.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  System_Purpose
+level: 1.1.0
+links: []
+normative: false
+ref: ''
+reviewed: g-ovgYtgIRm1GLvl3FnUM8YibegH8fBD_IVJ_m--Tcs=
+text: |
+  System Purpose

--- a/reqs/syrs/MCUBOOT.SYRS-00002.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00002.yml
@@ -2,10 +2,10 @@ active: true
 derived: false
 header: |
   System_Purpose
-level: 1.1.0
+level: 1.1
 links: []
 normative: false
 ref: ''
 reviewed: g-ovgYtgIRm1GLvl3FnUM8YibegH8fBD_IVJ_m--Tcs=
 text: |
-  System Purpose
+  The MCUboot Project seeks to produce, develop and maintain an open-source reference secure bootloader for microcontroller-based systems.

--- a/reqs/syrs/MCUBOOT.SYRS-00003.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00003.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  System_Scope
+level: 1.2.0
+links: []
+normative: false
+ref: ''
+reviewed: 0B08Bm3sL2HUYRX3uBXT4_9D6tv1lWvu5A7KqjxuBGA=
+text: |
+  System Scope

--- a/reqs/syrs/MCUBOOT.SYRS-00004.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00004.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  System_Overview
+level: 1.3.0
+links: []
+normative: false
+ref: ''
+reviewed: RaWxeiCgttTyGPlIa7h_ZW4sQVZp0h2CWwmV0UksG34=
+text: |
+  System Overview

--- a/reqs/syrs/MCUBOOT.SYRS-00005.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00005.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  System_Context
+level: 1.3.1.0
+links: []
+normative: false
+ref: ''
+reviewed: JlWT1FyfwhgOh-A38HEsJScgVm1JJfwABdDbCl7Sl4o=
+text: |
+  System Context

--- a/reqs/syrs/MCUBOOT.SYRS-00006.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00006.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  System_Perspective
+level: 1.3.1.1.0
+links: []
+normative: false
+ref: ''
+reviewed: C1rGiS-QbxPR062OI6_3qPJ-n90-7497wI2Yrzr9skU=
+text: |
+  System Perspective

--- a/reqs/syrs/MCUBOOT.SYRS-00007.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00007.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  System_Boundaries_-_Summary
+level: 1.3.1.2.0
+links: []
+normative: false
+ref: ''
+reviewed: fYH3V93nIQ5tWWr0SOzbe5kQcKqKcQFuZXLsHuXWqno=
+text: |
+  System Boundaries - Summary

--- a/reqs/syrs/MCUBOOT.SYRS-00008.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00008.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  System_Modeling_-_General
+level: 1.3.1.3.0
+links: []
+normative: false
+ref: ''
+reviewed: N2QXxRg2VPHNw2SHZsTAYUplgFD5ZK4QY7ltTeD-0lM=
+text: |
+  System Modeling - General

--- a/reqs/syrs/MCUBOOT.SYRS-00009.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00009.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  System_Functions
+level: 1.3.2.0
+links: []
+normative: false
+ref: ''
+reviewed: 9sgMNmzOWp47l58DNNEv0cHj6guniGyEQqKxhnw6X4E=
+text: |
+  System Functions

--- a/reqs/syrs/MCUBOOT.SYRS-00010.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00010.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  User_Characteristics
+level: 1.3.3.0
+links: []
+normative: false
+ref: ''
+reviewed: yoUs2FH71jXDEFeeXAZZJATX8ZX-dJbJkiVVUhC-MPg=
+text: |
+  User Characteristics

--- a/reqs/syrs/MCUBOOT.SYRS-00011.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00011.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Definitions
+level: 1.4.0
+links: []
+normative: false
+ref: ''
+reviewed: 8cURxAX6uK2_paMo3YHkFmvmv3UXRcnirkLVqJu9VU0=
+text: |
+  Definitions

--- a/reqs/syrs/MCUBOOT.SYRS-00012.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00012.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  References
+level: 2.0
+links: []
+normative: false
+ref: ''
+reviewed: MVG07n_NYb8AoOTt_Q0tk3oPBMGF2omScvumu6Y-iTE=
+text: |
+  References

--- a/reqs/syrs/MCUBOOT.SYRS-00013.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00013.yml
@@ -1,0 +1,10 @@
+active: true
+derived: false
+header: |
+  Reference_1
+level: 2.1
+links: []
+normative: true
+ref: ''
+reviewed: 0v2t6ApJ6wHrSsL2k4R6bk2xQ3OKoaz8I3oypucxmn0=
+text: ''

--- a/reqs/syrs/MCUBOOT.SYRS-00014.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00014.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements
+level: 3.0
+links: []
+normative: false
+ref: ''
+reviewed: ouiYIi7pEpIyS-ikehH-0Dk38ATIap72wX1FE1o-JVA=
+text: |
+  Requirements

--- a/reqs/syrs/MCUBOOT.SYRS-00015.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00015.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Functional
+level: 3.1.0
+links: []
+normative: false
+ref: ''
+reviewed: g1pp2liSbcFy4ZqXh0Tjx7BO8FtSWKifNGjR7NSgR8M=
+text: |
+  Requirements - Functional

--- a/reqs/syrs/MCUBOOT.SYRS-00016.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00016.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Usability
+level: 3.2.0
+links: []
+normative: false
+ref: ''
+reviewed: rSOC8RWTOkoU_Y8MdWFS9XWp-Bt9s14Bwt3lg4GOqcY=
+text: |
+  Requirements - Usability

--- a/reqs/syrs/MCUBOOT.SYRS-00017.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00017.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Performance
+level: 3.3.0
+links: []
+normative: false
+ref: ''
+reviewed: FHek9XLBC6SNsPSFxclaggnQ9mOFifoOATc-_CVAWHI=
+text: |
+  Requirements - Performance

--- a/reqs/syrs/MCUBOOT.SYRS-00018.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00018.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Interface
+level: 3.4.0
+links: []
+normative: false
+ref: ''
+reviewed: EQ2ddhfBnZgT5XA45QCTpA48ciyOv4EY7bxtRDNNdPI=
+text: |
+  Requirements - Interface

--- a/reqs/syrs/MCUBOOT.SYRS-00019.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00019.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_System_Operations
+level: 3.5.0
+links: []
+normative: false
+ref: ''
+reviewed: Qm8syjtq1HXuGVNzZxR8mn5aIgIYC5M6QCvTPW8cxFw=
+text: |
+  Requirements - System Operations

--- a/reqs/syrs/MCUBOOT.SYRS-00020.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00020.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_System_Modes_and_States
+level: 3.6.0
+links: []
+normative: false
+ref: ''
+reviewed: gH6U4MKMWyR07KQgoSlT6I_y9pRyv_GVZjvTX0hTKvk=
+text: |
+  Requirements - System Modes and States

--- a/reqs/syrs/MCUBOOT.SYRS-00021.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00021.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Physical_Characteristics
+level: 3.7.0
+links: []
+normative: false
+ref: ''
+reviewed: EBf_9XG39mUrjoKVXR26INrk_SomH303Y3iJw5eG59w=
+text: |
+  Requirements - Physical Characteristics

--- a/reqs/syrs/MCUBOOT.SYRS-00022.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00022.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Environmental_Conditions
+level: 3.8.0
+links: []
+normative: false
+ref: ''
+reviewed: W-z1IcXOj1WUHnbGUHb8JUi7BsYRYcmJUdzUWhi4XOA=
+text: |
+  Requirements - Environmental Conditions

--- a/reqs/syrs/MCUBOOT.SYRS-00023.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00023.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requriements_-_Security
+level: 3.9.0
+links: []
+normative: false
+ref: ''
+reviewed: LdkCySfLodw9ZfB52mUHc1ftm0KS0C430Fh65bU2POU=
+text: |
+  Requirements - Security

--- a/reqs/syrs/MCUBOOT.SYRS-00024.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00024.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Information_Management
+level: 3.10.0
+links: []
+normative: false
+ref: ''
+reviewed: PG9Q9_WVK4hRkntaoG7zv95BSat-PKEpUMMe_4o8gXw=
+text: |
+  Requirements - Information Management

--- a/reqs/syrs/MCUBOOT.SYRS-00025.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00025.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Policy_and_Regulation
+level: 3.11.0
+links: []
+normative: false
+ref: ''
+reviewed: q3799LS8d3maS9KV2vFhRMbpSn-KtbzLwf8H0GLeOTk=
+text: |
+  Requirements - olicy and Regulation

--- a/reqs/syrs/MCUBOOT.SYRS-00026.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00026.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_System_Life_Cycle_Sustainment
+level: 3.12.0
+links: []
+normative: false
+ref: ''
+reviewed: W5aUdLqdsrRN9bzPLgdBHShiJnOe6fE_eiATBMWqtQM=
+text: |
+  Requirements - System Life Cycle Sustainment

--- a/reqs/syrs/MCUBOOT.SYRS-00027.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00027.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Requirements_-_Packaging,_Handling,_Shipping_and_Transportation
+level: 3.13.0
+links: []
+normative: false
+ref: ''
+reviewed: YChwdgcaHHRfrwgLtUliHo8TcAtnWhWm30F9uCeRlTI=
+text: |
+  Requirements - Packaging, Handling, Shipping and Transportation

--- a/reqs/syrs/MCUBOOT.SYRS-00028.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00028.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications
+level: 4.0
+links: []
+normative: false
+ref: ''
+reviewed: 7tir9tkXtShvZbUIv7at4hWzcKs-JpzV0knb-GDC6Jg=
+text: |
+  Verifications

--- a/reqs/syrs/MCUBOOT.SYRS-00029.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00029.yml
@@ -1,7 +1,7 @@
 active: true
 derived: false
 header: |
-  Verifications_-_Functiona
+  Verifications_-_Functional
 level: 4.1.0
 links: []
 normative: false

--- a/reqs/syrs/MCUBOOT.SYRS-00029.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00029.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Functiona
+level: 4.1.0
+links: []
+normative: false
+ref: ''
+reviewed: H24p5jQ9GcERMrghgxsXMP13Ou-HA3j0aTkv6OGchVg=
+text: |
+  Verifications - Functional

--- a/reqs/syrs/MCUBOOT.SYRS-00030.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00030.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Usability
+level: 4.2.0
+links: []
+normative: false
+ref: ''
+reviewed: Lz8TrPbfLBWKLuBbZHYB2G-P-3L7Pmk69VIq28NpQr8=
+text: |
+  Verifications - Usability

--- a/reqs/syrs/MCUBOOT.SYRS-00031.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00031.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Performance
+level: 4.3.0
+links: []
+normative: false
+ref: ''
+reviewed: 9-DTwDi31x564MWBsXvyOWFHaFoxuc2N_TbXf9j7bug=
+text: |
+  Verifications - Performance

--- a/reqs/syrs/MCUBOOT.SYRS-00032.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00032.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Interface
+level: 4.4.0
+links: []
+normative: false
+ref: ''
+reviewed: TPE5Mg7vgjqV4UfZmRMT1YkFe1urYtno5b03OzFNxRo=
+text: |
+  Verifications - Interface

--- a/reqs/syrs/MCUBOOT.SYRS-00033.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00033.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_System_Operations
+level: 4.5.0
+links: []
+normative: false
+ref: ''
+reviewed: Fl8Wb0Rw3bE5vBlpmnlQTp1-g1ttjURl9HMA1_PBGWE=
+text: |
+  Verifications - System Operations

--- a/reqs/syrs/MCUBOOT.SYRS-00034.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00034.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_System_Modes_and_States
+level: 4.6.0
+links: []
+normative: false
+ref: ''
+reviewed: oHXNTBRsKKsAdD02Cs5QWnPST8bfGcr6E0BdyqyD9WI=
+text: |
+  Verifications - System Modes and States

--- a/reqs/syrs/MCUBOOT.SYRS-00035.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00035.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Physical_Characteristics
+level: 4.7.0
+links: []
+normative: false
+ref: ''
+reviewed: GeYDG7fj8kAnORJNWwB6xz9ypse6-KbZp9M67FzRWys=
+text: |
+  Verifications - Physical Characteristics

--- a/reqs/syrs/MCUBOOT.SYRS-00036.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00036.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Environmental_Conditions
+level: 4.8.0
+links: []
+normative: false
+ref: ''
+reviewed: _ufJHOh9ZOuI2hqgNQmuNeeVqiqMBtZ7MXanRNGUC_U=
+text: |
+  Verifications - Environmental Conditions

--- a/reqs/syrs/MCUBOOT.SYRS-00037.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00037.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Security
+level: 4.9.0
+links: []
+normative: false
+ref: ''
+reviewed: gq7l_muddi0gmkD4bgSRIc9n_BcazYEkvZ4kzpG6K18=
+text: |
+  Verifications - Security

--- a/reqs/syrs/MCUBOOT.SYRS-00038.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00038.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Information_Management
+level: 4.10.0
+links: []
+normative: false
+ref: ''
+reviewed: 08mRcYiLtjFo4D7reD29MvNi3HkcHx81qAWsQpgRBsE=
+text: |
+  Verifications - Information Management

--- a/reqs/syrs/MCUBOOT.SYRS-00039.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00039.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Policy_and_Regulation
+level: 4.11.0
+links: []
+normative: false
+ref: ''
+reviewed: AyZP4yQ4uVT0UtPvhDZqZlY4JqgxPo5qkAkBYgoyC58=
+text: |
+  Verifications - Policy and Regulation

--- a/reqs/syrs/MCUBOOT.SYRS-00040.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00040.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_System_Life_Cycle_Sustainment
+level: 4.12.0
+links: []
+normative: false
+ref: ''
+reviewed: bS7q3CHLrvjrKH5GeMekOq9fHxFP7vvWKbxyabIz44o=
+text: |
+  Verifications - System Life Cycle Sustainment

--- a/reqs/syrs/MCUBOOT.SYRS-00041.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00041.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Verifications_-_Packaging,_Handling,_Shipping_and_Transportation
+level: 4.13.0
+links: []
+normative: false
+ref: ''
+reviewed: 4zk-TWqvNzjgGgi-YZ7du5bkxfrxJkf6nMvWl89uPCo=
+text: |
+  Verifications - Packaging, Handling, Shipping and Transportation

--- a/reqs/syrs/MCUBOOT.SYRS-00042.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00042.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Appendices
+level: 5.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Appendices

--- a/reqs/syrs/MCUBOOT.SYRS-00043.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00043.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Assumptions_and_Dependencies
+level: 5.1.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Assumptions and Dependencies

--- a/reqs/syrs/MCUBOOT.SYRS-00044.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00044.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Acronyms_and_Abbreviations
+level: 5.2.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Acronyms and Abbreviations

--- a/reqs/syrs/MCUBOOT.SYRS-00045.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00045.yml
@@ -1,0 +1,21 @@
+active: true
+derived: false
+header: |
+  Scope_Breadth
+level: 1.2.1
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  The scope of the MCUboot Project includes:
+
+  1. Source, verification suites, and documentation for:
+
+    - MCUboot functionality and framework interfaces
+    - MCUboot port glue code into one or more target OS ecosystems (e.g., Mynewt)
+
+  2. Processes and resources for:
+
+    - hosting the MCUboot Project
+    - managing the MCUboot Project

--- a/reqs/syrs/MCUBOOT.SYRS-00046.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00046.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  Needs_Addressed_by_MCUboot_Project
+level: 1.2.2
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  The MCUboot Project solution will address the following high-level needs:
+
+  - TBD

--- a/reqs/syrs/MCUBOOT.SYRS-00047.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00047.yml
@@ -1,0 +1,11 @@
+active: true
+derived: false
+header: |
+  Needs_Addressed_by_MCUboot_Reference
+level: 1.2.3
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  The MCUboot reference repository will address the following high-level needs:

--- a/reqs/syrs/MCUBOOT.SYRS-00048.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00048.yml
@@ -1,0 +1,10 @@
+active: true
+derived: false
+header: ''
+level: 1.2.3.1
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Reusable immutable bootloader application

--- a/reqs/syrs/MCUBOOT.SYRS-00049.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00049.yml
@@ -1,0 +1,10 @@
+active: true
+derived: false
+header: ''
+level: 1.2.2.1
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  MCUboot issue tracking

--- a/reqs/syrs/MCUBOOT.SYRS-00050.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00050.yml
@@ -1,0 +1,10 @@
+active: true
+derived: false
+header: ''
+level: 1.2.3.2
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Reusable mutable bootloader application.

--- a/reqs/syrs/MCUBOOT.SYRS-00051.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00051.yml
@@ -1,0 +1,10 @@
+active: true
+derived: false
+header: ''
+level: 1.2.3.3
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Bootloader runs from flash as execute-in-place image.

--- a/reqs/syrs/MCUBOOT.SYRS-00052.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00052.yml
@@ -1,0 +1,10 @@
+active: true
+derived: false
+header: ''
+level: 1.2.2.2
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  MCUboot versioning with release notes

--- a/reqs/syrs/MCUBOOT.SYRS-00053.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00053.yml
@@ -1,0 +1,10 @@
+active: true
+derived: false
+header: ''
+level: 1.2.3.4
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: |
+  Bootloader runs from RAM

--- a/reqs/syrs/MCUBOOT.SYRS-00054.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00054.yml
@@ -1,11 +1,11 @@
 active: true
 derived: false
 header: |
-  MCUboot-to-Loaded_Executable_Interface
-level: 4.1.0
+  MCUboot_Executable_Metadata
+level: 3.4.1.0
 links: []
 normative: false
 ref: ''
 reviewed: null
 text: |
-  MCUboot-to-Loaded Executable Interface
+  MCUboot Executable Metadata

--- a/reqs/syrs/MCUBOOT.SYRS-00055.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00055.yml
@@ -1,11 +1,11 @@
 active: true
 derived: false
 header: |
-  MCUboot-to-Loaded_Executable_Interface
-level: 4.1.0
+  MCUboot_Execution_Status
+level: 3.4.2.0
 links: []
 normative: false
 ref: ''
 reviewed: null
 text: |
-  MCUboot-to-Loaded Executable Interface
+  MCUboot Execution Status

--- a/reqs/syrs/MCUBOOT.SYRS-00056.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00056.yml
@@ -1,11 +1,11 @@
 active: true
 derived: false
 header: |
-  MCUboot-to-Loaded_Executable_Interface
-level: 4.1.0
+  MCUboot_Execution_Logs
+level: 3.4.3.0
 links: []
 normative: false
 ref: ''
 reviewed: null
 text: |
-  MCUboot-to-Loaded Executable Interface
+  MCUboot Execution Logs

--- a/reqs/syrs/MCUBOOT.SYRS-00057.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00057.yml
@@ -1,0 +1,12 @@
+active: true
+derived: false
+header: |
+  Bootloar_Persistently_Log_Security_Events
+level: 3.4.3.1.0
+links:
+- MCUBOOT.STRS-00057: null
+normative: false
+ref: ''
+reviewed: null
+text: |
+  The MCUboot executable shall persistently log security events.

--- a/reqs/syrs/MCUBOOT.SYRS-00058.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00058.yml
@@ -1,0 +1,12 @@
+active: true
+derived: false
+header: |
+  MCUboot_Executable_Metadata
+level: 3.4.1.1.0
+links:
+- MCUBOOT.STRS-00060: null
+normative: true
+ref: ''
+reviewed: null
+text: |
+  The MCUboot executable shall present metadata about itself to the loaded image.

--- a/reqs/syrs/MCUBOOT.SYRS-00059.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00059.yml
@@ -1,0 +1,12 @@
+active: true
+derived: false
+header: |
+  MCUboot_Executable_Status
+level: 3.4.2.1.0
+links:
+- MCUBOOT.STRS-00060: null
+normative: true
+ref: ''
+reviewed: null
+text: |
+  The MCUboot executable shall present status about itself to the loaded image.

--- a/reqs/syrs/MCUBOOT.SYRS-00060.yml
+++ b/reqs/syrs/MCUBOOT.SYRS-00060.yml
@@ -1,0 +1,13 @@
+active: true
+derived: false
+header: |
+  MCUboot_image_automated_source_license_compatibility_verification
+level: 3.11.1.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: |
+  Where automated verification of compatibility of source licensing is available,
+  when automated verification of compatibility of source licensing is requested,
+  the build system of the MCUboot solution shall verify the compatibility of source licensing of all source files needed in the resulting executable image.

--- a/reqs/uirs/.doorstop.yml
+++ b/reqs/uirs/.doorstop.yml
@@ -1,0 +1,5 @@
+settings:
+  digits: 5
+  parent: MCUBOOT.SYAD
+  prefix: MCUBOOT.UIRS
+  sep: '-'

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,3 +2,4 @@ cryptography>=2.6
 intelhex
 click
 cbor2
+doorstop


### PR DESCRIPTION
This PR introduces formal requirements management using Doorstop (https://github.com/doorstop-dev/doorstop), a LGPLv3 licensed open-source requirements management tool being considered by Zephyr Project.  Doorstop supports tracing between requirement documents kept within the same repository.  Each document is kept in a separate directory, with each document item kept in a separate file.  The files are named with a document-identifying prefix followed by a unique item number.  The files contain the controlled fields plus item metadata (e.g., links, approval state, normative, etc).  

NOTE: It appears no open-source requirements management tool is capable of meeting all of the needs faced by MCUBoot.  At least this tool enables capturing, managing, and formally tracing/reporting requirements within this project.

This PR sets up a preliminary requirements document tree and populates the first 3 documents (StRS, SyRS, SyAD) with an outline structure (headers) following examples for IEC 29148:2018 examples for StRS and SyRS and following the 4+1 Architectural View Model for SyAD.  Content will be left for other PRs.

Empty documents have also been set up for each of the following expected system elements:
- OS
- UI
- Logging
- NVM (Flash? Storage?)
- Console for recovery application