### PR TITLE
Zephyr: Update boot shared data Kconfigs and add active slot to boot shared data

### DIFF
--- a/boot/bootutil/include/bootutil/boot_record.h
+++ b/boot/bootutil/include/bootutil/boot_record.h
@@ -61,11 +61,13 @@ int boot_save_boot_status(uint8_t sw_module,
  *
  * @param[in]  hdr        Pointer to the image header stored in RAM.
  * @param[in]  fap        Pointer to the flash area where image is stored.
+ * @param[in]  slot       The currently active slot being booted.
  *
  * @return                0 on success; nonzero on failure.
  */
 int boot_save_shared_data(const struct image_header *hdr,
-                          const struct flash_area *fap);
+                          const struct flash_area *fap,
+                          const uint32_t active_slot);
 
 #ifdef __cplusplus
 }

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -146,7 +146,8 @@ boot_add_shared_data(struct boot_loader_state *state,
 
 #ifdef MCUBOOT_DATA_SHARING
     rc = boot_save_shared_data(boot_img_hdr(state, active_slot),
-                                BOOT_IMG_AREA(state, active_slot));
+                                BOOT_IMG_AREA(state, active_slot),
+                                active_slot);
     if (rc != 0) {
         BOOT_LOG_ERR("Failed to add data to shared memory area.");
         return rc;

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -370,6 +370,14 @@ config MEASURED_BOOT
 config BOOT_SHARE_DATA
 	bool "Save application specific data in shared memory area"
 	default n
+	depends on RETAINED_MEM
+	depends on RETENTION
+	depends on RETENTION_BOOTLOADER_CONFIG
+	help
+	  This will place information about the mcuboot configuration and
+	  running application into a shared memory area (requires that the
+	  `zephyr,bootloader-config` chosen node by correctly assigned) that the
+	  application can then read and use as is needed.
 
 choice BOOT_FAULT_INJECTION_HARDENING_PROFILE
 	prompt "Fault injection hardening profile"


### PR DESCRIPTION
    zephyr: Depend upon retention subsystem for shared boot data
    
    Shared boot data support is being added to zephyr and uses the
    retention subsystem, thus set the Kconfigs up to describe this and
    add help text.

    bootutil: Add active slot number to shared data
    
    This allows the currently executing slot number to be checked by
    the external function, which can be used by XIP images to know
    which slot is currently being executed from to allow for correct
    uploading/positioning of firmware files.
