### PR TITLE
boot: zephyr: Fix int-to-pointer-cast for ram-load

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -303,7 +303,7 @@ static void do_boot(struct boot_rsp *rsp)
     void *start;
 
 #if defined(MCUBOOT_RAM_LOAD)
-    start = (void *)(rsp->br_hdr->ih_load_addr + rsp->br_hdr->ih_hdr_size);
+    start = (void *)((uintptr_t)rsp->br_hdr->ih_load_addr + rsp->br_hdr->ih_hdr_size);
 #else
     uintptr_t flash_base;
     int rc;


### PR DESCRIPTION
Fix casting `uint32_t` to 64bit `void` pointer for 64bit platforms during `MCUBOOT_RAM_LOAD`.

This fixes the following warning when building on zephyr with `MCUBOOT_RAM_LOAD` enabled
```
mcuboot/boot/zephyr/main.c:306:13: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
  306 |     start = (void *)(rsp->br_hdr->ih_load_addr + rsp->br_hdr->ih_hdr_size);
      |             ^
cc1: all warnings being treated as errors
```