### PR TITLE
FIH: Fix possible static check error caused by FIH_DECLARE

### DIFF
--- a/boot/bootutil/include/bootutil/fault_injection_hardening.h
+++ b/boot/bootutil/include/bootutil/fault_injection_hardening.h
@@ -249,8 +249,7 @@ fih_int fih_int_encode(int x)
 #endif /* FIH_ENABLE_DOUBLE_VARS */
 
 #define FIH_DECLARE(var, val) \
-    fih_ret var; \
-    FIH_SET(var, val);
+    fih_ret FIH_SET(var, val)
 
 /* C has a common return pattern where 0 is a correct value and all others are
  * errors. This function converts 0 to FIH_SUCCESS and any other number to a


### PR DESCRIPTION
The current FIH_DECLARE macro would cause static check failure if the variable is reassigned in the code before using the initial value.