### PR TITLE
boot_serial: Allow using a buffer larger than 512 bytes

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -78,7 +78,10 @@
 
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
-#define BOOT_SERIAL_INPUT_MAX   512
+#ifndef MCUBOOT_SERIAL_MAX_RECEIVE_SIZE
+#define MCUBOOT_SERIAL_MAX_RECEIVE_SIZE 512
+#endif
+
 #define BOOT_SERIAL_OUT_MAX     (128 * BOOT_IMAGE_NUMBER)
 
 #ifdef __ZEPHYR__
@@ -107,8 +110,8 @@ BOOT_LOG_MODULE_DECLARE(mcuboot);
 #define IMAGES_ITER(x)
 #endif
 
-static char in_buf[BOOT_SERIAL_INPUT_MAX + 1];
-static char dec_buf[BOOT_SERIAL_INPUT_MAX + 1];
+static char in_buf[MCUBOOT_SERIAL_MAX_RECEIVE_SIZE + 1];
+static char dec_buf[MCUBOOT_SERIAL_MAX_RECEIVE_SIZE + 1];
 const struct boot_uart_funcs *boot_uf;
 static struct nmgr_hdr *bs_hdr;
 static bool bs_entry;

--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -52,10 +52,16 @@ config MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD
 	  selection is done.
 
 config BOOT_MAX_LINE_INPUT_LEN
-	int "Maximum command line length"
+	int "Maximum input line length"
 	default 512
 	help
-	  Maximum length of commands transported over the serial port.
+	  Maximum length of input serial port buffer.
+
+config BOOT_SERIAL_MAX_RECEIVE_SIZE
+	int "Maximum command line length"
+	default 1024
+	help
+	  Maximum length of received commands via the serial port.
 
 config BOOT_SERIAL_DETECT_PORT
 	string "GPIO device to trigger serial recovery mode (DEPRECATED)"

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -241,6 +241,10 @@
 #define MCUBOOT_MAX_IMG_SECTORS       128
 #endif
 
+#ifdef CONFIG_BOOT_SERIAL_MAX_RECEIVE_SIZE
+#define MCUBOOT_SERIAL_MAX_RECEIVE_SIZE CONFIG_BOOT_SERIAL_MAX_RECEIVE_SIZE
+#endif
+
 /* Support 32-byte aligned flash sizes */
 #if DT_HAS_CHOSEN(zephyr_flash)
     #if DT_PROP_OR(DT_CHOSEN(zephyr_flash), write_block_size, 0) > 8


### PR DESCRIPTION
There are 3 levels of buffers and only the first one seems to be configurable, this fixes that issue.

Fixes #1535


I don't know if 512 is a minimum so have only allowed changing the size if a larger value is set