### PR TITLE
Fix Mynewt with swap move

### DIFF
--- a/boot/mynewt/flash_map_backend/include/flash_map_backend/flash_map_backend.h
+++ b/boot/mynewt/flash_map_backend/include/flash_map_backend/flash_map_backend.h
@@ -10,6 +10,7 @@
 #include <sysflash/sysflash.h>
 #include <flash_map/flash_map.h>
 #include <mcuboot_config/mcuboot_config.h>
+#include <unistd.h>  /* off_t */
 
 #if (MCUBOOT_IMAGE_NUMBER == 1)
 
@@ -40,6 +41,13 @@
 int flash_area_id_from_multi_image_slot(int image_index, int slot);
 int flash_area_id_to_multi_image_slot(int image_index, int area_id);
 
+struct flash_sector {
+    uint32_t fs_off;
+    uint32_t fs_size;
+};
+
+int flash_area_sector_from_off(off_t off, struct flash_sector *sector);
+
 static inline uint8_t flash_area_get_id(const struct flash_area *fa)
 {
     return fa->fa_id;
@@ -58,6 +66,11 @@ static inline uint32_t flash_area_get_off(const struct flash_area *fa)
 static inline uint32_t flash_area_get_size(const struct flash_area *fa)
 {
     return fa->fa_size;
+}
+
+static inline uint32_t flash_sector_get_off(const struct flash_sector *fs)
+{
+    return fs->fs_off;
 }
 
 #endif /* __FLASH_MAP_BACKEND_H__ */

--- a/boot/mynewt/flash_map_backend/src/flash_map_extended.c
+++ b/boot/mynewt/flash_map_backend/src/flash_map_extended.c
@@ -19,6 +19,8 @@
 
 #include <flash_map/flash_map.h>
 #include <flash_map_backend/flash_map_backend.h>
+#include <hal/hal_bsp.h>
+#include <hal/hal_flash_int.h>
 
 int flash_area_id_from_multi_image_slot(int image_index, int slot)
 {
@@ -41,4 +43,37 @@ int flash_area_id_to_multi_image_slot(int image_index, int area_id)
         return 1;
     }
     return 255;
+}
+
+int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
+{
+    const struct flash_area *fa;
+    const struct hal_flash *hf;
+    uint32_t start;
+    uint32_t size;
+    int rc;
+    int i;
+
+    rc = flash_area_open(FLASH_AREA_IMAGE_0, &fa);
+    if (rc != 0) {
+        return -1;
+    }
+
+    rc = -1;
+    hf = hal_bsp_flash_dev(fa->fa_device_id);
+    for (i = 0; i < hf->hf_sector_cnt; i++) {
+        hf->hf_itf->hff_sector_info(hf, i, &start, &size);
+        if (start < fa->fa_off) {
+            continue;
+        }
+        if (off >= start - fa->fa_off && off <= (start - fa->fa_off) + size) {
+            sector->fs_off = start - fa->fa_off;
+            sector->fs_size = size;
+            rc = 0;
+            break;
+        }
+    }
+
+    flash_area_close(fa);
+    return rc;
 }

--- a/ci/mynewt_targets/swap_move/pkg.yml
+++ b/ci/mynewt_targets/swap_move/pkg.yml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: "targets/swap_move"
+pkg.type: "target"
+pkg.description:
+pkg.author:
+pkg.homepage:
+
+pkg.deps:
+    - "@mcuboot/boot/mynewt"

--- a/ci/mynewt_targets/swap_move/syscfg.yml
+++ b/ci/mynewt_targets/swap_move/syscfg.yml
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:
+    BOOT_SERIAL: 0
+    BOOT_SERIAL_DETECT_PIN: 11
+    BOOT_SERIAL_DETECT_PIN_VAL: 0
+    BOOT_SERIAL_REPORT_PIN: 13
+    BOOTUTIL_VALIDATE_SLOT0: 0
+    BOOTUTIL_MAX_IMG_SECTORS: 256
+    BOOTUTIL_SWAP_USING_MOVE: 1
+    BOOTUTIL_SIGN_EC256: 0
+    BOOTUTIL_SIGN_RSA: 0
+    BOOTUTIL_ENCRYPT_RSA: 0
+    BOOTUTIL_ENCRYPT_KW: 0
+    BOOTUTIL_USE_MBED_TLS: 0
+    BOOTUTIL_USE_TINYCRYPT: 1
+    BOOTUTIL_OVERWRITE_ONLY: 0
+    BOOTUTIL_OVERWRITE_ONLY_FAST: 1
+    BOOTUTIL_HAVE_LOGGING: 0
+    BOOTUTIL_NO_LOGGING: 1
+    BOOTUTIL_LOG_LEVEL: 'BOOTUTIL_LOG_LEVEL_INFO'
+    CONSOLE_COMPAT: 1
+    CONSOLE_INPUT: 0
+    CONSOLE_UART: 0
+    CONSOLE_RTT: 0
+    OS_CPUTIME_TIMER_NUM: 0
+    TIMER_0: 1
+    UART_0: 0
+    BOOTUTIL_BOOTSTRAP: 0
+    MBEDTLS_NIST_KW_C: 0

--- a/ci/mynewt_targets/swap_move/target.yml
+++ b/ci/mynewt_targets/swap_move/target.yml
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+target.app: "@mcuboot/boot/mynewt"
+target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"
+target.build_profile: "optimized"


### PR DESCRIPTION
Add Mynewt build configuration with swap move enabled to the CI. Fixes the Mynewt build using swap move, by adding the `flash_sector` struct and functions used to calculate the maximum image size.

The implementation was tested on nrf52840dk and b-l475e-iot01a.

Fixes #1567 