### PR TITLE
bootutil: Fix erase of trailer when located in scratch area

### DIFF
--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -673,7 +673,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
         BOOT_STATUS_ASSERT(rc == 0);
 
         if (erase_scratch) {
-            rc = boot_erase_region(fap_scratch, 0, sz);
+            rc = boot_erase_region(fap_scratch, 0, flash_area_get_size(fap_scratch));
             assert(rc == 0);
         }
     }


### PR DESCRIPTION
Trailer is temporary located in scratch when data of image goes up to last sector of primary slot. At the end of the swap procedure, the temporary trailer in scratch must be erased to prevent mcuboot from reading a stale status from the scratch area. The erase tentative was not correct, this is fixed.Issue is easily reproduced with an image size of one sector.