### PR TITLE
ci: Update TF-M version to be aligned with FIH library changes

### DIFF
--- a/ci/fih-tests_run.sh
+++ b/ci/fih-tests_run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2020-2022 Arm Limited
+# Copyright (c) 2020-2023 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ set -e
 pushd .. &&\
    git clone https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git &&\
    pushd trusted-firmware-m &&\
-   git fetch https://review.trustedfirmware.org/TF-M/trusted-firmware-m refs/changes/09/18309/2 && git checkout FETCH_HEAD &&\
+   git checkout 8faae452712b630dc69c24da61e84c88a901d2d4 &&\
    popd
 
 if [[ $GITHUB_ACTIONS == true ]]; then


### PR DESCRIPTION
So far the FIH CI job was fetching a WIP change from TF-M Gerrit to align the MCUboot and TF-M from the FIH library point of view. This change is replacing to fetch the final version instead of the WIP change.