### PR TITLE
bootutil: Pass flash_area to boot_read_swap_size

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -239,7 +239,7 @@ boot_enc_key_off(const struct flash_area *fap, uint8_t slot)
  *
  * @returns 0 on success, -1 on errors
  */
-static int
+int
 boot_find_status(int image_index, const struct flash_area **fap)
 {
     uint8_t areas[] = {
@@ -283,54 +283,44 @@ boot_find_status(int image_index, const struct flash_area **fap)
 }
 
 int
-boot_read_swap_size(int image_index, uint32_t *swap_size)
+boot_read_swap_size(const struct flash_area *fap, uint32_t *swap_size)
 {
     uint32_t off;
-    const struct flash_area *fap;
     int rc;
 
-    rc = boot_find_status(image_index, &fap);
-    if (rc == 0) {
-        off = boot_swap_size_off(fap);
-        rc = flash_area_read(fap, off, swap_size, sizeof *swap_size);
-        flash_area_close(fap);
-    }
+    off = boot_swap_size_off(fap);
+    rc = flash_area_read(fap, off, swap_size, sizeof *swap_size);
 
     return rc;
 }
 
 #ifdef MCUBOOT_ENC_IMAGES
 int
-boot_read_enc_key(int image_index, uint8_t slot, struct boot_status *bs)
+boot_read_enc_key(const struct flash_area *fap, uint8_t slot, struct boot_status *bs)
 {
     uint32_t off;
-    const struct flash_area *fap;
 #if MCUBOOT_SWAP_SAVE_ENCTLV
     int i;
 #endif
     int rc;
 
-    rc = boot_find_status(image_index, &fap);
-    if (rc == 0) {
-        off = boot_enc_key_off(fap, slot);
+    off = boot_enc_key_off(fap, slot);
 #if MCUBOOT_SWAP_SAVE_ENCTLV
-        rc = flash_area_read(fap, off, bs->enctlv[slot], BOOT_ENC_TLV_ALIGN_SIZE);
-        if (rc == 0) {
-            for (i = 0; i < BOOT_ENC_TLV_ALIGN_SIZE; i++) {
-                if (bs->enctlv[slot][i] != 0xff) {
-                    break;
-                }
-            }
-            /* Only try to decrypt non-erased TLV metadata */
-            if (i != BOOT_ENC_TLV_ALIGN_SIZE) {
-                rc = boot_enc_decrypt(bs->enctlv[slot], bs->enckey[slot]);
+    rc = flash_area_read(fap, off, bs->enctlv[slot], BOOT_ENC_TLV_ALIGN_SIZE);
+    if (rc == 0) {
+        for (i = 0; i < BOOT_ENC_TLV_ALIGN_SIZE; i++) {
+            if (bs->enctlv[slot][i] != 0xff) {
+                break;
             }
         }
-#else
-        rc = flash_area_read(fap, off, bs->enckey[slot], BOOT_ENC_KEY_ALIGN_SIZE);
-#endif
-        flash_area_close(fap);
+        /* Only try to decrypt non-erased TLV metadata */
+        if (i != BOOT_ENC_TLV_ALIGN_SIZE) {
+            rc = boot_enc_decrypt(bs->enctlv[slot], bs->enckey[slot]);
+        }
     }
+#else
+    rc = flash_area_read(fap, off, bs->enckey[slot], BOOT_ENC_KEY_ALIGN_SIZE);
+#endif
 
     return rc;
 }

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -261,6 +261,7 @@ fih_ret bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig,
 
 fih_ret boot_fih_memequal(const void *s1, const void *s2, size_t n);
 
+int boot_find_status(int image_index, const struct flash_area **fap);
 int boot_magic_compatible_check(uint8_t tbl_val, uint8_t val);
 uint32_t boot_status_sz(uint32_t min_write_sz);
 uint32_t boot_trailer_sz(uint32_t min_write_sz);
@@ -281,7 +282,7 @@ int boot_write_trailer(const struct flash_area *fap, uint32_t off,
                        const uint8_t *inbuf, uint8_t inlen);
 int boot_write_trailer_flag(const struct flash_area *fap, uint32_t off,
                             uint8_t flag_val);
-int boot_read_swap_size(int image_index, uint32_t *swap_size);
+int boot_read_swap_size(const struct flash_area *fap, uint32_t *swap_size);
 int boot_slots_compatible(struct boot_loader_state *state);
 uint32_t boot_status_internal_off(const struct boot_status *bs, int elem_sz);
 int boot_read_image_header(struct boot_loader_state *state, int slot,
@@ -296,7 +297,8 @@ bool boot_status_is_reset(const struct boot_status *bs);
 #ifdef MCUBOOT_ENC_IMAGES
 int boot_write_enc_key(const struct flash_area *fap, uint8_t slot,
                        const struct boot_status *bs);
-int boot_read_enc_key(int image_index, uint8_t slot, struct boot_status *bs);
+int boot_read_enc_key(const struct flash_area *fap, uint8_t slot,
+                      struct boot_status *bs);
 #endif
 
 /**

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1223,8 +1223,8 @@ static int
 boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
 {
     struct image_header *hdr;
-#ifdef MCUBOOT_ENC_IMAGES
     const struct flash_area *fap;
+#ifdef MCUBOOT_ENC_IMAGES
     uint8_t slot;
     uint8_t i;
 #endif
@@ -1300,14 +1300,17 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
          * If a swap was under way, the swap_size should already be present
          * in the trailer...
          */
-        rc = boot_read_swap_size(image_index, &bs->swap_size);
+
+        rc = boot_find_status(image_index, &fap);
+        assert(fap != NULL);
+        rc = boot_read_swap_size(fap, &bs->swap_size);
         assert(rc == 0);
 
         copy_size = bs->swap_size;
 
 #ifdef MCUBOOT_ENC_IMAGES
         for (slot = 0; slot < BOOT_NUM_SLOTS; slot++) {
-            rc = boot_read_enc_key(image_index, slot, bs);
+            rc = boot_read_enc_key(fap, slot, bs);
             assert(rc == 0);
 
             for (i = 0; i < BOOT_ENC_KEY_SIZE; i++) {
@@ -1321,6 +1324,7 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
             }
         }
 #endif
+        flash_area_close(fap);
     }
 
     swap_run(state, bs, copy_size);

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -86,11 +86,12 @@ boot_read_image_header(struct boot_loader_state *state, int slot,
 
     off = 0;
     if (bs && !boot_status_is_reset(bs)) {
-        rc = boot_read_swap_size(BOOT_CURR_IMG(state), &swap_size);
-        if (rc) {
+	boot_find_status(BOOT_CURR_IMG(state), &fap);
+        if (fap == NULL || boot_read_swap_size(fap, &swap_size)) {
             rc = BOOT_EFLASH;
             goto done;
         }
+        flash_area_close(fap);
 
         last_idx = find_last_idx(state, swap_size);
         sz = boot_img_sector_size(state, BOOT_PRIMARY_SLOT, 0);


### PR DESCRIPTION
Modifies boot_read_swap_size and boot_read_enc_key to use
flash_area object pointer instead of image index.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

Depends on https://github.com/mcu-tools/mcuboot/pull/1601