### PR TITLE
boot_serial: espressif: add serial recovery mode to ESP32-S2 and ESP32-S3 

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -40,7 +40,7 @@
 #elif __ESPRESSIF__
 #include <bootloader_utility.h>
 #include <esp_rom_sys.h>
-#include <rom/crc.h>
+#include <esp_crc.h>
 #include <endian.h>
 #include <mbedtls/base64.h>
 #else
@@ -732,8 +732,8 @@ boot_serial_output(void)
     crc =  crc16_itu_t(crc, data, len);
 #elif __ESPRESSIF__
     /* For ESP32 it was used the CRC API in rom/crc.h */
-    crc =  ~crc16_be(~CRC16_INITIAL_CRC, (uint8_t *)bs_hdr, sizeof(*bs_hdr));
-    crc =  ~crc16_be(~crc, (uint8_t *)data, len);
+    crc =  ~esp_crc16_be(~CRC16_INITIAL_CRC, (uint8_t *)bs_hdr, sizeof(*bs_hdr));
+    crc =  ~esp_crc16_be(~crc, (uint8_t *)data, len);
 #else
     crc = crc16_ccitt(CRC16_INITIAL_CRC, bs_hdr, sizeof(*bs_hdr));
     crc = crc16_ccitt(crc, data, len);
@@ -819,7 +819,7 @@ boot_serial_in_dec(char *in, int inlen, char *out, int *out_off, int maxout)
 #ifdef __ZEPHYR__
     crc = crc16_itu_t(CRC16_INITIAL_CRC, out, len);
 #elif __ESPRESSIF__
-    crc = ~crc16_be(~CRC16_INITIAL_CRC, (uint8_t *)out, len);
+    crc = ~esp_crc16_be(~CRC16_INITIAL_CRC, (uint8_t *)out, len);
 #else
     crc = crc16_ccitt(CRC16_INITIAL_CRC, out, len);
 #endif

--- a/boot/espressif/hal/include/esp32s2/esp32s2.cmake
+++ b/boot/espressif/hal/include/esp32s2/esp32s2.cmake
@@ -5,6 +5,7 @@
 list(APPEND hal_srcs
     ${esp_idf_dir}/components/esp_hw_support/port/${MCUBOOT_TARGET}/regi2c_ctrl.c
     ${esp_idf_dir}/components/efuse/src/esp_efuse_api_key_esp32xx.c
+    ${esp_idf_dir}/components/esp_rom/patches/esp_rom_crc.c
     )
 
 list(APPEND LINKER_SCRIPTS

--- a/boot/espressif/hal/src/esp32s2/bootloader_init.c
+++ b/boot/espressif/hal/src/esp32s2/bootloader_init.c
@@ -14,6 +14,8 @@
 #include "esp_rom_gpio.h"
 
 #include "bootloader_init.h"
+#include "bootloader_common.h"
+#include "bootloader_console.h"
 #include "bootloader_mem.h"
 #include "bootloader_clock.h"
 #include "bootloader_flash_config.h"
@@ -120,18 +122,6 @@ static esp_err_t bootloader_init_spi_flash(void)
     return ESP_OK;
 }
 
