### PR TITLE
boot/zephyr: allow custom boot max align

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -55,6 +55,15 @@ config NRF_CC310_BL
 	bool
 	default n
 
+DT_CHOSEN_FLASH_NODE := $(dt_chosen_path,$(zephyr,flash))
+
+config BOOT_MAX_ALIGN
+	int
+	prompt "Custom value"
+	default $(dt_node_int_prop_int,$(DT_CHOSEN_FLASH_NODE),write-block-size) \
+		if $(dt_node_has_prop,$(DT_CHOSEN_FLASH_NODE),write-block-size)
+	default 8 if !$(dt_node_has_prop,$(DT_CHOSEN_FLASH_NODE),write-block-size)
+
 menu "MCUBoot settings"
 
 config SINGLE_APPLICATION_SLOT

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -249,12 +249,8 @@
 #define MCUBOOT_SERIAL_UNALIGNED_BUFFER_SIZE CONFIG_BOOT_SERIAL_UNALIGNED_BUFFER_SIZE
 #endif
 
-/* Support 32-byte aligned flash sizes */
-#if DT_HAS_CHOSEN(zephyr_flash)
-    #if DT_PROP_OR(DT_CHOSEN(zephyr_flash), write_block_size, 0) > 8
-        #define MCUBOOT_BOOT_MAX_ALIGN \
-            DT_PROP(DT_CHOSEN(zephyr_flash), write_block_size)
-    #endif
+#ifdef CONFIG_BOOT_MAX_ALIGN
+#define MCUBOOT_BOOT_MAX_ALIGN CONFIG_BOOT_MAX_ALIGN
 #endif
 
 #if CONFIG_BOOT_WATCHDOG_FEED


### PR DESCRIPTION
#1404 binds `BOOT_MAX_ALIGN` to `zephyr,flash` which is usually MCU's flash.
That creates issues when users use `imgtool.py` with custom `--align` that doesn't match with `write-block-size` of `zephyr,flash`.

This PR allows `BOOT_MAX_ALIGN` to be specified via Kconfig. However, it preserves the original behavior for the default value if `zephyr,flash` exists and has `write-block-size` property.

If absent, the value `8` is used.

Kconfig doesn't enforce any value restriction.

There is already a built-in check for it to be `[8, 32]`:
https://github.com/mcu-tools/mcuboot/blob/453e8bd7deebdb2fe9a8a02c6cb6a15fe1083887/boot/bootutil/include/bootutil/bootutil_public.h#L86-L87

That can be moved to Kconfig using the `range` attribute. However, I am not sure what values are valid.
Single/Octo/Quad[SPI] are able to write 1 byte, project documentation mentions allowed value of 4, then there is handling of a case when it is > 1024:

https://github.com/mcu-tools/mcuboot/blob/5047f032c93fd8957be6529f8f1ad7a3fe626057/boot/bootutil/src/loader.c#L84-L88

Maybe @gustavonihei or someone else who knows could shine some light on that.
