### PR TITLE
Replace flash_area_sector_from_off with flash_area_get_sector

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -318,7 +318,7 @@ static off_t erase_range(const struct flash_area *fap, off_t start, off_t end)
         return start;
     }
 
-    if (flash_area_sector_from_off(end, &sect)) {
+    if (flash_area_get_sector(fap, end, &sect)) {
         return -EINVAL;
     }
 
@@ -437,7 +437,7 @@ bs_upload(char *buf, int len)
          * TODO: This is single occurrence issue, it should get detected during tests
          * and fixed otherwise you are deploying broken mcuboot.
          */
-        if (flash_area_sector_from_off(boot_status_off(fap), &status_sector)) {
+        if (flash_area_get_sector(fap, boot_status_off(fap), &status_sector)) {
             rc = MGMT_ERR_EUNKNOWN;
             BOOT_LOG_ERR("Unable to determine flash sector of the image trailer");
             goto out;

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -395,7 +395,7 @@ uint32_t bootutil_max_image_size(const struct flash_area *fap)
 #elif defined(MCUBOOT_SWAP_USING_MOVE)
     struct flash_sector sector;
     /* get the last sector offset */
-    int rc = flash_area_sector_from_off(boot_status_off(fap), &sector);
+    int rc = flash_area_get_sector(fap, boot_status_off(fap), &sector);
     if (rc) {
         BOOT_LOG_ERR("Unable to determine flash sector of the image trailer");
         return 0; /* Returning of zero here should cause any check which uses

--- a/boot/espressif/include/flash_map_backend/flash_map_backend.h
+++ b/boot/espressif/include/flash_map_backend/flash_map_backend.h
@@ -80,6 +80,10 @@ int flash_area_get_sectors(int fa_id, uint32_t *count,
 //! Retrieve the flash sector a given offset belongs to.
 int flash_area_sector_from_off(uint32_t off, struct flash_sector *sector);
 
+//! Retrieve the flash sector a given offset belongs to.
+int flash_area_get_sector(const struct flash_area *area, uint32_t off,
+                          struct flash_sector *sector);
+
 //! Returns the `fa_id` for slot, where slot is 0 (primary) or 1 (secondary).
 //!
 //! `image_index` (0 or 1) is the index of the image. Image index is

--- a/boot/espressif/port/esp_mcuboot.c
+++ b/boot/espressif/port/esp_mcuboot.c
@@ -372,6 +372,15 @@ int flash_area_sector_from_off(uint32_t off, struct flash_sector *sector)
     return 0;
 }
 
+int flash_area_get_sector(const struct flash_area *fa, uint32_t off,
+                          struct flash_sector *sector)
+{
+    sector->fs_off = (off / FLASH_SECTOR_SIZE) * FLASH_SECTOR_SIZE;
+    sector->fs_size = FLASH_SECTOR_SIZE;
+
+    return 0;
+}
+
 int flash_area_id_from_multi_image_slot(int image_index, int slot)
 {
     BOOT_LOG_DBG("%s", __func__);

--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -140,3 +140,24 @@ __weak uint8_t flash_area_erased_val(const struct flash_area *fap)
     (void)fap;
     return ERASED_VAL;
 }
+
+int flash_area_get_sector(const struct flash_area *fap, off_t off,
+                          struct flash_sector *fsp)
+{
+    struct flash_pages_info fpi;
+    int rc;
+
+    if (off >= fap->fa_size) {
+        return -ERANGE;
+    }
+
+    rc = flash_get_page_info_by_offs(fap->fa_dev, fap->fa_off + off,
+            &fpi);
+
+    if (rc == 0) {
+        fsp->fs_off = fpi.start_offset - fap->fa_off;
+        fsp->fs_size = fpi.size;
+    }
+
+    return rc;
+}

--- a/boot/zephyr/include/flash_map_backend/flash_map_backend.h
+++ b/boot/zephyr/include/flash_map_backend/flash_map_backend.h
@@ -103,6 +103,17 @@ static inline uint32_t flash_sector_get_size(const struct flash_sector *fs)
 	return fs->fs_size;
 }
 
+/* Retrieve the flash sector withing given flash area, at a given offset.
+ *
+ * @param fa        flash area where the sector is taken from.
+ * @param off       offset within flash area.
+ * @param sector    structure of sector information.
+ * Returns 0 on success, -ERANGE if @p off is beyond flash area size,
+ *         other negative errno code on failure.
+ */
+int flash_area_get_sector(const struct flash_area *fa, off_t off,
+                          struct flash_sector *fs);
+
 #ifdef __cplusplus
 }
 #endif

--- a/boot/zephyr/single_loader.c
+++ b/boot/zephyr/single_loader.c
@@ -350,7 +350,7 @@ decrypt_image_inplace(const struct flash_area *fa_p,
     memset(&_bs, 0, sizeof(struct boot_status));
 
     /* Get size from last sector to know page/sector erase size */
-    rc = flash_area_sector_from_off(boot_status_off(fa_p), &sector);
+    rc = flash_area_get_sector(fap, boot_status_off(fa_p), &sector);
 
 
     image_index = BOOT_CURR_IMG(state);

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -481,6 +481,40 @@ int flash_area_sector_from_off(uint32_t off, struct flash_sector *sector)
     return (i < slot->num_areas) ? 0 : -1;
 }
 
+int flash_area_get_sector(const struct flash_area *fa, uint32_t off,
+                          struct flash_sector *sector)
+{
+    uint32_t i, sec_off, sec_size;
+    struct area *slot;
+    struct area_desc *flash_areas;
+
+    flash_areas = sim_get_flash_areas();
+    for (i = 0; i < flash_areas->num_slots; i++) {
+        if (&flash_areas->slots[i].whole == fa)
+            break;
+    }
+
+    if (i == flash_areas->num_slots) {
+        printf("Unsupported area\n");
+        abort();
+    }
+
+    slot = &flash_areas->slots[i];
+
+    for (i = 0; i < slot->num_areas; i++) {
+        sec_off = slot->areas[i].fa_off - slot->whole.fa_off;
+        sec_size = slot->areas[i].fa_size;
+
+        if (off >= sec_off && off < (sec_off + sec_size)) {
+            sector->fs_off = sec_off;
+            sector->fs_size = sec_size;
+            break;
+        }
+    }
+
+    return (i < slot->num_areas) ? 0 : -1;
+}
+
 void sim_assert(int x, const char *assertion, const char *file, unsigned int line, const char *function)
 {
     if (!(x)) {

--- a/sim/mcuboot-sys/csupport/storage/flash_map.h
+++ b/sim/mcuboot-sys/csupport/storage/flash_map.h
@@ -143,6 +143,16 @@ int flash_area_get_sectors(int fa_id, uint32_t *count,
  */
 int flash_area_sector_from_off(uint32_t off, struct flash_sector *sector);
 
+/* Retrieve the flash sector a given offset, within flash area.
+ *
+ * @param fa        flash area.
+ * @param off       offset of sector.
+ * @param sector    pointer to structure for obtained information.
+ * Returns 0 on success, or an error code on failure.
+ */
+int flash_area_get_sector(const struct flash_area *fa, uint32_t off,
+  struct flash_sector *sector);
+
 /*
  * Similar to flash_area_get_sectors(), but return the values in an
  * array of struct flash_area instead.


### PR DESCRIPTION
The flash_area_sector_from_off  uses hardcoded flash_area object pointer, the flash_area_get_sector takes flash_area pointer.

Commits for:
1.  Zephyr implementation;
2. sim implementation;
3. espressif implementation;
4. general code switch;
5. zephyr/single_loader switch.