### PR TITLE
imgtool: fix tlv encoding

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -111,9 +111,9 @@ class TLV():
         """
         e = STRUCT_ENDIAN_DICT[self.endian]
         if isinstance(kind, int):
-            buf = struct.pack(e + 'BBH', kind, 0, len(payload))
+            buf = struct.pack(e + 'HH', kind, len(payload))
         else:
-            buf = struct.pack(e + 'BBH', TLV_VALUES[kind], 0, len(payload))
+            buf = struct.pack(e + 'HH', TLV_VALUES[kind], len(payload))
         self.buf += buf
         self.buf += payload
 


### PR DESCRIPTION
As mcuboot supports 2 byte tlv type, where range 0x00a0 - 0xfffe is vendor reserved, allow setting tlv with non-zero upper byte.

Also fix potential big-endian issues with type encoding.