### PR TITLE
Add generic ECDSA TLV Signature type & P384 to imgtool

### DIFF
--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -86,10 +86,10 @@ struct flash_area;
 #define IMAGE_TLV_SHA256            0x10   /* SHA256 of image hdr and body */
 #define IMAGE_TLV_RSA2048_PSS       0x20   /* RSA2048 of hash output */
 #define IMAGE_TLV_ECDSA224          0x21   /* ECDSA of hash output - Not supported anymore */
-#define IMAGE_TLV_ECDSA256          0x22   /* ECDSA of hash output */
+#define IMAGE_TLV_ECDSA256          0x22   /* ECDSA of hash output - Not supported anymore */
 #define IMAGE_TLV_RSA3072_PSS       0x23   /* RSA3072 of hash output */
 #define IMAGE_TLV_ED25519           0x24   /* ed25519 of hash output */
-#define IMAGE_TLV_ECDSA_SIG         0x25   /* generic ECDSA signature */
+#define IMAGE_TLV_ECDSA_SIG         0x25   /* ECDSA of hash output */
 #define IMAGE_TLV_ENC_RSA2048       0x30   /* Key encrypted with RSA-OAEP-2048 */
 #define IMAGE_TLV_ENC_KW            0x31   /* Key encrypted with AES-KW 128 or 256*/
 #define IMAGE_TLV_ENC_EC256         0x32   /* Key encrypted with ECIES-EC256 */

--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -89,6 +89,7 @@ struct flash_area;
 #define IMAGE_TLV_ECDSA256          0x22   /* ECDSA of hash output */
 #define IMAGE_TLV_RSA3072_PSS       0x23   /* RSA3072 of hash output */
 #define IMAGE_TLV_ED25519           0x24   /* ed25519 of hash output */
