### PR TITLE
imgtool: fix getpriv format type for keys

### DIFF
--- a/scripts/imgtool/keys/ed25519.py
+++ b/scripts/imgtool/keys/ed25519.py
@@ -34,7 +34,7 @@ class Ed25519Public(KeyClass):
                 encoding=serialization.Encoding.DER,
                 format=serialization.PublicFormat.SubjectPublicKeyInfo)
 
-    def get_private_bytes(self, minimal):
+    def get_private_bytes(self, minimal, format):
         self._unsupported('get_private_bytes')
 
     def export_private(self, path, passwd=None):
@@ -75,7 +75,7 @@ class Ed25519(Ed25519Public):
     def _get_public(self):
         return self.key.public_key()
 
-    def get_private_bytes(self, minimal):
+    def get_private_bytes(self, minimal, format):
         raise Ed25519UsageError("Operation not supported with {} keys".format(
             self.shortname()))
 

--- a/scripts/imgtool/keys/privatebytes.py
+++ b/scripts/imgtool/keys/privatebytes.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from cryptography.hazmat.primitives import serialization
+
+
+class PrivateBytesMixin():
+    def _get_private_bytes(self, minimal, format, exclass):
+        if format is None:
+            format = self._DEFAULT_FORMAT
+        if format not in self._VALID_FORMATS:
+            raise exclass("{} does not support {}".format(
+                self.shortname(), format))
+        return format, self.key.private_bytes(
+                encoding=serialization.Encoding.DER,
+                format=self._VALID_FORMATS[format],
+                encryption_algorithm=serialization.NoEncryption())

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -157,8 +157,8 @@ def getpub(key, encoding, lang):
 @click.option('-k', '--key', metavar='filename', required=True)
 @click.option('-f', '--format',
               type=click.Choice(valid_formats),
-              help='Valid formats: {}'.format(', '.join(valid_formats)),
-              default='pkcs8')
+              help='Valid formats: {}'.format(', '.join(valid_formats))
+              )
 @click.command(help='Dump private key from keypair')
 def getpriv(key, minimal, format):
     key = load_key(key)


### PR DESCRIPTION
A previous change was added to allow the `getpriv` command to dump ec256 keys in both openssl and pkcs8. That PR did not touch other key file types which resulted in errors using that command with RSA, X25519, etc.

This commit generalizes the passing of the `format` parameter, so each key type can decide which format it allows a dump to be produced in, and what default to use.

Fixes #1529