### PR TITLE
Add west.yml to make manifest-module.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -1,0 +1,32 @@
+# Copyright (c) 2022 Legrand North America, LLC.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# The west manifest file for Zephyr ecosystem development.
+#
+# Usage:
+# west init -m https://github.com/mcu-tools/mcuboot --mr main $new_workspace
+# cd $new && west update
+
+manifest:
+  version: "0.12"
+
+  remotes:
+    - name: zephyrproject
+      url-base: https://github.com/zephyrproject-rtos
+    - name: mcu-tools
+      url-base: https://github.com/mcu-tools
+
+  defaults:
+    remote: mcu-tools
+
+  projects:
+    - name: zephyr
+      revision: main
+      remote: zephyrproject
+      import:
+        name-blocklist:
+          - mcuboot
+
+  self:
+    path: mcuboot


### PR DESCRIPTION
Extending mcuboot to be a Zephyr manifest-module enables mcuboot integration consistent with Zephyr's example-application.

Verified by:

```
west init https://github.com/$my_account/mcuboot \
     --mr $my_branch ~/$my_wksp && \
cd ~/$my_wksp && \
west update && \
source zephyr/zephyr_env.sh && \
west build -p always -b nrf52840dk_nrf52840 mcuboot/boot/zephyr
```

Fixes #1496

Signed-off-by: Gregory Shue <gregory.shue@legrand.com>