### PR TITLE
boot: zephyr: prefer swap move if scratch_partition not enabled

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -197,7 +197,7 @@ config BOOT_VALIDATE_SLOT0_ONCE
 config BOOT_PREFER_SWAP_MOVE
 	bool "Prefer the newer swap move algorithm"
 	default y if SOC_FAMILY_NRF
-	default n
+	default y if !$(dt_nodelabel_enabled,scratch_partition)
 	help
 	  If y, the BOOT_IMAGE_UPGRADE_MODE will default to using
 	  "move" instead of "scratch".  This is a separate bool config


### PR DESCRIPTION
With the exception of nrf targets `BOOT_SWAP_USING_SCRATCH` mode was still the preferred algorithm.

Changing the preferred mode in cases where no `scratch_partition` is defined will allow successfully building mcuboot for such boards without the need for any board specific overlays.