+#define IMAGE_TLV_ECDSA_SIG         0x25   /* generic ECDSA signature */
 #define IMAGE_TLV_ENC_RSA2048       0x30   /* Key encrypted with RSA-OAEP-2048 */
 #define IMAGE_TLV_ENC_KW            0x31   /* Key encrypted with AES-KW 128 or 256*/
 #define IMAGE_TLV_ENC_EC256         0x32   /* Key encrypted with ECIES-EC256 */

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -184,10 +184,11 @@ bootutil_img_hash(struct enc_key_data *enc_state, int image_index,
 #    endif
 #    define SIG_BUF_SIZE (MCUBOOT_SIGN_RSA_LEN / 8)
 #    define EXPECTED_SIG_LEN(x) ((x) == SIG_BUF_SIZE) /* 2048 bits */
-#elif defined(MCUBOOT_SIGN_EC256)
-#    define EXPECTED_SIG_TLV IMAGE_TLV_ECDSA256
+#elif defined(MCUBOOT_SIGN_EC256) || \
+      defined(MCUBOOT_SIGN_EC)
+#    define EXPECTED_SIG_TLV IMAGE_TLV_ECDSA_SIG
 #    define SIG_BUF_SIZE 128
-#    define EXPECTED_SIG_LEN(x)  (1) /* always true, ASN.1 will validate */
+#    define EXPECTED_SIG_LEN(x) (1) /* always true, ASN.1 will validate */
 #elif defined(MCUBOOT_SIGN_ED25519)
 #    define EXPECTED_SIG_TLV IMAGE_TLV_ED25519
 #    define SIG_BUF_SIZE 64

--- a/docs/design.md
+++ b/docs/design.md
@@ -108,9 +108,10 @@ struct image_tlv {
 #define IMAGE_TLV_SHA256            0x10   /* SHA256 of image hdr and body */
 #define IMAGE_TLV_RSA2048_PSS       0x20   /* RSA2048 of hash output */
 #define IMAGE_TLV_ECDSA224          0x21   /* ECDSA of hash output - Not supported anymore */
-#define IMAGE_TLV_ECDSA256          0x22   /* ECDSA of hash output */
+#define IMAGE_TLV_ECDSA256          0x22   /* ECDSA of hash output - Not supported anymore */
 #define IMAGE_TLV_RSA3072_PSS       0x23   /* RSA3072 of hash output */
 #define IMAGE_TLV_ED25519           0x24   /* ED25519 of hash output */
+#define IMAGE_TLV_ECDSA_SIG         0x25   /* ECDSA of hash output */
 #define IMAGE_TLV_ENC_RSA2048       0x30   /* Key encrypted with RSA-OAEP-2048 */
 #define IMAGE_TLV_ENC_KW            0x31   /* Key encrypted with AES-KW-128 or
                                               256 */

--- a/docs/release-notes.d/ecdsa-tlv-p384.md
+++ b/docs/release-notes.d/ecdsa-tlv-p384.md
@@ -1,0 +1,2 @@
+- Add generic ECDSA TLV, remove the ECDSA256 and ECDSA224 curve TLVs.
+- Add P384 support to imgtool.

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -484,10 +484,18 @@ class Image():
                 else:
                     print(os.path.basename(__file__) + ": sign the digest")
                     sig = key.sign_digest(digest)
-                tlv.add(key.sig_tlv(), sig)
+                # only ecdsa256 has legacy tlv type
+                if use_legacy_tlv and isinstance(key, ecdsa.ECDSA256P1):
+                    tlv.add(key.legacy_sig_tlv(), sig)
+                else:
+                    tlv.add(key.sig_tlv(), sig)
                 self.signature = sig
             elif fixed_sig is not None and key is None:
-                tlv.add(pub_key.sig_tlv(), fixed_sig['value'])
+                if use_legacy_tlv and isinstance(pub_key,
+                                                 ecdsa.ECDSA256P1Public):
+                    tlv.add(pub_key.legacy_sig_tlv(), fixed_sig['value'])
+                else:
+                    tlv.add(pub_key.sig_tlv(), fixed_sig['value'])
                 self.signature = fixed_sig['value']
             else:
                 raise click.UsageError("Can not sign using key and provide fixed-signature at the same time")

--- a/scripts/imgtool/keys/__init__.py
+++ b/scripts/imgtool/keys/__init__.py
@@ -1,4 +1,5 @@
 # Copyright 2017 Linaro Limited
+# Copyright 2023 Arm Limited
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -30,7 +31,8 @@ from cryptography.hazmat.primitives.asymmetric.x25519 import (
     X25519PrivateKey, X25519PublicKey)
 
 from .rsa import RSA, RSAPublic, RSAUsageError, RSA_KEY_SIZES
-from .ecdsa import ECDSA256P1, ECDSA256P1Public, ECDSAUsageError
+from .ecdsa import (ECDSA256P1, ECDSA256P1Public,
+                    ECDSA384P1, ECDSA384P1Public, ECDSAUsageError)
 from .ed25519 import Ed25519, Ed25519Public, Ed25519UsageError
 from .x25519 import X25519, X25519Public, X25519UsageError
 
@@ -42,7 +44,8 @@ class PasswordRequired(Exception):
 
 
 def load(path, passwd=None):
-    """Try loading a key from the given path.  Returns None if the password wasn't specified."""
+    """Try loading a key from the given path.
+      Returns None if the password wasn't specified."""
     with open(path, 'rb') as f:
         raw_pem = f.read()
     try:
@@ -73,17 +76,23 @@ def load(path, passwd=None):
             raise Exception("Unsupported RSA key size: " + pk.key_size)
         return RSAPublic(pk)
     elif isinstance(pk, EllipticCurvePrivateKey):
-        if pk.curve.name != 'secp256r1':
+        if pk.curve.name not in ('secp256r1', 'secp384r1'):
             raise Exception("Unsupported EC curve: " + pk.curve.name)
-        if pk.key_size != 256:
+        if pk.key_size not in (256, 384):
             raise Exception("Unsupported EC size: " + pk.key_size)
-        return ECDSA256P1(pk)
+        if pk.curve.name == 'secp256r1':
+            return ECDSA256P1(pk)
+        elif pk.curve.name == 'secp384r1':
+            return ECDSA384P1(pk)
     elif isinstance(pk, EllipticCurvePublicKey):
-        if pk.curve.name != 'secp256r1':
+        if pk.curve.name not in ('secp256r1', 'secp384r1'):
             raise Exception("Unsupported EC curve: " + pk.curve.name)
-        if pk.key_size != 256:
+        if pk.key_size not in (256, 384):
             raise Exception("Unsupported EC size: " + pk.key_size)
-        return ECDSA256P1Public(pk)
+        if pk.curve.name == 'secp256r1':
+            return ECDSA256P1Public(pk)
+        elif pk.curve.name == 'secp384r1':
+            return ECDSA384P1Public(pk)
     elif isinstance(pk, Ed25519PrivateKey):
         return Ed25519(pk)
     elif isinstance(pk, Ed25519PublicKey):

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -48,6 +48,10 @@ def gen_ecdsa_p256(keyfile, passwd):
     keys.ECDSA256P1.generate().export_private(keyfile, passwd=passwd)
 
 
+def gen_ecdsa_p384(keyfile, passwd):
+    keys.ECDSA384P1.generate().export_private(keyfile, passwd=passwd)
+
+
 def gen_ed25519(keyfile, passwd):
     keys.Ed25519.generate().export_private(path=keyfile, passwd=passwd)
 
@@ -62,6 +66,7 @@ keygens = {
     'rsa-2048':   gen_rsa2048,
     'rsa-3072':   gen_rsa3072,
     'ecdsa-p256': gen_ecdsa_p256,
+    'ecdsa-p384': gen_ecdsa_p384,
     'ed25519':    gen_ed25519,
     'x25519':     gen_x25519,
 }
@@ -183,7 +188,7 @@ def verify(key, imgfile):
     elif ret == image.VerifyResult.INVALID_TLV_INFO_MAGIC:
         print("Invalid TLV info magic; is this an MCUboot image?")
     elif ret == image.VerifyResult.INVALID_HASH:
-        print("Image has an invalid sha256 digest")
+        print("Image has an invalid hash")
     elif ret == image.VerifyResult.INVALID_SIGNATURE:
         print("No signature found for the given key")
     else:
@@ -384,6 +389,8 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
     if enckey and key:
         if ((isinstance(key, keys.ECDSA256P1) and
              not isinstance(enckey, keys.ECDSA256P1Public))
+           or (isinstance(key, keys.ECDSA384P1) and
+               not isinstance(enckey, keys.ECDSA384P1Public))
                 or (isinstance(key, keys.RSA) and
                     not isinstance(enckey, keys.RSAPublic))):
             # FIXME

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -362,6 +362,8 @@ class BasedIntParamType(click.ParamType):
               help='send to OUTFILE the payload or payload''s digest instead '
               'of complied image. These data can be used for external image '
               'signing')
+@click.option('--legacy-ecdsa-tlv', default=False, is_flag=True,
+              help='Use the old curve specific ECDSA TLV')
 @click.command(help='''Create a signed or unsigned image\n
                INFILE and OUTFILE are parsed as Intel HEX if the params have
                .hex extension, otherwise binary format is used''')
@@ -370,7 +372,7 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
          endian, encrypt_keylen, encrypt, infile, outfile, dependencies,
          load_addr, hex_addr, erased_val, save_enctlv, security_counter,
          boot_record, custom_tlv, rom_fixed, max_align, clear, fix_sig,
-         fix_sig_pubkey, sig_out, vector_to_sign):
+         fix_sig_pubkey, sig_out, vector_to_sign, legacy_ecdsa_tlv):
 
     if confirm:
         # Confirmed but non-padded images don't make much sense, because
