### PR TITLE
Allow downgrade prevention without the need to overwrite the received image

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -743,7 +743,7 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
         goto out;
     }
 
-#if defined(MCUBOOT_OVERWRITE_ONLY) && defined(MCUBOOT_DOWNGRADE_PREVENTION)
+#if defined(MCUBOOT_DOWNGRADE_PREVENTION)
     if (slot != BOOT_PRIMARY_SLOT) {
         /* Check if version of secondary slot is sufficient */
         rc = boot_version_cmp(

--- a/docs/design.md
+++ b/docs/design.md
@@ -1268,9 +1268,8 @@ vulnerable version of its firmware.
 
 During the software based downgrade prevention the image version numbers are
 compared. This feature is enabled with the `MCUBOOT_DOWNGRADE_PREVENTION`
-option. In this case downgrade prevention is only available when the
-overwrite-based image update strategy is used (i.e. `MCUBOOT_OVERWRITE_ONLY`
-is set).
+option. If the new image has a lower version number, it will be erased from
+the flash; otherwise the configured swapping method is used.
 
 ### [Hardware-based downgrade prevention](#hw-downgrade-prevention)
 


### PR DESCRIPTION
Offers the option to use bootloader defined downgrade prevention without losing the possibility to revert back to the old image if test running the new image yields an error.

Signed-off-by: Robert Schulze <robert.schulze@deveritec.com>