### PR TITLE
Fix error: format '%u' expects argument of type 'unsigned int', but argument 5 has type 'uint32_t'

### DIFF
--- a/boot/nuttx/src/flash_map_backend/flash_map_backend.c
+++ b/boot/nuttx/src/flash_map_backend/flash_map_backend.c
@@ -603,7 +603,7 @@ uint32_t flash_area_align(const struct flash_area *fa)
 
   const uint32_t minimum_write_length = 1;
 
-  BOOT_LOG_INF("ID:%" PRIu8 " align:%" PRIu8,
+  BOOT_LOG_INF("ID:%" PRIu8 " align:%" PRIu32,
                fa->fa_id, minimum_write_length);
 
   return minimum_write_length;


### PR DESCRIPTION
Fix the warning reported here:
https://github.com/apache/incubator-nuttx-apps/actions/runs/3455216080/jobs/5767096531