-static void bootloader_init_uart_console(void)
-{
-    const int uart_num = 0;
-
-    uartAttach(NULL);
-    ets_install_uart_printf();
-    uart_tx_wait_idle(0);
-
-    const int uart_baud = CONFIG_ESP_CONSOLE_UART_BAUDRATE;
-    uart_div_modify(uart_num, (rtc_clk_apb_freq_get() << 4) / uart_baud);
-}
-
 static void bootloader_super_wdt_auto_feed(void)
 {
     REG_SET_BIT(RTC_CNTL_SWD_CONF_REG, RTC_CNTL_SWD_AUTO_FEED_EN);
@@ -158,7 +148,7 @@ esp_err_t bootloader_init(void)
     /* config clock */
     bootloader_clock_configure();
     /* initialize uart console, from now on, we can use ets_printf */
-    bootloader_init_uart_console();
+    bootloader_console_init();
     /* read bootloader header */
     if ((ret = bootloader_read_bootloader_header()) != ESP_OK) {
         goto err;

--- a/boot/espressif/hal/src/esp32s3/bootloader_init.c
+++ b/boot/espressif/hal/src/esp32s3/bootloader_init.c
@@ -17,6 +17,8 @@
 #include "esp_efuse.h"
 
 #include "bootloader_init.h"
+#include "bootloader_common.h"
+#include "bootloader_console.h"
 #include "bootloader_mem.h"
 #include "bootloader_clock.h"
 #include "bootloader_flash_config.h"
@@ -142,16 +144,6 @@ static esp_err_t bootloader_init_spi_flash(void)
     return ESP_OK;
 }
 
-static void bootloader_init_uart_console(void)
-{
-    const int uart_num = 0;
-
-    esp_rom_install_uart_printf();
-    esp_rom_uart_tx_wait_idle(0);
-    uint32_t clock_hz = UART_CLK_FREQ_ROM;
-    esp_rom_uart_set_clock_baudrate(uart_num, clock_hz, CONFIG_ESP_CONSOLE_UART_BAUDRATE);
-}
-
 static void wdt_reset_cpu0_info_enable(void)
 {
     REG_SET_BIT(SYSTEM_CPU_PERI_CLK_EN_REG, SYSTEM_CLK_EN_ASSIST_DEBUG);
@@ -261,7 +253,7 @@ esp_err_t bootloader_init(void)
     // config clock
     bootloader_clock_configure();
     /* initialize uart console, from now on, we can use ets_printf */
-    bootloader_init_uart_console();
+    bootloader_console_init();
     // Check and run XMC startup flow
     if ((ret = bootloader_flash_xmc_startup()) != ESP_OK) {
        goto err;

--- a/boot/espressif/port/esp32s2/bootloader.conf
+++ b/boot/espressif/port/esp32s2/bootloader.conf
@@ -12,6 +12,37 @@ CONFIG_ESP_MCUBOOT_WDT_ENABLE=y
 CONFIG_ESP_SCRATCH_OFFSET=0x210000
 CONFIG_ESP_SCRATCH_SIZE=0x40000
 
+# Enables the MCUboot Serial Recovery, that allows the use of
+# MCUMGR to upload a firmware through the serial port
+# CONFIG_ESP_MCUBOOT_SERIAL=y
+# Use sector erasing (recommended) instead of entire image size
+# erasing when uploading through Serial Recovery
+# CONFIG_ESP_MCUBOOT_ERASE_PROGRESSIVELY=y
+
+# GPIO used to boot on Serial Recovery
+# CONFIG_ESP_SERIAL_BOOT_GPIO_DETECT=5
+# GPIO input type (0 for Pull-down, 1 for Pull-up)
+# CONFIG_ESP_SERIAL_BOOT_GPIO_INPUT_TYPE=0
+# GPIO signal value
+# CONFIG_ESP_SERIAL_BOOT_GPIO_DETECT_VAL=1
+# Delay time for identify the GPIO signal
+# CONFIG_ESP_SERIAL_BOOT_DETECT_DELAY_S=5
+# UART port used for serial communication (not needed when using USB)
+# CONFIG_ESP_SERIAL_BOOT_UART_NUM=1
+# GPIO for Serial RX signal
+# CONFIG_ESP_SERIAL_BOOT_GPIO_RX=18
+# GPIO for Serial TX signal
+# CONFIG_ESP_SERIAL_BOOT_GPIO_TX=17
+
+# Use UART0 for console printing (use either UART or USB alone)
+CONFIG_ESP_CONSOLE_UART=y
+CONFIG_ESP_CONSOLE_UART_NUM=0
+# Configures alternative UART port for console printing
+# (UART_NUM=0 must not be changed)
+# CONFIG_ESP_CONSOLE_UART_CUSTOM=y
+# CONFIG_ESP_CONSOLE_UART_TX_GPIO=17
+# CONFIG_ESP_CONSOLE_UART_RX_GPIO=18
+
 # CONFIG_ESP_SIGN_EC256=y
 # CONFIG_ESP_SIGN_ED25519=n
 # CONFIG_ESP_SIGN_RSA=n

--- a/boot/espressif/port/esp32s2/ld/bootloader.ld
+++ b/boot/espressif/port/esp32s2/ld/bootloader.ld
@@ -40,6 +40,7 @@ SECTIONS
     *libhal.a:bootloader_efuse_esp32s2.*(.literal .text .literal.* .text.*)
     *libhal.a:bootloader_utility.*(.literal .text .literal.* .text.*)
     *libhal.a:bootloader_sha.*(.literal .text .literal.* .text.*)
+    *libhal.a:bootloader_console.*(.literal .text .literal.* .text.*)
     *libhal.a:bootloader_console_loader.*(.literal .text .literal.* .text.*)
     *libhal.a:bootloader_panic.*(.literal .text .literal.* .text.*)
     *libhal.a:bootloader_soc.*(.literal .text .literal.* .text.*)

--- a/boot/espressif/port/esp32s2/serial_adapter.c
+++ b/boot/espressif/port/esp32s2/serial_adapter.c
@@ -1,0 +1,191 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <bootutil/bootutil_log.h>
+
+#include <esp_rom_uart.h>
+#include <esp_rom_gpio.h>
+#include <esp_rom_sys.h>
+#include <esp_rom_caps.h>
+#include <soc/uart_periph.h>
+#include <soc/gpio_struct.h>
+#include <soc/io_mux_reg.h>
+#include <soc/rtc.h>
+#include <hal/gpio_types.h>
+#include <hal/gpio_ll.h>
+#include <hal/uart_ll.h>
+#include <hal/clk_gate_ll.h>
+#include <hal/gpio_hal.h>
+
+#ifdef CONFIG_ESP_SERIAL_BOOT_GPIO_DETECT
+#define SERIAL_BOOT_GPIO_DETECT     CONFIG_ESP_SERIAL_BOOT_GPIO_DETECT
+#else
+#define SERIAL_BOOT_GPIO_DETECT     GPIO_NUM_5
+#endif
+
+#ifdef CONFIG_ESP_SERIAL_BOOT_GPIO_DETECT_VAL
+#define SERIAL_BOOT_GPIO_DETECT_VAL     CONFIG_ESP_SERIAL_BOOT_GPIO_DETECT_VAL
+#else
+#define SERIAL_BOOT_GPIO_DETECT_VAL     1
+#endif
+
+#ifdef CONFIG_ESP_SERIAL_BOOT_DETECT_DELAY_S
+#define SERIAL_BOOT_DETECT_DELAY_S     CONFIG_ESP_SERIAL_BOOT_DETECT_DELAY_S
+#else
+#define SERIAL_BOOT_DETECT_DELAY_S     5
+#endif
+
+#ifdef CONFIG_ESP_SERIAL_BOOT_GPIO_INPUT_TYPE
+#define SERIAL_BOOT_GPIO_INPUT_TYPE    CONFIG_ESP_SERIAL_BOOT_GPIO_INPUT_TYPE
+#else
+// pull-down
+#define SERIAL_BOOT_GPIO_INPUT_TYPE    0
+#endif
+
+#ifdef CONFIG_ESP_SERIAL_BOOT_UART_NUM
+#define SERIAL_BOOT_UART_NUM    CONFIG_ESP_SERIAL_BOOT_UART_NUM
+#else
+#define SERIAL_BOOT_UART_NUM    ESP_ROM_UART_1
+#endif
+
+#ifdef CONFIG_ESP_SERIAL_BOOT_GPIO_RX
+#define SERIAL_BOOT_GPIO_RX     CONFIG_ESP_SERIAL_BOOT_GPIO_RX
+#else
+#define SERIAL_BOOT_GPIO_RX     GPIO_NUM_18
+#endif
+
+#ifdef CONFIG_ESP_SERIAL_BOOT_GPIO_TX
+#define SERIAL_BOOT_GPIO_TX     CONFIG_ESP_SERIAL_BOOT_GPIO_TX
+#else
+#define SERIAL_BOOT_GPIO_TX     GPIO_NUM_17
+#endif
+
+static uart_dev_t *serial_boot_uart_dev = (SERIAL_BOOT_UART_NUM == 0) ?
+                                          &UART0 :
+                                          &UART1;
+
+void console_write(const char *str, int cnt)
+{
+    uint32_t tx_len;
+    uint32_t write_len;
+
+    do {
+        tx_len = uart_ll_get_txfifo_len(serial_boot_uart_dev);
+        if (tx_len > 0) {
+            write_len = tx_len < cnt ? tx_len : cnt;
+            uart_ll_write_txfifo(serial_boot_uart_dev, (const uint8_t *)str, write_len);
+            cnt -= write_len;
+        }
+        MCUBOOT_WATCHDOG_FEED();
+        esp_rom_delay_us(1000);
+    } while (cnt > 0);
+}
+
+int console_read(char *str, int cnt, int *newline)
+{
+    uint32_t len = 0;
+    uint32_t read_len = 0;
+    bool stop = false;
+
+    do {
+        len = uart_ll_get_rxfifo_len(serial_boot_uart_dev);
+
+        if (len > 0) {
+            for (uint32_t i = 0; i < len; i++) {
+                /* Read the character from the RX FIFO */
+                uart_ll_read_rxfifo(serial_boot_uart_dev, (uint8_t *)&str[read_len], 1);
+                read_len++;
+                if (read_len == cnt - 1|| str[read_len - 1] == '\n') {
+                    stop = true;
+                    break;
+                }
+            }
+        }
+        MCUBOOT_WATCHDOG_FEED();
+        esp_rom_delay_us(1000);
+    } while (!stop);
+    *newline = (str[read_len - 1] == '\n') ? 1 : 0;
+    return read_len;
+}
+
+int boot_console_init(void)
+{
+    BOOT_LOG_INF("Initializing serial boot pins");
+
+    /* Enable GPIO for UART RX */
+    esp_rom_gpio_pad_select_gpio(SERIAL_BOOT_GPIO_RX);
+    esp_rom_gpio_connect_in_signal(SERIAL_BOOT_GPIO_RX,
+                                   UART_PERIPH_SIGNAL(SERIAL_BOOT_UART_NUM, SOC_UART_RX_PIN_IDX),
+                                   0);
+    gpio_ll_input_enable(&GPIO, SERIAL_BOOT_GPIO_RX);
+    esp_rom_gpio_pad_pullup_only(SERIAL_BOOT_GPIO_RX);
+
+    /* Enable GPIO for UART TX */
+    esp_rom_gpio_pad_select_gpio(SERIAL_BOOT_GPIO_TX);
+    esp_rom_gpio_connect_out_signal(SERIAL_BOOT_GPIO_TX,
+                                    UART_PERIPH_SIGNAL(SERIAL_BOOT_UART_NUM, SOC_UART_TX_PIN_IDX),
+                                    0, 0);
+    gpio_ll_output_enable(&GPIO, SERIAL_BOOT_GPIO_TX);
+
+    uart_ll_set_sclk(serial_boot_uart_dev, UART_SCLK_APB);
+    uart_ll_set_mode_normal(serial_boot_uart_dev);
+    uart_ll_set_baudrate(serial_boot_uart_dev, 115200);
+    uart_ll_set_stop_bits(serial_boot_uart_dev, 1u);
+    uart_ll_set_parity(serial_boot_uart_dev, UART_PARITY_DISABLE);
+    uart_ll_set_rx_tout(serial_boot_uart_dev, 16);
+    uart_ll_set_data_bit_num(serial_boot_uart_dev, UART_DATA_8_BITS);
+    uart_ll_set_tx_idle_num(serial_boot_uart_dev, 0);
+    uart_ll_set_hw_flow_ctrl(serial_boot_uart_dev, UART_HW_FLOWCTRL_DISABLE, 100);
+    periph_ll_enable_clk_clear_rst(PERIPH_UART0_MODULE + SERIAL_BOOT_UART_NUM);
+
+    uart_ll_txfifo_rst(serial_boot_uart_dev);
+    uart_ll_rxfifo_rst(serial_boot_uart_dev);
+    esp_rom_delay_us(50000);
+
+    return 0;
+}
+
+bool boot_serial_detect_pin(void)
+{
+    bool detected = false;
+    int pin_value = 0;
+
+    esp_rom_gpio_pad_select_gpio(SERIAL_BOOT_GPIO_DETECT);
+    gpio_ll_input_enable(&GPIO, SERIAL_BOOT_GPIO_DETECT);
+    switch (SERIAL_BOOT_GPIO_INPUT_TYPE) {
+        // Pull-down
+        case 0:
+            gpio_ll_pulldown_en(&GPIO, SERIAL_BOOT_GPIO_DETECT);
+            break;
+        // Pull-up
+        case 1:
+            gpio_ll_pullup_en(&GPIO, SERIAL_BOOT_GPIO_DETECT);
+            break;
+    }
+    esp_rom_delay_us(50000);
+
+    pin_value = gpio_ll_get_level(&GPIO, SERIAL_BOOT_GPIO_DETECT);
+    detected = (pin_value == SERIAL_BOOT_GPIO_DETECT_VAL);
+    esp_rom_delay_us(50000);
+
+    if (detected) {
+        if (SERIAL_BOOT_DETECT_DELAY_S > 0) {
+            /* The delay time is an approximation */
+            for (int i = 0; i < (SERIAL_BOOT_DETECT_DELAY_S * 100); i++) {
+                esp_rom_delay_us(10000);
+                pin_value = gpio_ll_get_level(&GPIO, SERIAL_BOOT_GPIO_DETECT);
+                detected = (pin_value == SERIAL_BOOT_GPIO_DETECT_VAL);
+                if (!detected) {
+                    break;
+                }
+            }
+        }
+    }
+    return detected;
+}

--- a/boot/espressif/port/esp32s3/bootloader.conf
+++ b/boot/espressif/port/esp32s3/bootloader.conf
@@ -32,6 +32,41 @@ CONFIG_ESP_SCRATCH_SIZE=0x40000
 # CONFIG_ESP_SCRATCH_OFFSET=0x210000
 # CONFIG_ESP_SCRATCH_SIZE=0x40000
 
+# Enables the MCUboot Serial Recovery, that allows the use of
+# MCUMGR to upload a firmware through the serial port
+# CONFIG_ESP_MCUBOOT_SERIAL=y
+# Use Serial through USB JTAG Serial port for Serial Recovery
+# CONFIG_ESP_MCUBOOT_SERIAL_USB_SERIAL_JTAG=y
+# Use sector erasing (recommended) instead of entire image size
+# erasing when uploading through Serial Recovery
+# CONFIG_ESP_MCUBOOT_ERASE_PROGRESSIVELY=y
+
+# GPIO used to boot on Serial Recovery
+# CONFIG_ESP_SERIAL_BOOT_GPIO_DETECT=5
+# GPIO input type (0 for Pull-down, 1 for Pull-up)
+# CONFIG_ESP_SERIAL_BOOT_GPIO_INPUT_TYPE=0
+# GPIO signal value
+# CONFIG_ESP_SERIAL_BOOT_GPIO_DETECT_VAL=1
+# Delay time for identify the GPIO signal
+# CONFIG_ESP_SERIAL_BOOT_DETECT_DELAY_S=5
+# UART port used for serial communication (not needed when using USB)
+# CONFIG_ESP_SERIAL_BOOT_UART_NUM=1
+# GPIO for Serial RX signal
+# CONFIG_ESP_SERIAL_BOOT_GPIO_RX=18
+# GPIO for Serial TX signal
+# CONFIG_ESP_SERIAL_BOOT_GPIO_TX=17
+
+# Use UART0 for console printing (use either UART or USB alone)
+CONFIG_ESP_CONSOLE_UART=y
+CONFIG_ESP_CONSOLE_UART_NUM=0
+# Configures alternative UART port for console printing
+# (UART_NUM=0 must not be changed)
+# CONFIG_ESP_CONSOLE_UART_CUSTOM=y
+# CONFIG_ESP_CONSOLE_UART_TX_GPIO=17
+# CONFIG_ESP_CONSOLE_UART_RX_GPIO=18
+# Use USB JTAG Serial for console printing
+# CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+
 # CONFIG_ESP_SIGN_EC256=y
 # CONFIG_ESP_SIGN_ED25519=n
 # CONFIG_ESP_SIGN_RSA=n

--- a/boot/espressif/port/esp32s3/ld/bootloader.ld
+++ b/boot/espressif/port/esp32s3/ld/bootloader.ld
@@ -40,6 +40,7 @@ SECTIONS
     *libhal.a:bootloader_efuse_esp32s3.*(.literal .text .literal.* .text.*)
     *libhal.a:bootloader_utility.*(.literal .text .literal.* .text.*)
     *libhal.a:bootloader_sha.*(.literal .text .literal.* .text.*)
+    *libhal.a:bootloader_console.*(.literal .text .literal.* .text.*)
     *libhal.a:bootloader_console_loader.*(.literal .text .literal.* .text.*)
     *libhal.a:bootloader_panic.*(.literal .text .literal.* .text.*)
     *libhal.a:bootloader_soc.*(.literal .text .literal.* .text.*)

--- a/boot/espressif/port/esp32s3/serial_adapter.c
+++ b/boot/espressif/port/esp32s3/serial_adapter.c
@@ -1,0 +1,228 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <bootutil/bootutil_log.h>
+
+#include <esp_rom_uart.h>
+#include <esp_rom_gpio.h>
+#include <esp_rom_sys.h>
+#include <esp_rom_caps.h>
+#include <soc/uart_periph.h>
+#include <soc/gpio_struct.h>
+#include <soc/io_mux_reg.h>
+#include <soc/rtc.h>
+#include <hal/gpio_types.h>
+#include <hal/gpio_ll.h>
+#include <hal/uart_ll.h>
+#include <hal/clk_gate_ll.h>
+#include <hal/gpio_hal.h>
+#include <hal/usb_serial_jtag_ll.h>
+
+#ifdef CONFIG_ESP_SERIAL_BOOT_GPIO_DETECT
+#define SERIAL_BOOT_GPIO_DETECT     CONFIG_ESP_SERIAL_BOOT_GPIO_DETECT
+#else
+#define SERIAL_BOOT_GPIO_DETECT     GPIO_NUM_5
+#endif
+
+#ifdef CONFIG_ESP_SERIAL_BOOT_GPIO_DETECT_VAL
+#define SERIAL_BOOT_GPIO_DETECT_VAL     CONFIG_ESP_SERIAL_BOOT_GPIO_DETECT_VAL
+#else
+#define SERIAL_BOOT_GPIO_DETECT_VAL     1
+#endif
+
+#ifdef CONFIG_ESP_SERIAL_BOOT_DETECT_DELAY_S
+#define SERIAL_BOOT_DETECT_DELAY_S     CONFIG_ESP_SERIAL_BOOT_DETECT_DELAY_S
+#else
+#define SERIAL_BOOT_DETECT_DELAY_S     5
+#endif
+
+#ifdef CONFIG_ESP_SERIAL_BOOT_GPIO_INPUT_TYPE
+#define SERIAL_BOOT_GPIO_INPUT_TYPE    CONFIG_ESP_SERIAL_BOOT_GPIO_INPUT_TYPE
+#else
+// pull-down
+#define SERIAL_BOOT_GPIO_INPUT_TYPE    0
+#endif
+
+#ifndef CONFIG_ESP_MCUBOOT_SERIAL_USB_SERIAL_JTAG
+
+#ifdef CONFIG_ESP_SERIAL_BOOT_UART_NUM
+#define SERIAL_BOOT_UART_NUM    CONFIG_ESP_SERIAL_BOOT_UART_NUM
+#else
+#define SERIAL_BOOT_UART_NUM    ESP_ROM_UART_1
+#endif
+
+#ifdef CONFIG_ESP_SERIAL_BOOT_GPIO_RX
+#define SERIAL_BOOT_GPIO_RX     CONFIG_ESP_SERIAL_BOOT_GPIO_RX
+#else
+#define SERIAL_BOOT_GPIO_RX     GPIO_NUM_18
+#endif
+
+#ifdef CONFIG_ESP_SERIAL_BOOT_GPIO_TX
+#define SERIAL_BOOT_GPIO_TX     CONFIG_ESP_SERIAL_BOOT_GPIO_TX
+#else
+#define SERIAL_BOOT_GPIO_TX     GPIO_NUM_17
+#endif
+
+static uart_dev_t *serial_boot_uart_dev = (SERIAL_BOOT_UART_NUM == 0) ?
+                                          &UART0 :
+                                          &UART1;
+
+#endif
+
+void console_write(const char *str, int cnt)
+{
+#ifdef CONFIG_ESP_MCUBOOT_SERIAL_USB_SERIAL_JTAG
+    usb_serial_jtag_ll_txfifo_flush();
+    while (!usb_serial_jtag_ll_txfifo_writable()) {
+        MCUBOOT_WATCHDOG_FEED();
+    }
+    usb_serial_jtag_ll_write_txfifo((const uint8_t *)str, cnt);
+    usb_serial_jtag_ll_txfifo_flush();
+#else
+    uint32_t tx_len;
+    uint32_t write_len;
+
+    do {
+        tx_len = uart_ll_get_txfifo_len(serial_boot_uart_dev);
+        if (tx_len > 0) {
+            write_len = tx_len < cnt ? tx_len : cnt;
+            uart_ll_write_txfifo(serial_boot_uart_dev, (const uint8_t *)str, write_len);
+            cnt -= write_len;
+        }
+        MCUBOOT_WATCHDOG_FEED();
+        esp_rom_delay_us(1000);
+    } while (cnt > 0);
+#endif
+}
+
+int console_read(char *str, int cnt, int *newline)
+{
+#ifdef CONFIG_ESP_MCUBOOT_SERIAL_USB_SERIAL_JTAG
+
+    uint32_t read_len = 0;
+
+    esp_rom_delay_us(1000);
+    do {
+        if (usb_serial_jtag_ll_rxfifo_data_available()) {
+            usb_serial_jtag_ll_read_rxfifo((uint8_t *)&str[read_len], 1);
+            read_len++;
+        }
+        MCUBOOT_WATCHDOG_FEED();
+        esp_rom_delay_us(1000);
+    }  while (!(read_len == cnt || str[read_len - 1] == '\n'));
+    *newline = (str[read_len - 1] == '\n') ? 1 : 0;
+
+    return read_len;
+#else
+    uint32_t len = 0;
+    uint32_t read_len = 0;
+    bool stop = false;
+
+    do {
+        len = uart_ll_get_rxfifo_len(serial_boot_uart_dev);
+
+        if (len > 0) {
+            for (uint32_t i = 0; i < len; i++) {
+                /* Read the character from the RX FIFO */
+                uart_ll_read_rxfifo(serial_boot_uart_dev, (uint8_t *)&str[read_len], 1);
+                read_len++;
+                if (read_len == cnt - 1|| str[read_len - 1] == '\n') {
+                    stop = true;
+                    break;
+                }
+            }
+        }
+        MCUBOOT_WATCHDOG_FEED();
+        esp_rom_delay_us(1000);
+    } while (!stop);
+
+    *newline = (str[read_len - 1] == '\n') ? 1 : 0;
+    return read_len;
+#endif
+}
+
+int boot_console_init(void)
+{
+    BOOT_LOG_INF("Initializing serial boot pins");
+
+#ifdef CONFIG_ESP_MCUBOOT_SERIAL_USB_SERIAL_JTAG
+    usb_serial_jtag_ll_txfifo_flush();
+    esp_rom_uart_tx_wait_idle(0);
+#else
+    /* Enable GPIO for UART RX */
+    esp_rom_gpio_pad_select_gpio(SERIAL_BOOT_GPIO_RX);
+    esp_rom_gpio_connect_in_signal(SERIAL_BOOT_GPIO_RX,
+                                   UART_PERIPH_SIGNAL(SERIAL_BOOT_UART_NUM, SOC_UART_RX_PIN_IDX),
+                                   0);
+    gpio_ll_input_enable(&GPIO, SERIAL_BOOT_GPIO_RX);
+    esp_rom_gpio_pad_pullup_only(SERIAL_BOOT_GPIO_RX);
+
+    /* Enable GPIO for UART TX */
+    esp_rom_gpio_pad_select_gpio(SERIAL_BOOT_GPIO_TX);
+    esp_rom_gpio_connect_out_signal(SERIAL_BOOT_GPIO_TX,
+                                    UART_PERIPH_SIGNAL(SERIAL_BOOT_UART_NUM, SOC_UART_TX_PIN_IDX),
+                                    0, 0);
+    gpio_ll_output_enable(&GPIO, SERIAL_BOOT_GPIO_TX);
+
+    uart_ll_set_sclk(serial_boot_uart_dev, UART_SCLK_APB);
+    uart_ll_set_mode_normal(serial_boot_uart_dev);
+    uart_ll_set_baudrate(serial_boot_uart_dev, 115200);
+    uart_ll_set_stop_bits(serial_boot_uart_dev, 1u);
+    uart_ll_set_parity(serial_boot_uart_dev, UART_PARITY_DISABLE);
+    uart_ll_set_rx_tout(serial_boot_uart_dev, 16);
+    uart_ll_set_data_bit_num(serial_boot_uart_dev, UART_DATA_8_BITS);
+    uart_ll_set_tx_idle_num(serial_boot_uart_dev, 0);
+    uart_ll_set_hw_flow_ctrl(serial_boot_uart_dev, UART_HW_FLOWCTRL_DISABLE, 100);
+    periph_ll_enable_clk_clear_rst(PERIPH_UART0_MODULE + SERIAL_BOOT_UART_NUM);
+
+    uart_ll_txfifo_rst(serial_boot_uart_dev);
+    uart_ll_rxfifo_rst(serial_boot_uart_dev);
+    esp_rom_delay_us(50000);
+#endif
+    return 0;
+}
+
+bool boot_serial_detect_pin(void)
+{
+    bool detected = false;
+    int pin_value = 0;
+
+    esp_rom_gpio_pad_select_gpio(SERIAL_BOOT_GPIO_DETECT);
+    gpio_ll_input_enable(&GPIO, SERIAL_BOOT_GPIO_DETECT);
+    switch (SERIAL_BOOT_GPIO_INPUT_TYPE) {
+        // Pull-down
+        case 0:
+            gpio_ll_pulldown_en(&GPIO, SERIAL_BOOT_GPIO_DETECT);
+            break;
+        // Pull-up
+        case 1:
+            gpio_ll_pullup_en(&GPIO, SERIAL_BOOT_GPIO_DETECT);
+            break;
+    }
+    esp_rom_delay_us(50000);
+
+    pin_value = gpio_ll_get_level(&GPIO, SERIAL_BOOT_GPIO_DETECT);
+    detected = (pin_value == SERIAL_BOOT_GPIO_DETECT_VAL);
+    esp_rom_delay_us(50000);
+
+    if (detected) {
+        if (SERIAL_BOOT_DETECT_DELAY_S > 0) {
+            /* The delay time is an approximation */
+            for (int i = 0; i < (SERIAL_BOOT_DETECT_DELAY_S * 100); i++) {
+                esp_rom_delay_us(10000);
+                pin_value = gpio_ll_get_level(&GPIO, SERIAL_BOOT_GPIO_DETECT);
+                detected = (pin_value == SERIAL_BOOT_GPIO_DETECT_VAL);
+                if (!detected) {
+                    break;
+                }
+            }
+        }
+    }
+    return detected;
+}

--- a/docs/readme-espressif.md
+++ b/docs/readme-espressif.md
@@ -552,7 +552,7 @@ Serial recovery mode allows management through MCUMGR (more information and how 
 ---
 ***Note***
 
-Supported on ESP32 and ESP32-C3.
+Supported on ESP32, ESP32-C3, ESP32-S2.
 
 ---
 

--- a/docs/readme-espressif.md
+++ b/docs/readme-espressif.md
@@ -552,7 +552,7 @@ Serial recovery mode allows management through MCUMGR (more information and how 
 ---
 ***Note***
 
-Supported on ESP32, ESP32-C3, ESP32-S2.
+Supported on ESP32, ESP32-C3, ESP32-S2 and ESP32-S3.
 
 ---
 


### PR DESCRIPTION
This MR adds the serial adapter for ESP32-S2 and ESP32-S3 for boot recovery and MCUMGR communication.

Note: the Espressif CRC call on boot_serial.c was changed due to chip compatibility (ESP32-S2 needed a different implementation).