### PR TITLE
bootutil: Fix bootutil_find_key return value

### DIFF
--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -247,7 +247,7 @@ bootutil_find_key(uint8_t image_index, uint8_t *key, uint16_t key_len)
 
     rc = boot_retrieve_public_key_hash(image_index, key_hash, &key_hash_size);
     if (rc) {
-        return rc;
+        return -1;
     }
 
     /* Adding hardening to avoid this potential attack:


### PR DESCRIPTION
The return value of bootutil_find_key is used as the key_id in the bootutil_img_validate function, and negative key_id value used in case of errors. If MCUBOOT_HW_KEY is set, than the key hash is read by boot_retrieve_public_key_hash function, but the exceptation is only to return nonzero on failure, so its error code should not be propagated up to the caller. Instead, bootutil_find_key should return -1 in case of a platform error.

Change-Id: I8e2bd12a5cf53787e10ae45c2ab556e8a856692d
Signed-off-by: Mark Horvath <mark.horvath@arm.com>