### PR TITLE
Remove MCUBOOT_SWAP_USING_SCRATCH being set when MCUBOOT_SINGLE_APPLICATION_SLOT has been selected

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -390,7 +390,7 @@ boot_write_enc_key(const struct flash_area *fap, uint8_t slot,
 
 uint32_t bootutil_max_image_size(const struct flash_area *fap)
 {
-#if defined(MCUBOOT_SWAP_USING_SCRATCH)
+#if defined(MCUBOOT_SWAP_USING_SCRATCH) || defined(MCUBOOT_SINGLE_APPLICATION_SLOT)
     return boot_status_off(fap);
 #elif defined(MCUBOOT_SWAP_USING_MOVE)
     struct flash_sector sector;

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -64,7 +64,8 @@ struct flash_area;
 #if !defined(MCUBOOT_OVERWRITE_ONLY) && \
     !defined(MCUBOOT_SWAP_USING_MOVE) && \
     !defined(MCUBOOT_DIRECT_XIP) && \
-    !defined(MCUBOOT_RAM_LOAD)
+    !defined(MCUBOOT_RAM_LOAD) && \
+    !defined(MCUBOOT_SINGLE_APPLICATION_SLOT)
 #define MCUBOOT_SWAP_USING_SCRATCH 1
 #endif
 

--- a/boot/zephyr/include/sysflash/sysflash.h
+++ b/boot/zephyr/include/sysflash/sysflash.h
@@ -47,11 +47,6 @@
 
 #define FLASH_AREA_IMAGE_PRIMARY(x)	FIXED_PARTITION_ID(slot0_partition)
 #define FLASH_AREA_IMAGE_SECONDARY(x)	FIXED_PARTITION_ID(slot0_partition)
-/* NOTE: Scratch parition is not used by single image DFU but some of
- * functions in common files reference it, so the definitions has been
- * provided to allow compilation of common units.
- */
-#define FLASH_AREA_IMAGE_SCRATCH	0
 
 #endif /* CONFIG_SINGLE_APPLICATION_SLOT */
 


### PR DESCRIPTION
Scratch is not used when MCUBOOT_SINGLE_APPLICATION_SLOT  is used but definition of FLASH_AREA_IMAGE_SCRATCH has been required anyway because it would be default algorithm if nothing else has been selected.