### PR TITLE
boot: zephyr: serial_recovery: Add boot mode enter ability

### DIFF
--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -174,6 +174,12 @@ config BOOT_SERIAL_BOOT_MODE
 	  retention system (i.e. an application must set the boot mode to stay
 	  in serial recovery mode and reboot the module).
 
+config BOOT_SERIAL_NO_APPLICATION
+	bool "Stay in bootloader if no application"
+	help
+	  Allows for entering serial recovery mode if there is no bootable
+	  application that the bootloader can jump to.
+
 endmenu
 
 endif # MCUBOOT_SERIAL

--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -180,6 +180,13 @@ config BOOT_SERIAL_NO_APPLICATION
 	  Allows for entering serial recovery mode if there is no bootable
 	  application that the bootloader can jump to.
 
+config BOOT_SERIAL_PIN_RESET
+	bool "Check for device reset by pin"
+	select HWINFO
+	help
+	  Checks if the module reset was caused by the reset pin and will
+	  remain in bootloader serial recovery mode if it was.
+
 endmenu
 
 endif # MCUBOOT_SERIAL

--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -1,15 +1,13 @@
 # Copyright (c) 2017-2020 Linaro Limited
 # Copyright (c) 2020 Arm Limited
-# Copyright (c) 2017-2022 Nordic Semiconductor ASA
+# Copyright (c) 2017-2023 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 menuconfig MCUBOOT_SERIAL
 	bool "MCUboot serial recovery"
 	default n
 	select REBOOT
-	select GPIO
 	select SERIAL
 	select UART_INTERRUPT_DRIVEN
 	select BASE64
@@ -85,14 +83,6 @@ config BOOT_SERIAL_MAX_RECEIVE_SIZE
 	  by the number of receive buffers, BOOT_LINE_BUFS to allow for
 	  optimal data transfer speeds).
 
-config BOOT_SERIAL_DETECT_DELAY
-	int "Serial detect pin detection delay time [ms]"
-	default 0
-	help
-	  Used to prevent the bootloader from loading on button press.
-	  Useful for powering on when using the same button as
-	  the one used to place the device in bootloader mode.
-
 config BOOT_ERASE_PROGRESSIVELY
 	bool "Erase flash progressively when receiving new firmware"
 	default y if SOC_FAMILY_NRF
@@ -117,6 +107,7 @@ menuconfig ENABLE_MGMT_PERUSER
 	  function is required to process these commands.
 
 if ENABLE_MGMT_PERUSER
+
 config BOOT_MGMT_CUSTOM_STORAGE_ERASE
 	bool "Enable storage erase command"
 	help
@@ -142,8 +133,26 @@ config BOOT_SERIAL_ENCRYPT_EC256
 	  encryption mechanism used in this case is ECIES using primitives
 	  described under "ECIES-P256 encryption" in docs/encrypted_images.md.
 
-config BOOT_SERIAL_WAIT_FOR_DFU
-	bool "Wait for a prescribed duration to see if DFU is invoked by receiving a mcumgr comand"
+menu "Entrance methods"
+
+menuconfig BOOT_SERIAL_ENTRANCE_GPIO
+	bool "GPIO"
+	default y
+	depends on GPIO
+	help
+	  Use a GPIO to enter serial recovery mode.
+
+config BOOT_SERIAL_DETECT_DELAY
+	int "Serial detect pin detection delay time [ms]"
+	default 0
+	depends on BOOT_SERIAL_ENTRANCE_GPIO
+	help
+	  Used to prevent the bootloader from loading on button press.
+	  Useful for powering on when using the same button as
+	  the one used to place the device in bootloader mode.
+
+menuconfig BOOT_SERIAL_WAIT_FOR_DFU
+	bool "Wait a prescribed duration to see if DFU is invoked by receiving a MCUmgr comand"
 	depends on BOOT_SERIAL_UART || BOOT_SERIAL_CDC_ACM
 	help
 	  If y, MCUboot waits for a prescribed duration of time to allow
@@ -155,6 +164,16 @@ config BOOT_SERIAL_WAIT_FOR_DFU_TIMEOUT
 	default 500
 	depends on BOOT_SERIAL_WAIT_FOR_DFU
 	help
-	  timeout in ms for MCUboot to wait to allow for DFU to be invoked.
+	  Timeout in ms for MCUboot to wait to allow for DFU to be invoked.
+
+config BOOT_SERIAL_BOOT_MODE
+	bool "Check boot mode via retention subsystem"
+	depends on RETENTION_BOOT_MODE
+	help
+	  Allows for entering serial recovery mode by using Zephyr's boot mode
+	  retention system (i.e. an application must set the boot mode to stay
+	  in serial recovery mode and reboot the module).
+
+endmenu
 
 endif # MCUBOOT_SERIAL

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -128,7 +128,8 @@ BOOT_LOG_MODULE_REGISTER(mcuboot);
 #ifdef CONFIG_MCUBOOT_SERIAL
 #if !defined(CONFIG_BOOT_SERIAL_ENTRANCE_GPIO) && \
     !defined(CONFIG_BOOT_SERIAL_WAIT_FOR_DFU) && \
-    !defined(CONFIG_BOOT_SERIAL_BOOT_MODE)
+    !defined(CONFIG_BOOT_SERIAL_BOOT_MODE) && \
+    !defined(CONFIG_BOOT_SERIAL_NO_APPLICATION)
 #error "Serial recovery selected without an entrance mode set"
 #endif
 #endif
@@ -595,6 +596,19 @@ void main(void)
         BOOT_LOG_ERR("Unable to find bootable image");
 
         mcuboot_status_change(MCUBOOT_STATUS_NO_BOOTABLE_IMAGE_FOUND);
+
+#ifdef CONFIG_BOOT_SERIAL_NO_APPLICATION
+        /* No bootable image and configuration set to remain in serial
+         * recovery mode
+         */
+#ifdef CONFIG_MCUBOOT_INDICATION_LED
+        gpio_pin_set_dt(&led0, 1);
+#endif
+
+        mcuboot_status_change(MCUBOOT_STATUS_SERIAL_DFU_ENTERED);
+        rc = boot_console_init();
+        boot_serial_start(&boot_funcs);
+#endif
 
         FIH_PANIC;
     }


### PR DESCRIPTION
Adds an optional entrance method for mcuboot's serial recovery by using Zephyr's boot mode data retention system, this allows for an application to set the retained data and reboot into the bootloader.