### PR TITLE
bootutil: Cosmetic internals refactor for misra-c:2012 compliance.

### DIFF
--- a/boot/bootutil/include/bootutil/enc_key_public.h
+++ b/boot/bootutil/include/bootutil/enc_key_public.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 #ifndef ALIGN_UP
-#define ALIGN_UP(num, align)    (((num) + ((align) - 1)) & ~((align) - 1))
+#define ALIGN_UP(num, align)    (((num) + ((align) - 1U)) & ~((align) - 1U))
 #endif
 
 #ifdef MCUBOOT_AES_256

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -76,7 +76,7 @@ fih_ret boot_fih_memequal(const void *s1, const void *s2, size_t n)
     uint8_t *s2_p = (uint8_t*) s2;
     FIH_DECLARE(ret, FIH_FAILURE);
 
-    for (i = 0; i < n; i++) {
+    for (i = 0U; i < n; i++) {
         if (s1_p[i] != s2_p[i]) {
             goto out;
         }
@@ -226,7 +226,7 @@ boot_find_status(int image_index, const struct flash_area **fap)
      * because magic is always written in the last step.
      */
 
-    for (i = 0; i < sizeof(areas) / sizeof(areas[0]); i++) {
+    for (i = 0U; i < sizeof(areas) / sizeof(areas[0]); i++) {
         uint8_t magic[BOOT_MAGIC_SZ];
 
         if (flash_area_open(areas[i], fap)) {
@@ -268,7 +268,7 @@ boot_read_enc_key(const struct flash_area *fap, uint8_t slot, struct boot_status
 {
     uint32_t off;
 #if MCUBOOT_SWAP_SAVE_ENCTLV
-    int i;
+    unsigned int i;
 #endif
     int rc;
 
@@ -276,7 +276,7 @@ boot_read_enc_key(const struct flash_area *fap, uint8_t slot, struct boot_status
 #if MCUBOOT_SWAP_SAVE_ENCTLV
     rc = flash_area_read(fap, off, bs->enctlv[slot], BOOT_ENC_TLV_ALIGN_SIZE);
     if (rc == 0) {
-        for (i = 0; i < BOOT_ENC_TLV_ALIGN_SIZE; i++) {
+        for (i = 0U; i < BOOT_ENC_TLV_ALIGN_SIZE; i++) {
             if (bs->enctlv[slot][i] != 0xff) {
                 break;
             }

--- a/boot/bootutil/src/bootutil_misc.h
+++ b/boot/bootutil/src/bootutil_misc.h
@@ -16,7 +16,7 @@
 #include "bootutil/enc_key.h"
 #endif
 
-static int
+static boot_magic_t
 boot_magic_decode(const uint8_t *magic)
 {
     if (memcmp(magic, BOOT_IMG_MAGIC, BOOT_MAGIC_SZ) == 0) {

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -880,11 +880,11 @@ done:
  *
  * @return                      The type of swap to perform (BOOT_SWAP_TYPE...)
  */
-static int
+static boot_swap_type_t
 boot_validated_swap_type(struct boot_loader_state *state,
                          struct boot_status *bs)
 {
-    int swap_type;
+    boot_swap_type_t swap_type;
     FIH_DECLARE(fih_rc, FIH_FAILURE);
 
     swap_type = boot_swap_type_multi(BOOT_CURR_IMG(state));
@@ -1523,7 +1523,7 @@ boot_perform_update(struct boot_loader_state *state, struct boot_status *bs)
 {
     int rc;
 #ifndef MCUBOOT_OVERWRITE_ONLY
-    uint8_t swap_type;
+    boot_swap_type_t swap_type;
 #endif
 
     /* At this point there are no aborted swaps. */

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -269,10 +269,10 @@ boot_slots_compatible(struct boot_loader_state *state)
                  (state)->image_ok)
 
 struct boot_status_table {
-    uint8_t bst_magic_primary_slot;
-    uint8_t bst_magic_scratch;
-    uint8_t bst_copy_done_primary_slot;
-    uint8_t bst_status_source;
+    boot_magic_t bst_magic_primary_slot;
+    boot_magic_t bst_magic_scratch;
+    boot_flag_t bst_copy_done_primary_slot;
+    boot_status_source_t bst_status_source;
 };
 
 /**

--- a/boot/espressif/port/esp_mcuboot.c
+++ b/boot/espressif/port/esp_mcuboot.c
@@ -28,19 +28,19 @@
 #endif
 
 #ifndef ALIGN_UP
-#  define ALIGN_UP(num, align)      (((num) + ((align) - 1)) & ~((align) - 1))
+#  define ALIGN_UP(num, align)      (((num) + ((align) - 1U)) & ~((align) - 1U))
 #endif
 
 #ifndef ALIGN_DOWN
-#  define ALIGN_DOWN(num, align)    ((num) & ~((align) - 1))
+#  define ALIGN_DOWN(num, align)    ((num) & ~((align) - 1U))
 #endif
 
 #ifndef ALIGN_OFFSET
-#  define ALIGN_OFFSET(num, align)  ((num) & ((align) - 1))
+#  define ALIGN_OFFSET(num, align)  ((num) & ((align) - 1U))
 #endif
 
 #ifndef IS_ALIGNED
-#  define IS_ALIGNED(num, align)    (ALIGN_OFFSET((num), (align)) == 0)
+#  define IS_ALIGNED(num, align)    (ALIGN_OFFSET((num), (align)) == 0U)
 #endif
 
 #define FLASH_BUFFER_SIZE           256 /* SPI Flash block size */


### PR DESCRIPTION
This request includes certain changes in the organization of data types and forms a strict type system.
The main purpose of such work is to ensure compliance with the requirements of the MISRA-C:2012 standard.

Mainly affects bootutil_public module