### PR TITLE
zephyr: serial_recovery: Make receive buffers configurable

### DIFF
--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -61,22 +61,27 @@ config BOOT_SERIAL_UNALIGNED_BUFFER_SIZE
 
 config BOOT_MAX_LINE_INPUT_LEN
 	int "Maximum input line length"
-	default 512
+	default 128
 	help
-	  Maximum length of input serial port buffer.
+	  Maximum length of input serial port buffer (SMP serial transport uses
+	  fragments of 128-bytes, this should not need to be changed unless a
+	  different value is used for the transport).
+
+config BOOT_LINE_BUFS
+	int "Number of receive buffers"
+	range 2 128
+	default 8
+	help
+	  Number of receive buffers for data received via the serial port.
 
 config BOOT_SERIAL_MAX_RECEIVE_SIZE
 	int "Maximum command line length"
 	default 1024
 	help
-	  Maximum length of received commands via the serial port.
-
-config BOOT_LINE_BUFS
-	int "Number of receive buffers"
-	range 2 128
-	default 2
-	help
-	  Number of receive buffers for data received via the serial port.
+	  Maximum length of received commands via the serial port (this should
+	  be equal to the maximum line length, BOOT_MAX_LINE_INPUT_LEN times
+	  by the number of receive buffers, BOOT_LINE_BUFS to allow for
+	  optimal data transfer speeds).
 
 config BOOT_SERIAL_DETECT_PORT
 	string "GPIO device to trigger serial recovery mode (DEPRECATED)"

--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -71,6 +71,13 @@ config BOOT_SERIAL_MAX_RECEIVE_SIZE
 	help
 	  Maximum length of received commands via the serial port.
 
+config BOOT_LINE_BUFS
+	int "Number of receive buffers"
+	range 2 128
+	default 2
+	help
+	  Number of receive buffers for data received via the serial port.
+
 config BOOT_SERIAL_DETECT_PORT
 	string "GPIO device to trigger serial recovery mode (DEPRECATED)"
 	default GPIO_0 if SOC_FAMILY_NRF

--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Nordic Semiconductor ASA
+ * Copyright (c) 2017-2023 Nordic Semiconductor ASA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ struct line_input {
 };
 
 static struct device const *uart_dev;
-static struct line_input line_bufs[2];
+static struct line_input line_bufs[CONFIG_BOOT_LINE_BUFS];
 
 static sys_slist_t avail_queue;
 static sys_slist_t lines_queue;


### PR DESCRIPTION
This allows making the number of receive buffers configurable instead of being fixed at 2.

Fixes some confusing Kconfig values to have values that make sense for the underlying SMP transport.


With this configuration, upload speeds of 17.7KiBps have been observed with USB-CDC recovery on an nRF52833 device with `CONFIG_BOOT_LINE_BUFS` set to 16 and `CONFIG_BOOT_SERIAL_MAX_RECEIVE_SIZE` set to 2048 with a custom MCUmgr application - which is over twice as fast as was possible without a configurable number of receive buffers.