### PR TITLE
espressif:ESP32-S3: Fix multiboot APP CPU start

### DIFF
--- a/boot/espressif/hal/include/esp32s3/esp32s3.cmake
+++ b/boot/espressif/hal/include/esp32s3/esp32s3.cmake
@@ -6,6 +6,12 @@ list(APPEND hal_srcs
     ${esp_idf_dir}/components/efuse/src/esp_efuse_api_key_esp32xx.c
 )
 
+if (DEFINED CONFIG_ESP_MULTI_PROCESSOR_BOOT)
+    list(APPEND hal_srcs
+        ${src_dir}/${MCUBOOT_TARGET}/app_cpu_start.c
+        )
+endif()
+
 list(APPEND LINKER_SCRIPTS
     -T${esp_idf_dir}/components/esp_rom/${MCUBOOT_TARGET}/ld/${MCUBOOT_TARGET}.rom.newlib.ld
     )

--- a/boot/espressif/hal/src/esp32s3/app_cpu_start.c
+++ b/boot/espressif/hal/src/esp32s3/app_cpu_start.c
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "app_cpu_start.h"
+
+#include "esp_rom_sys.h"
+#include "soc/dport_reg.h"
+#include "soc/gpio_periph.h"
+#include "soc/rtc_periph.h"
+#include "soc/rtc_cntl_reg.h"
+#include "esp32s3/rom/cache.h"
+#include "esp32s3/rom/uart.h"
+#include "esp_cpu.h"
+#include "esp_log.h"
+
+static const char *TAG = "app_cpu_start";
+
+void appcpu_start(uint32_t entry_addr)
+{
+    ESP_LOGI(TAG, "Starting APPCPU");
+
+    esp_cpu_unstall(1);
+
+    // Enable clock and reset APP CPU. Note that OpenOCD may have already
+    // enabled clock and taken APP CPU out of reset. In this case don't reset
+    // APP CPU again, as that will clear the breakpoints which may have already
+    // been set.
+    if (!REG_GET_BIT(SYSTEM_CORE_1_CONTROL_0_REG, SYSTEM_CONTROL_CORE_1_CLKGATE_EN)) {
+        REG_SET_BIT(SYSTEM_CORE_1_CONTROL_0_REG, SYSTEM_CONTROL_CORE_1_CLKGATE_EN);
+        REG_CLR_BIT(SYSTEM_CORE_1_CONTROL_0_REG, SYSTEM_CONTROL_CORE_1_RUNSTALL);
+        REG_SET_BIT(SYSTEM_CORE_1_CONTROL_0_REG, SYSTEM_CONTROL_CORE_1_RESETING);
+        REG_CLR_BIT(SYSTEM_CORE_1_CONTROL_0_REG, SYSTEM_CONTROL_CORE_1_RESETING);
+    }
+
+    ets_set_appcpu_boot_addr(entry_addr);
+    esp_rom_delay_us(10000);
+    uart_tx_wait_idle(0);
+    ESP_LOGI(TAG, "APPCPU start sequence complete");
+}

--- a/boot/espressif/port/esp32s3/ld/bootloader.ld
+++ b/boot/espressif/port/esp32s3/ld/bootloader.ld
@@ -57,6 +57,7 @@ SECTIONS
     *libhal.a:esp_efuse_api.*(.literal .text .literal.* .text.*)
     *libhal.a:esp_efuse_utility.*(.literal .text .literal.* .text.*)
     *libhal.a:esp_efuse_api_key_esp32xx.*(.literal .text .literal.* .text.*)
+    *libhal.a:app_cpu_start.*(.literal .text .literal.* .text.*)
     *esp_mcuboot.*(.literal .text .literal.* .text.*)
     *esp_loader.*(.literal .text .literal.* .text.*)
     *(.fini.literal)


### PR DESCRIPTION
Add missing function for starting the APP CPU when booting the second image (multi image).