### PR TITLE
zephyr: Explicitly select CONFIG_CRC for CONFIG_MCUBOOT_SERIAL

### DIFF
--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -13,6 +13,7 @@ menuconfig MCUBOOT_SERIAL
 	select SERIAL
 	select UART_INTERRUPT_DRIVEN
 	select BASE64
+	select CRC
 	help
 	  If y, enables a serial-port based update mode. This allows
 	  MCUboot itself to load update images into flash over a UART.


### PR DESCRIPTION
The serial recovery depends on CRC from Zephyr, which it should have been selecting explicitly.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>