### PR TITLE
zephyr: serial_recovery: Use Zephyr manifest zcbor files

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -239,9 +239,6 @@ if(CONFIG_MCUBOOT_SERIAL)
   zephyr_sources(${BOOT_DIR}/zephyr/serial_adapter.c)
   zephyr_sources(${BOOT_DIR}/boot_serial/src/boot_serial.c)
   zephyr_sources(${BOOT_DIR}/boot_serial/src/serial_recovery_cbor.c)
-  zephyr_sources(${BOOT_DIR}/boot_serial/src/zcbor_decode.c)
-  zephyr_sources(${BOOT_DIR}/boot_serial/src/zcbor_encode.c)
-  zephyr_sources(${BOOT_DIR}/boot_serial/src/zcbor_common.c)
 
   zephyr_sources_ifdef(CONFIG_BOOT_MGMT_ECHO ${BOOT_DIR}/boot_serial/src/serial_recovery_echo.c)
 

--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -14,6 +14,7 @@ menuconfig MCUBOOT_SERIAL
 	select UART_INTERRUPT_DRIVEN
 	select BASE64
 	select CRC
+	select ZCBOR
 	help
 	  If y, enables a serial-port based update mode. This allows
 	  MCUboot itself to load update images into flash over a UART.


### PR DESCRIPTION
Switches from using the zcbor files in-tree to using the ones that are part of the zephyr manifest, this prevents using old and potentially buggy versions of the zcbor library.