### PR TITLE
ci: Fix imgtool CI workflow on `main` branch

### DIFF
--- a/ci/imgtool_install.sh
+++ b/ci/imgtool_install.sh
@@ -19,5 +19,5 @@ if [[ $TRAVIS == "true" ]]; then
     fi
 fi
 
-pip install setuptools twine packaging wheel
+pip install setuptools twine packaging==21.3 wheel
 pip install --pre imgtool


### PR DESCRIPTION
## Summary

**imgtool** relies on `packaging.version.LegacyVersion` to parse image version numbers, and this has been removed in packaging 22.0.
This results in the following error in the **Publish** step:
```python
+ python ../ci/compare_versions.py --old 1.9.0 --new 1.9.0
Traceback (most recent call last):
  File "/home/runner/work/mcuboot/mcuboot/scripts/../ci/compare_versions.py", line 15, in <module>
    from packaging.version import parse, LegacyVersion
ImportError: cannot import name 'LegacyVersion' from 'packaging.version' (/usr/local/lib/python3.10/dist-packages/packaging/version.py)
```
https://github.com/mcu-tools/mcuboot/actions/runs/3741361421/jobs/6350869462

Proposed fix based on https://github.com/pypa/pip-audit/pull/427.

## Impact
Should have no impact. Patch should bring CI back to normal.

## Testing
CI build pass.
