### PR TITLE
zephyr: Add missing flash_map.h to sysflash.h

### DIFF
--- a/boot/zephyr/include/sysflash/sysflash.h
+++ b/boot/zephyr/include/sysflash/sysflash.h
@@ -3,8 +3,9 @@
 #ifndef __SYSFLASH_H__
 #define __SYSFLASH_H__
 
-#include <zephyr/devicetree.h>
 #include <mcuboot_config/mcuboot_config.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/storage/flash_map.h>
 
 #ifndef CONFIG_SINGLE_APPLICATION_SLOT
 


### PR DESCRIPTION
The sysflash.h defines FLASH_AREA_ macros using FIXED_PARTITION macros that are provided by flash_map.h, but it does not include the required header.