### PR TITLE
CI: Improve FIH job result assesment

### DIFF
--- a/.github/workflows/fih_tests.yaml
+++ b/.github/workflows/fih_tests.yaml
@@ -13,13 +13,17 @@ concurrency:
 jobs:
   config:
     strategy:
+      fail-fast: false
       matrix:
         fih_env:
         # FIH environment must use the following space separated format:
         #   BUILD_TYPE SKIP_SIZE DAMAGE_TYPE FIH_LEVEL(optional)
-        - "RELEASE 2,4,6,8,10 SIGNATURE"
-        - "RELEASE 2,4,6,8,10 SIGNATURE LOW"
-        - "RELEASE 2,4,6,8,10 SIGNATURE MEDIUM"
+        - "RELEASE 2,4,6 SIGNATURE"
+        - "RELEASE 2,4,6 SIGNATURE LOW"
+        - "RELEASE 2,4,6 SIGNATURE MEDIUM"
+        - "RELEASE 8,10 SIGNATURE"
+        - "RELEASE 8,10 SIGNATURE LOW"
+        - "RELEASE 8,10 SIGNATURE MEDIUM"
         - "MINSIZEREL 2,4,6 SIGNATURE"
         - "MINSIZEREL 2,4,6 SIGNATURE LOW"
         - "MINSIZEREL 2,4,6 SIGNATURE MEDIUM"

--- a/ci/fih_test_docker/execute_test.sh
+++ b/ci/fih_test_docker/execute_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2020-2022 Arm Limited
+# Copyright (c) 2020-2023 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,3 +63,4 @@ echo "    - SKIP_SIZE: $SKIP_SIZE"
 echo "    - DAMAGE_TYPE: $DAMAGE_TYPE"
 
 python3 $MCUBOOT_PATH/ci/fih_test_docker/generate_test_report.py fih_test_output.yaml
+python3 $MCUBOOT_PATH/ci/fih_test_docker/validate_output.py fih_test_output.yaml $SKIP_SIZE $FIH_LEVEL

--- a/ci/fih_test_docker/generate_test_report.py
+++ b/ci/fih_test_docker/generate_test_report.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Arm Limited
+# Copyright (c) 2020-2023 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,47 +13,12 @@
 # limitations under the License.
 
 import argparse
-import yaml
-import collections
-
-CATEGORIES = {
-        'TOTAL': 'Total tests run',
-        'SUCCESS': 'Tests executed successfully',
-        'FAILED': 'Tests failed to execute successfully',
-        # the execution never reached the address
-        'ADDRES_NOEXEC': 'Address was not executed',
-        # The address was successfully skipped by the debugger
-        'SKIPPED': 'Address was skipped',
-        'NO_BOOT': 'System not booted (desired behaviour)',
-        'BOOT': 'System booted (undesired behaviour)'
-}
+from utils import CATEGORIES, parse_yaml_file
 
 
 def print_results(results):
-    test_stats = collections.Counter()
-    failed_boot_last_lines = collections.Counter()
-    exec_fail_reasons = collections.Counter()
 
-    for test in results:
-        test = test["skip_test"]
-
-        test_stats.update([CATEGORIES['TOTAL']])
-
-        if test["test_exec_ok"]:
-            test_stats.update([CATEGORIES['SUCCESS']])
-
-            if "skipped" in test.keys() and not test["skipped"]:
-                # The debugger didn't stop at this address
-                test_stats.update([CATEGORIES['ADDRES_NOEXEC']])
-                continue
-
-            if test["boot"]:
-                test_stats.update([CATEGORIES['BOOT']])
-                continue
-
-            failed_boot_last_lines.update([test["last_line"]])
-        else:
-            exec_fail_reasons.update([test["test_exec_fail_reason"]])
+    test_stats, failed_boot_last_lines, exec_fail_reasons = results
 
     print("{:s}: {:d}.".format(CATEGORIES['TOTAL'], test_stats[CATEGORIES['TOTAL']]))
     print("{:s} ({:d}):".format(CATEGORIES['SUCCESS'], test_stats[CATEGORIES['SUCCESS']]))
@@ -74,14 +39,8 @@ def main():
     parser.add_argument('filename', help='yaml file to process')
 
     args = parser.parse_args()
-
-    with open(args.filename) as output_yaml_file:
-        results = yaml.safe_load(output_yaml_file)
-
-        if results:
-            print_results(results)
-        else:
-            print("Failed to parse output yaml file.")
+    results = parse_yaml_file(args.filename)
+    print_results(results)
 
 
 if __name__ == "__main__":

--- a/ci/fih_test_docker/utils.py
+++ b/ci/fih_test_docker/utils.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2023 Arm Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import yaml
+
+CATEGORIES = {
+        'TOTAL': 'Total tests run',
+        'SUCCESS': 'Tests executed successfully',
+        'FAILED': 'Tests failed to execute successfully',
+        # the execution never reached the address
+        'ADDRES_NOEXEC': 'Address was not executed',
+        # The address was successfully skipped by the debugger
+        'SKIPPED': 'Address was skipped',
+        'NO_BOOT': 'System not booted (desired behaviour)',
+        'BOOT': 'System booted (undesired behaviour)'
+}
+
+
+def parse_yaml_file(filepath):
+    with open(filepath) as f:
+        results = yaml.safe_load(f)
+
+    if not results:
+        raise ValueError("Failed to parse output yaml file.")
+
+    test_stats = collections.Counter()
+    failed_boot_last_lines = collections.Counter()
+    exec_fail_reasons = collections.Counter()
+
+    for test in results:
+        test = test["skip_test"]
+
+        test_stats.update([CATEGORIES['TOTAL']])
+
+        if test["test_exec_ok"]:
+            test_stats.update([CATEGORIES['SUCCESS']])
+
+            if "skipped" in test.keys() and not test["skipped"]:
+                # The debugger didn't stop at this address
+                test_stats.update([CATEGORIES['ADDRES_NOEXEC']])
+                continue
+
+            if test["boot"]:
+                test_stats.update([CATEGORIES['BOOT']])
+                continue
+
+            failed_boot_last_lines.update([test["last_line"]])
+        else:
+            exec_fail_reasons.update([test["test_exec_fail_reason"]])
+
+    return test_stats, failed_boot_last_lines, exec_fail_reasons

--- a/ci/fih_test_docker/validate_output.py
+++ b/ci/fih_test_docker/validate_output.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2023 Arm Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from utils import CATEGORIES, parse_yaml_file
+
+
+def validate_output(test_stats, skip_size, fih_level):
+    if (test_stats[CATEGORIES['BOOT']] > 0
+       and skip_size == "2,4,6" and fih_level == "MEDIUM"):
+        raise ValueError("The number of sucessful boots was more than zero")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='''Process a FIH test output yaml file,
+     and validate no sucessfull boots have happened''')
+    parser.add_argument('filename', help='yaml file to process')
+    parser.add_argument('skip_size', help='instruction skip size')
+    parser.add_argument('fih_level', nargs="?",
+                        help='fault injection hardening level')
+
+    args = parser.parse_args()
+    test_stats = parse_yaml_file(args.filename)[0]
+    validate_output(test_stats, args.skip_size, args.fih_level)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request modifies the FIH CI job to fail in case a successful boot happens.

The CI should fail if a successful boot is achieved by bypassing one or two instructions as it would defeat the purpose of the FIH mechanisms. The relevant workflow has also been modified to disable the auto-cancel feature if one of the configs fail.

relevant issue: #1584 