### PR TITLE
nrf: cc310: Change license to Apache-2

### DIFF
--- a/ext/nrf/cc310_glue.c
+++ b/ext/nrf/cc310_glue.c
@@ -1,7 +1,18 @@
 /*
- * Copyright (c) 2019 Nordic Semiconductor ASA
+ *  Copyright Nordic Semiconductor ASA
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 #include "cc310_glue.h"

--- a/ext/nrf/cc310_glue.h
+++ b/ext/nrf/cc310_glue.h
@@ -1,8 +1,20 @@
 /*
- * Copyright (c) 2019 Nordic Semiconductor ASA
+ *  Copyright Nordic Semiconductor ASA
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
+
 #ifndef NRF_CC310_GLUE_H__
 #define NRF_CC310_GLUE_H__
 


### PR DESCRIPTION
This fixes the issue: #1624 by changing the license to Apache-2. There isn't a need to have these files nordic licensed.