### PR TITLE
zephyr: serial recovery: Prevent USB init failure if already setup

### DIFF
--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -203,7 +203,7 @@ boot_uart_fifo_init(void)
 
 #if CONFIG_BOOT_SERIAL_CDC_ACM
 	int rc = usb_enable(NULL);
-	if (rc) {
+	if (rc && rc != -EALREADY) {
 		return (-1);
 	}
 #endif


### PR DESCRIPTION
Prevents an issue with devices that already have USB setup (e.g. devices using USB CDC for logging/console).