### PR TITLE
boot_serial: Fix Mynewt tests build

### DIFF
--- a/boot/boot_serial/src/boot_serial_priv.h
+++ b/boot/boot_serial/src/boot_serial_priv.h
@@ -54,6 +54,10 @@ extern "C" {
 #define NMGR_ID_CONS_ECHO_CTRL  1
 #define NMGR_ID_RESET           5
 
+#ifndef __packed
+#define __packed __attribute__((__packed__))
+#endif
+
 struct nmgr_hdr {
     uint8_t  nh_op;             /* NMGR_OP_XXX */
     uint8_t  nh_flags;


### PR DESCRIPTION
__packed is Zephyr specific macro and it may not be available in all environments. Use more generic __attribute__((packed)) instead.