### PR TITLE
boot: nuttx: Support application specific wdg initialization.

### DIFF
--- a/boot/nuttx/include/mcuboot_config/mcuboot_config.h
+++ b/boot/nuttx/include/mcuboot_config/mcuboot_config.h
@@ -181,6 +181,15 @@
  */
 
 #ifdef CONFIG_MCUBOOT_WATCHDOG
+
+#ifndef CONFIG_MCUBOOT_WATCHDOG_DEVPATH
+#  define CONFIG_MCUBOOT_WATCHDOG_DEVPATH "/dev/watchdog0"
+#endif
+
+#ifndef CONFIG_MCUBOOT_WATCHDOG_TIMEOUT
+#  define CONFIG_MCUBOOT_WATCHDOG_TIMEOUT 10000      /* Watchdog timeout in ms */
+#endif
+
 #  define MCUBOOT_WATCHDOG_FEED()       do                           \
                                           {                          \
                                             mcuboot_watchdog_feed(); \

--- a/boot/nuttx/include/watchdog/watchdog.h
+++ b/boot/nuttx/include/watchdog/watchdog.h
@@ -41,4 +41,25 @@
 
 void mcuboot_watchdog_feed(void);
 
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mcuboot_watchdog_init
+ *
+ * Description:
+ *   Initialize the watchdog timer by setting the trigger timeout and 
+ *   starting it.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   OK on success, ERROR if not.
+ *
+ ****************************************************************************/
+
+int mcuboot_watchdog_init(void);
+
 #endif /* __BOOT_NUTTX_INCLUDE_WATCHDOG_WATCHDOG_H */

--- a/boot/nuttx/main.c
+++ b/boot/nuttx/main.c
@@ -114,6 +114,15 @@ int main(int argc, FAR char *argv[])
 
   syslog(LOG_INFO, "*** Booting MCUboot build %s ***\n", CONFIG_MCUBOOT_VERSION);
 
+#ifdef CONFIG_MCUBOOT_WATCHDOG
+  int ret = mcuboot_watchdog_init();
+  if (ret < 0)
+  {
+    syslog(LOG_ERR, "Unable to initialize the watchdog timer\n");
+    FIH_PANIC;
+  }
+#endif
+
   FIH_CALL(boot_go, fih_rc, &rsp);
 
   if (fih_not_eq(fih_rc, FIH_SUCCESS))


### PR DESCRIPTION
Signed-off-by: Andrés Sánchez Pascual <tito97_sp@hotmail.com>

**Rationale:**
Wdg timer set up and starting is an application specific action that should be performed at application level inside the main() funcion.

**Tested**
Tested on target.