### PR TITLE
boot: zephyr: add support for RT595

### DIFF
--- a/boot/zephyr/boards/mimxrt595_evk_cm33.conf
+++ b/boot/zephyr/boards/mimxrt595_evk_cm33.conf
@@ -1,0 +1,3 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+CONFIG_BOOT_MAX_IMG_SECTORS=8192


### PR DESCRIPTION
Add support for RT595 to MCUBoot. A larger number of max sectors is required due to the large flash size present on the RT595 EVK.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>