### PR TITLE
MCUBoot: Implement multi memory boot feature

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -83,7 +83,14 @@ fih_ret boot_go_for_image_id(struct boot_rsp *rsp, uint32_t image_id);
 
 struct boot_loader_state;
 void boot_state_clear(struct boot_loader_state *state);
-fih_ret context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp);
+
+fih_ret context_boot_go_flash(struct boot_loader_state *state, struct boot_rsp *rsp);
+
+#if defined(MCUBOOT_RAM_LOAD)
+fih_ret context_boot_go_ram(struct boot_loader_state *state, struct boot_rsp *rsp);
+fih_ret boot_go_for_image_id_ram(struct boot_rsp *rsp, uint32_t image_id);
+#endif
+
 
 #define SPLIT_GO_OK                 (0)
 #define SPLIT_GO_NON_MATCHING       (-1)

--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -155,6 +155,14 @@ struct image_tlv {
 #define MUST_DECRYPT(fap, idx, hdr) \
     (flash_area_get_id(fap) == FLASH_AREA_IMAGE_SECONDARY(idx) && IS_ENCRYPTED(hdr))
 
+#if defined(MCUBOOT_RAM_LOAD)
+#define IS_RAM_BOOTABLE(hdr)                                       \
+    ((((hdr)->ih_flags & IMAGE_F_RAM_LOAD) == IMAGE_F_RAM_LOAD) && \
+     ((hdr)->ih_load_addr != 0U) && ((hdr)->ih_load_addr != (uintptr_t)(-1)))
+#else
+#define IS_RAM_BOOTABLE(hdr) (false)
+#endif
+
 _Static_assert(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
                "struct image_header not required size");
 

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -115,47 +115,58 @@ bootutil_img_hash(struct enc_key_data *enc_state, int image_index,
     /* If protected TLVs are present they are also hashed. */
     size += hdr->ih_protect_tlv_size;
 
-#ifdef MCUBOOT_RAM_LOAD
-    bootutil_sha256_update(&sha256_ctx,
-                           (void*)(IMAGE_RAM_BASE + hdr->ih_load_addr),
-                           size);
-#else
-    for (off = 0; off < size; off += blk_sz) {
-        blk_sz = size - off;
-        if (blk_sz > tmp_buf_sz) {
-            blk_sz = tmp_buf_sz;
+    do
+    {      
+#if defined(MCUBOOT_RAM_LOAD)
+#if defined(MCUBOOT_MULTI_MEMORY_LOAD)
+        if (IS_RAM_BOOTABLE(hdr))
+#endif /* MCUBOOT_MULTI_MEMORY_LOAD */
+        {
+            bootutil_sha256_update(
+                &sha256_ctx, (void *)(IMAGE_RAM_BASE + hdr->ih_load_addr), size);
+                break;
         }
+#endif /* MCUBOOT_RAM_LOAD */
+#if !(defined(MCUBOOT_RAM_LOAD) && !defined(MCUBOOT_MULTI_MEMORY_LOAD))
+        {
+            for (off = 0; off < size; off += blk_sz) {
+                blk_sz = size - off;
+                if (blk_sz > tmp_buf_sz) {
+                    blk_sz = tmp_buf_sz;
+                }
 #ifdef MCUBOOT_ENC_IMAGES
-        /* The only data that is encrypted in an image is the payload;
-         * both header and TLVs (when protected) are not.
-         */
-        if ((off < hdr_size) && ((off + blk_sz) > hdr_size)) {
-            /* read only the header */
-            blk_sz = hdr_size - off;
-        }
-        if ((off < tlv_off) && ((off + blk_sz) > tlv_off)) {
-            /* read only up to the end of the image payload */
-            blk_sz = tlv_off - off;
-        }
-#endif
-        rc = flash_area_read(fap, off, tmp_buf, blk_sz);
-        if (rc) {
-            bootutil_sha256_drop(&sha256_ctx);
-            return rc;
-        }
+                /* The only data that is encrypted in an image is the payload;
+                * both header and TLVs (when protected) are not.
+                */
+                if ((off < hdr_size) && ((off + blk_sz) > hdr_size)) {
+                    /* read only the header */
+                    blk_sz = hdr_size - off;
+                }
+                if ((off < tlv_off) && ((off + blk_sz) > tlv_off)) {
+                    /* read only up to the end of the image payload */
+                    blk_sz = tlv_off - off;
+                }
+#endif /* MCUBOOT_ENC_IMAGES */
+                rc = flash_area_read(fap, off, tmp_buf, blk_sz);
+                if (rc) {
+                    bootutil_sha256_drop(&sha256_ctx);
+                    return rc;
+                }
 #ifdef MCUBOOT_ENC_IMAGES
-        if (MUST_DECRYPT(fap, image_index, hdr)) {
-            /* Only payload is encrypted (area between header and TLVs) */
-            if (off >= hdr_size && off < tlv_off) {
-                blk_off = (off - hdr_size) & 0xf;
-                boot_encrypt(enc_state, image_index, fap, off - hdr_size,
-                        blk_sz, blk_off, tmp_buf);
+                if (MUST_DECRYPT(fap, image_index, hdr)) {
+                    /* Only payload is encrypted (area between header and TLVs) */
+                    if (off >= hdr_size && off < tlv_off) {
+                        blk_off = (off - hdr_size) & 0xf;
+                        boot_encrypt(enc_state, image_index, fap,
+                                     off - hdr_size, blk_sz, blk_off, tmp_buf);
+                    }
+                }
+#endif /* MCUBOOT_ENC_IMAGES */
+                bootutil_sha256_update(&sha256_ctx, tmp_buf, blk_sz);
             }
         }
-#endif
-        bootutil_sha256_update(&sha256_ctx, tmp_buf, blk_sz);
-    }
-#endif /* MCUBOOT_RAM_LOAD */
+#endif /* !MCUBOOT_RAM_LOAD || MCUBOOT_MULTI_MEMORY_LOAD */
+    } while (false);
     bootutil_sha256_finish(&sha256_ctx, hash_result);
     bootutil_sha256_drop(&sha256_ctx);
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -188,14 +188,10 @@ fill_rsp(struct boot_loader_state *state, struct boot_rsp *rsp)
     }
 #endif
 
-#if defined(MCUBOOT_MULTI_MEMORY_LOAD)
-    if ((state->slot_usage[BOOT_CURR_IMG(state)].active_slot != BOOT_PRIMARY_SLOT) &&
-        (state->slot_usage[BOOT_CURR_IMG(state)].active_slot != NO_ACTIVE_SLOT))
-#endif
 #if defined(MCUBOOT_DIRECT_XIP) || defined(MCUBOOT_RAM_LOAD)
-    {
         active_slot = state->slot_usage[BOOT_CURR_IMG(state)].active_slot;
-    }
+#else
+    active_slot = BOOT_PRIMARY_SLOT;
 #endif
 
     rsp->br_flash_dev_id = flash_area_get_device_id(BOOT_IMG_AREA(state, active_slot));

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -76,7 +76,6 @@ boot_read_image_header(struct boot_loader_state *state, int slot,
     return rc;
 }
 
-#if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)
 /**
  * Reads the status of a partially-completed swap, if any.  This is necessary
  * to recover in case the boot lodaer was reset in the middle of a swap
@@ -742,7 +741,5 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
 
 }
 #endif /* !MCUBOOT_OVERWRITE_ONLY */
-
-#endif /* !MCUBOOT_DIRECT_XIP && !MCUBOOT_RAM_LOAD */
 
 #endif /* !MCUBOOT_SWAP_USING_MOVE */

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -274,7 +274,11 @@ int invoke_boot_go(struct sim_context *ctx, struct area_desc *adesc,
         (void) image_id;
 #endif /* BOOT_IMAGE_NUMBER > 1 */
 
-        res = context_boot_go(state, rsp);
+#if defined(MCUBOOT_RAM_LOAD)
+        res = context_boot_go_ram(state, rsp);
+#else
+        res = context_boot_go_flash(state, rsp);
+#endif
         sim_reset_flash_areas();
         sim_reset_context();
         free(state);


### PR DESCRIPTION
Implement multi memory boot feature

In the current implementation, the ability to launch several applications using different memory modes has been added.
Use cases: multi core and ram app boot alongside with flash based applications

- MCUBOOT_MULTI_MEMORY_LOAD 
--- Feature: partial multi-image boot for RAM based applications 
--- Feature: partial multi-image boot for Flash applications