### PR TITLE
boot_serial: Add packed to struct

### DIFF
--- a/boot/boot_serial/src/boot_serial_priv.h
+++ b/boot/boot_serial/src/boot_serial_priv.h
@@ -61,7 +61,7 @@ struct nmgr_hdr {
     uint16_t nh_group;          /* NMGR_GROUP_XXX */
     uint8_t  nh_seq;            /* sequence number */
     uint8_t  nh_id;             /* message ID within group */
-};
+} __packed;
 
 /*
  * From imgmgr.h


### PR DESCRIPTION
Adds a packed attribute to the nmgr struct to avoid issues on architectures that do not support unaligned memory access.