### PR TITLE
flash_map_backend: Remove flash_area_id_to_image_slot

### DIFF
--- a/boot/cypress/cy_flash_pal/cy_flash_map.c
+++ b/boot/cypress/cy_flash_pal/cy_flash_map.c
@@ -438,11 +438,6 @@ int flash_area_id_to_multi_image_slot(int image_index, int area_id)
     return -1;
 }
 
-int flash_area_id_to_image_slot(int area_id)
-{
-    return flash_area_id_to_multi_image_slot(0, area_id);
-}
-
 uint8_t flash_area_erased_val(const struct flash_area *fap)
 {
     int ret = 0;

--- a/boot/cypress/cy_flash_pal/include/flash_map_backend/flash_map_backend.h
+++ b/boot/cypress/cy_flash_pal/include/flash_map_backend/flash_map_backend.h
@@ -172,8 +172,6 @@ uint32_t flash_area_align(const struct flash_area *);
 int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret);
 /*< Returns the `fa_id` for slot, where slot is 0 (primary) or 1 (secondary) */
 int flash_area_id_from_image_slot(int slot);
-/*< Returns the slot, for the `fa_id` supplied */
-int flash_area_id_to_image_slot(int area_id);
 
 int flash_area_id_from_multi_image_slot(int image_index, int slot);
 int flash_area_id_to_multi_image_slot(int image_index, int area_id);

--- a/boot/mbed/include/flash_map_backend/flash_map_backend.h
+++ b/boot/mbed/include/flash_map_backend/flash_map_backend.h
@@ -161,7 +161,6 @@ int flash_area_id_from_image_slot(int slot);
 int flash_area_id_from_multi_image_slot(int image_index, int slot);
 
 
-int flash_area_id_to_image_slot(int area_id);
 /**
  * Converts the specified flash area ID and image index (in multi-image setup)
  * to an image slot index.

--- a/boot/mbed/src/flash_map_backend.cpp
+++ b/boot/mbed/src/flash_map_backend.cpp
@@ -231,10 +231,6 @@ int flash_area_id_from_image_slot(int slot) {
     return slot;
 }
 
-int flash_area_id_to_image_slot(int area_id) {
-    return area_id;
-}
-
 /**
  * Multi images support not implemented yet
  */

--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -83,11 +83,6 @@ int flash_area_id_to_multi_image_slot(int image_index, int area_id)
     return -1;
 }
 
-int flash_area_id_to_image_slot(int area_id)
-{
-    return flash_area_id_to_multi_image_slot(0, area_id);
-}
-
 #if defined(CONFIG_MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD)
 int flash_area_id_from_direct_image(int image_id)
 {

--- a/boot/zephyr/include/flash_map_backend/flash_map_backend.h
+++ b/boot/zephyr/include/flash_map_backend/flash_map_backend.h
@@ -48,14 +48,6 @@ int flash_area_id_from_image_slot(int slot);
 int flash_area_id_from_multi_image_slot(int image_index, int slot);
 
 /**
- * Converts the specified flash area ID to an image slot index.
- *
- * Returns image slot index (0 or 1), or -1 if ID doesn't correspond to an image
- * slot.
- */
-int flash_area_id_to_image_slot(int area_id);
-
-/**
  * Converts the specified flash area ID and image index (in multi-image setup)
  * to an image slot index.
  *

--- a/sim/mcuboot-sys/csupport/storage/flash_map.h
+++ b/sim/mcuboot-sys/csupport/storage/flash_map.h
@@ -152,7 +152,6 @@ int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret);
 
 int flash_area_id_from_image_slot(int slot);
 int flash_area_id_from_multi_image_slot(int image_index, int slot);
-int flash_area_id_to_image_slot(int area_id);
 int flash_area_id_to_multi_image_slot(int image_index, int area_id);
 
 #ifdef __cplusplus


### PR DESCRIPTION
The function has not been in use and some ports have not been implementing it anyway.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>