@@ -437,7 +439,7 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
 
     img.create(key, public_key_format, enckey, dependencies, boot_record,
                custom_tlvs, int(encrypt_keylen), clear, baked_signature,
-               pub_key, vector_to_sign)
+               pub_key, vector_to_sign, legacy_ecdsa_tlv)
     img.save(outfile, hex_addr)
 
     if sig_out is not None:

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1889,10 +1889,7 @@ fn make_tlv() -> TlvGen {
             TlvGen::new_rsa3072_pss()
         } else if Caps::EcdsaP256.present() {
             TlvGen::new_ecdsa()
-        } else if Caps::EcdsaSig.present() {
-            TlvGen::new_generic_ecdsa()
-        }
-         else if Caps::Ed25519.present() {
+        } else if Caps::Ed25519.present() {
             TlvGen::new_ed25519()
         } else {
             TlvGen::new_hash_only()

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1889,7 +1889,10 @@ fn make_tlv() -> TlvGen {
             TlvGen::new_rsa3072_pss()
         } else if Caps::EcdsaP256.present() {
             TlvGen::new_ecdsa()
-        } else if Caps::Ed25519.present() {
+        } else if Caps::EcdsaSig.present() {
+            TlvGen::new_generic_ecdsa()
+        }
+         else if Caps::Ed25519.present() {
             TlvGen::new_ed25519()
         } else {
             TlvGen::new_hash_only()

--- a/sim/src/tlv.rs
+++ b/sim/src/tlv.rs
@@ -54,6 +54,7 @@ pub enum TlvKinds {
     ECDSA256 = 0x22,
     RSA3072 = 0x23,
     ED25519 = 0x24,
+    ECDSASIG = 0x25,
     ENCRSA2048 = 0x30,
     ENCKW = 0x31,
     ENCEC256 = 0x32,
@@ -159,6 +160,13 @@ impl TlvGen {
             kinds: vec![TlvKinds::SHA256, TlvKinds::ECDSA256],
             ..Default::default()
         }
+    }
+
+    #[allow(dead_code)]
+    pub fn new_generic_ecdsa() -> TlvGen {
+        TlvGen {
+            kinds: vec![TlvKinds::SHA256,TlvKinds::ECDSASIG],
+            ..Default::default()}
     }
 
     #[allow(dead_code)]
@@ -367,6 +375,10 @@ impl ManifestGen for TlvGen {
             estimate += 4 + 32; // keyhash
             estimate += 4 + 64; // ED25519 signature.
         }
+        if self.kinds.contains(&TlvKinds::ECDSASIG) {
+            estimate += 4 + 32; // keyhash
+            estimate += 4 + 72; // ECDSA256 (varies)
+        }
 
         // Estimate encryption.
         let flag = TlvFlags::ENCRYPTED_AES256 as u32;
@@ -450,7 +462,7 @@ impl ManifestGen for TlvGen {
             // signature verification can be validated.
             let mut corrupt_hash = self.gen_corrupted;
             for k in &[TlvKinds::RSA2048, TlvKinds::RSA3072,
-                TlvKinds::ECDSA256, TlvKinds::ED25519]
+                TlvKinds::ECDSA256, TlvKinds::ED25519, TlvKinds::ECDSASIG]
             {
                 if self.kinds.contains(k) {
                     corrupt_hash = false;
@@ -523,6 +535,28 @@ impl ManifestGen for TlvGen {
             } else {
                 result.write_u16::<LittleEndian>(TlvKinds::RSA3072 as u16).unwrap();
             }
+            result.write_u16::<LittleEndian>(signature.len() as u16).unwrap();
+            result.extend_from_slice(&signature);
+        }
+
+        if self.kinds.contains(&TlvKinds::ECDSASIG) {
+            let rng = rand::SystemRandom::new();
+            let keyhash = digest::digest(&digest::SHA256, ECDSA256_PUB_KEY);
+            let key_bytes = pem::parse(include_bytes!("../../root-ec-p256-pkcs8.pem").as_ref()).unwrap();
+            let sign_algo = &ECDSA_P256_SHA256_ASN1_SIGNING;
+            let key_pair = EcdsaKeyPair::from_pkcs8(sign_algo, &key_bytes.contents).unwrap();
+            let signature = key_pair.sign(&rng,&sig_payload).unwrap();
+
+            // Write public key
+            let keyhash_slice = keyhash.as_ref();
+            assert!(keyhash_slice.len() == 32);
+            result.write_u16::<LittleEndian>(TlvKinds::KEYHASH as u16).unwrap();
+            result.write_u16::<LittleEndian>(32).unwrap();
+            result.extend_from_slice(keyhash_slice);
+
+            // Write signature
+            result.write_u16::<LittleEndian>(TlvKinds::ECDSASIG as u16).unwrap();
+            let signature = signature.as_ref().to_vec();
             result.write_u16::<LittleEndian>(signature.len() as u16).unwrap();
             result.extend_from_slice(&signature);
         }


### PR DESCRIPTION
This pull request removes the current curve specific signature TLV types (ECDSAP224, ECDSAP256) and introduces a new generic one (ECDSASIG) that is not tied a curve, and adds P384 curve support to the imgtool.

Even in the current implementation the way the signature parsing happens is not relevant from a TLV standpoint as the curve to use is encoded in the signature itself (as per RFC 5820) and all the current crypto backends parse the signature the same way. The curve independent TLV would be beneficial later if a new crypto backend or new curve type would be introduced, such as P384.

Relevant issue: #1596 