### PR TITLE
boot: zephyr: boards: nrf52840dk: Fix overlay

### DIFF
--- a/boot/zephyr/boards/nrf52840dk_qspi_nor_secondary.overlay
+++ b/boot/zephyr/boards/nrf52840dk_qspi_nor_secondary.overlay
@@ -7,7 +7,6 @@
 /delete-node/ &boot_partition;
 /delete-node/ &slot0_partition;
 /delete-node/ &slot1_partition;
-/delete-node/ &scratch_partition;
 
 &flash0 {
 	partitions {


### PR DESCRIPTION
Fixes an issue with a node which has been removed from zephyr.

Zephyr PR: https://github.com/zephyrproject-rtos/zephyr/pull/52028
Scratch partitions have been removed from upstream nordic boards, therefore the area no longer needs to be removed by the nrf52840dk overlay because it no longer exists