### PR TITLE
zephyr: Remove flash_area_ implementations from header

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2022 Nordic Semiconductor ASA
  * Copyright (c) 2015 Runtime Inc
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -139,4 +139,29 @@ __weak uint8_t flash_area_erased_val(const struct flash_area *fap)
 {
     (void)fap;
     return ERASED_VAL;
+}
+
+uint32_t flash_area_get_size(const struct flash_area *fa)
+{
+	return (uint32_t)fa->fa_size;
+}
+
+uint32_t flash_area_get_off(const struct flash_area *fa)
+{
+	return (uint32_t)fa->fa_off;
+}
+
+uint8_t flash_area_get_id(const struct flash_area *fa)
+{
+	return fa->fa_id;
+}
+
+uint32_t flash_sector_get_off(const struct flash_sector *fs)
+{
+	return fs->fs_off;
+}
+
+uint32_t flash_sector_get_size(const struct flash_sector *fs)
+{
+	return fs->fs_size;
 }

--- a/boot/zephyr/include/flash_map_backend/flash_map_backend.h
+++ b/boot/zephyr/include/flash_map_backend/flash_map_backend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2018-2022 Nordic Semiconductor ASA
  * Copyright (c) 2015 Runtime Inc
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -70,20 +70,11 @@ int flash_area_id_to_multi_image_slot(int image_index, int area_id);
  */
 int flash_area_sector_from_off(off_t off, struct flash_sector *sector);
 
-static inline uint32_t flash_area_get_off(const struct flash_area *fa)
-{
-	return (uint32_t)fa->fa_off;
-}
+uint32_t flash_area_get_off(const struct flash_area *fa);
 
-static inline uint32_t flash_area_get_size(const struct flash_area *fa)
-{
-	return (uint32_t)fa->fa_size;
-}
+uint32_t flash_area_get_size(const struct flash_area *fa);
 
-static inline uint8_t flash_area_get_id(const struct flash_area *fa)
-{
-	return fa->fa_id;
-}
+uint8_t flash_area_get_id(const struct flash_area *fa);
 
 uint8_t flash_area_get_device_id(const struct flash_area *fa);
 
@@ -93,15 +84,9 @@ uint8_t flash_area_get_device_id(const struct flash_area *fa);
  */
 uint8_t flash_area_erased_val(const struct flash_area *fap);
 
-static inline uint32_t flash_sector_get_off(const struct flash_sector *fs)
-{
-	return fs->fs_off;
-}
+uint32_t flash_sector_get_off(const struct flash_sector *fs);
 
-static inline uint32_t flash_sector_get_size(const struct flash_sector *fs)
-{
-	return fs->fs_size;
-}
+uint32_t flash_sector_get_size(const struct flash_sector *fs);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
bootutil_public.h has been leaking implementations of some of flash_area_ functions defined in flash_map_backend.h.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>