### PR TITLE
boot: Update Nordic's license identifier tag

### DIFF
--- a/ext/nrf/cc310_glue.c
+++ b/ext/nrf/cc310_glue.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include "cc310_glue.h"

--- a/ext/nrf/cc310_glue.h
+++ b/ext/nrf/cc310_glue.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 #ifndef NRF_CC310_GLUE_H__
 #define NRF_CC310_GLUE_H__


### PR DESCRIPTION
Nordic had changed its license identifier to new more accurate id: LicenseRef-Nordic-5-Clause.
Old identifiers should be updated.
