### PR TITLE
boot: serial_recovery: Add image hash support

### DIFF
--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -168,4 +168,11 @@ config BOOT_SERIAL_WAIT_FOR_DFU_TIMEOUT
 	help
 	  timeout in ms for MCUboot to wait to allow for DFU to be invoked.
 
+config BOOT_SERIAL_IMG_GRP_HASH
+	bool "Image list hash support"
+	default y
+	help
+	  If y, image list responses will include the image hash (adds ~100
+	  bytes of flash).
+
 endif # MCUBOOT_SERIAL

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -205,6 +205,10 @@
 #define MCUBOOT_SERIAL_WAIT_FOR_DFU
 #endif
 
+#ifdef CONFIG_BOOT_SERIAL_IMG_GRP_HASH
+#define MCUBOOT_SERIAL_IMG_GRP_HASH
+#endif
+
 /*
  * The option enables code, currently in boot_serial, that attempts
  * to erase flash progressively, as update fragments are received,


### PR DESCRIPTION
Adds support for outputting the image hash TLV in serial recovery mode, which is needed to comply with the img_mgmt MCUmgr group requirements.

Fixes #1581

Test file upload and listing from mcuboot:
```
Images:
 image=0 slot=0
    version: 0.0.0.0
    bootable: false
    flags: 
    hash: 73fc86f2aee87d13620ca718b851e524a01cd6d20aede1672ed3e31457b35d24
Split status: N/A (0)
```
And checking from actual booted image:
```
Images:
 image=0 slot=0
    version: 0.0.0
    bootable: true
    flags: active confirmed
    hash: 73fc86f2aee87d13620ca718b851e524a01cd6d20aede1672ed3e31457b35d24
Split status: N/A (0)
```