### PR TITLE
boot:nuttx: Fix sign-comparsion issue

### DIFF
--- a/boot/nuttx/src/flash_map_backend/flash_map_backend.c
+++ b/boot/nuttx/src/flash_map_backend/flash_map_backend.c
@@ -421,7 +421,7 @@ int flash_area_read(const struct flash_area *fa, uint32_t off,
   /* Reposition the file offset from the beginning of the flash area */
 
   seekpos = lseek(dev->fd, (off_t)off, SEEK_SET);
-  if (seekpos != off)
+  if (seekpos != (off_t)off)
     {
       int errcode = errno;
 
@@ -489,7 +489,7 @@ int flash_area_write(const struct flash_area *fa, uint32_t off,
   /* Reposition the file offset from the beginning of the flash area */
 
   seekpos = lseek(dev->fd, (off_t)off, SEEK_SET);
-  if (seekpos != off)
+  if (seekpos != (off_t)off)
     {
       int errcode = errno;
 


### PR DESCRIPTION
Signed-off-by: Andrés Sánchez Pascual <tito97_sp@hotmail.com>

Fix compiler error: comparison of integer expressions of different signedness: 'off_t' {aka 'long int'} and 'uint32_t' {aka 'long unsigned int'} [-Werror=sign-compare]
  492 |   if (seekpos != off)