### PR TITLE
zephyr: Disable and deprecate flash erase

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -481,8 +481,8 @@ config BOOT_USB_DFU_DETECT_DELAY
 endif # BOOT_USB_DFU_GPIO
 
 config ZEPHYR_TRY_MASS_ERASE
-	bool "Try to mass erase flash when flashing MCUboot image"
-	default y
+	bool "Try to mass erase flash when flashing MCUboot image (DEPRECATED)"
+	select DEPRECATED
 	help
 	  If y, attempt to configure the Zephyr build system's "flash"
 	  target to mass-erase the flash device before flashing the
@@ -490,6 +490,9 @@ config ZEPHYR_TRY_MASS_ERASE
 	  are in a consistent state.
 
 	  This is not available for all targets.
+
+	  This option has been deprecated, to perform a mass erase when
+	  flashing a board, `west flash --erase` should be used instead.
 
 config BOOT_USE_BENCH
         bool "Enable benchmark code"


### PR DESCRIPTION
This deprecates the flash erase Kconfig for zephyr, if this action is required then the board should be flashed using west with the `--erase` argument supplied instead.

Fixes #1573