### PR TITLE
Require devs to write release note snippets

### DIFF
--- a/docs/SubmittingPatches.md
+++ b/docs/SubmittingPatches.md
@@ -30,6 +30,20 @@ Certificate of Origin" located at the bottom of this page:
   see this [link]
   (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
 
+## Release notes
+
+To facilitate creating release notes at release time, all non-trivial
+changes must include a release note snippet in the pull request.
+This can be either a separate commit, or as part of a single commit
+(generally, if there are multiple commits to the pull request, the
+release note snippet should be a separate commit, and a pull request
+that is a single commit can include the release note snippet in that
+commit).  In either case, the release notes must be included in the
+same PR that makes the given change.
+
+The release notes should be placed in the `docs/release-notes.d`
+directory. Please see the readme file in that directory for specifics.
+
 ## Developer certificate of origin
 
 The following is the "Developer Certificate of Origin":

--- a/docs/release-notes.d/00readme.md
+++ b/docs/release-notes.d/00readme.md
@@ -1,0 +1,29 @@
+# Pending release notes directory
+
+This directory contains release note entries that have not been merged
+into the main release-notes.md document.
+
+Generally a release note entry should be created for changes that:
+
+- Fix bugs in the code.
+- Implement new features.
+- Change existing behavior.
+
+Release notes are generally not needed for:
+
+- Some documentation improvements.
+- Strictly internal changes to the code that won't be visible to users
+  of the code.
+
+## Release note format
+
+Release notes are included in files under this `docs/release-notes.d`
+directory and have a name of `*.md`.  They will be included in the
+`release-notes.md` file, and should be formatted as a Markdown list
+entry.  (A script will be developed to collect these, ordered by when
+the commits were added to the tree.)
+
+Choose a filename that is related to what this change does.  The names
+are not used for anything in particular, but to keep the files
+distinct so that there isn't a concern with merge conflicts as
+different pull requests merge in different orders.

--- a/docs/release.md
+++ b/docs/release.md
@@ -24,6 +24,12 @@ Before making a release, update the `docs/release-notes.md` file
 to describe the release. This should be a high-level description of
 the changes, not a list of the git commits.
 
+Provided that changes going into the release have followed the
+contribution guidelines, this should mostly consist of collecting the
+various snippets in the `docs/release-notes.d` directory.  After
+incorporating these snippets into the release notes, the snippet files
+should be removed to ready the directory for the next release cycle.
+
 ## Release candidates
 
 Before each release, tags are made (see below) for at least one


### PR DESCRIPTION
This PR documents the process whereby devs are required to write release note snippets as part of their changes. These notes will be reviewed together with the code.

I would like to merge this immediately after the 1.10.0 release, and start enforcing the release notes for PRs after this release.