### PR TITLE
Add support for a PSA Crypto APIs backend for RSA and SHA

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/common.h
+++ b/boot/bootutil/include/bootutil/crypto/common.h
@@ -7,9 +7,10 @@
 #ifndef __BOOTUTIL_CRYPTO_COMMON_H__
 #define __BOOTUTIL_CRYPTO_COMMON_H__
 
-/* TODO May need to update this in a future 3.x version of Mbed TLS.
- * Extract a member of the mbedtls context structure.
+/* The check below can be performed even for those cases
+ * where MCUBOOT_USE_MBED_TLS has not been defined
  */
+#include "mbedtls/version.h"
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000
 #define MBEDTLS_CONTEXT_MEMBER(X) MBEDTLS_PRIVATE(X)
 #else

--- a/boot/bootutil/include/bootutil/crypto/rsa.h
+++ b/boot/bootutil/include/bootutil/crypto/rsa.h
@@ -1,0 +1,356 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Arm Limited
+ */
+
+/*
+ * This module provides a thin abstraction over some of the crypto
+ * primitives to make it easier to swap out the used crypto library.
+ *
+ * At this point, the choices are: MCUBOOT_USE_MBED_TLS and
+ * MCUBOOT_USE_PSA_CRYPTO. Note that support for  MCUBOOT_USE_PSA_CRYPTO is
+ * still experimental and it might not support all the crypto abstractions
+ * that MCUBOOT_USE_MBED_TLS supports. For this reason, it's allowed to have
+ * both of them defined, and for crypto modules that support both abstractions,
+ * the MCUBOOT_USE_PSA_CRYPTO will take precedence.
+ */
+
+/*
+ * Note: The source file that includes this header should either define one of the
+ * two options BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED or BOOTUTIL_CRYPTO_RSA_SIGN_ENABLED
+ * This will make the signature functions or encryption functions visible without
+ * generating a "defined but not used" compiler warning
+ */
+
+#ifndef __BOOTUTIL_CRYPTO_RSA_H_
+#define __BOOTUTIL_CRYPTO_RSA_H_
+
+#include "mcuboot_config/mcuboot_config.h"
+
+#if defined(MCUBOOT_USE_PSA_CRYPTO) || defined(MCUBOOT_USE_MBED_TLS)
+#define MCUBOOT_USE_PSA_OR_MBED_TLS
+#endif /* MCUBOOT_USE_PSA_CRYPTO || MCUBOOT_USE_MBED_TLS */
+
+#if (defined(MCUBOOT_USE_PSA_OR_MBED_TLS)) != 1
+    #error "One crypto backend must be defined: either MBED_TLS/PSA_CRYPTO"
+#endif
+
+#if defined(MCUBOOT_USE_PSA_CRYPTO)
+
+#include <psa/crypto.h>
+#include "bootutil/enc_key_public.h"
+
+#elif defined(MCUBOOT_USE_MBED_TLS)
+
+#include "mbedtls/rsa.h"
+#include "mbedtls/version.h"
+#if defined(BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED)
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+#include "rsa_alt_helpers.h"
+#else
+#include "mbedtls/rsa_internal.h"
+#endif
+#endif /* BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED */
+#include "mbedtls/asn1.h"
+#include "bootutil/crypto/common.h"
+
+#endif /* MCUBOOT_USE_MBED_TLS */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(MCUBOOT_USE_PSA_CRYPTO)
+
+typedef struct {
+    psa_key_id_t key_id;
+} bootutil_rsa_context;
+
+static inline void bootutil_rsa_init(bootutil_rsa_context *ctx)
+{
+    ctx->key_id = PSA_KEY_ID_NULL;
+}
+
+static inline void bootutil_rsa_drop(bootutil_rsa_context *ctx)
+{
+    if (ctx->key_id != PSA_KEY_ID_NULL) {
+        (void)psa_destroy_key(ctx->key_id);
+    }
+}
+
+#if defined(BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED)
+static int bootutil_rsa_oaep_decrypt(
+    bootutil_rsa_context *ctx,
+    size_t *olen,
+    const uint8_t *input,
+    uint8_t *output,
+    size_t output_max_len)
+{
+    psa_status_t status = PSA_ERROR_INVALID_ARGUMENT;
+
+    /* Perform an additional defensive check to compare the modulus of the RSA
+     * key to the expected input to the decryption function, i.e. TLV_ENC_RSA_SZ
+     */
+    psa_key_attributes_t key_attr =  psa_key_attributes_init();
+    status = psa_get_key_attributes(ctx->key_id, &key_attr);
+    if (status != PSA_SUCCESS) {
+        return -1;
+    }
+    size_t input_size = PSA_BITS_TO_BYTES(psa_get_key_bits(&key_attr));
+    if (input_size != TLV_ENC_RSA_SZ) {
+        return -1;
+    }
+
+    status = psa_asymmetric_decrypt(ctx->key_id, PSA_ALG_RSA_OAEP(PSA_ALG_SHA_256),
+                                    input, TLV_ENC_RSA_SZ, NULL, 0,
+                                    output, output_max_len, olen);
+    return (int)status;
+}
+
+/*
+ * Parse a RSA private key with format specified in RFC3447 A.1.2
+ *
+ * The key is meant to be used for OAEP decrypt hence algorithm and usage are hardcoded
+ */
+static int
+bootutil_rsa_parse_private_key(bootutil_rsa_context *ctx, uint8_t **p, uint8_t *end)
+{
+    psa_status_t status = PSA_ERROR_INVALID_ARGUMENT;
+    psa_key_attributes_t key_attributes = psa_key_attributes_init();
+
+    /* Set attributes and import key */
+    psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_DECRYPT);
+    psa_set_key_algorithm(&key_attributes, PSA_ALG_RSA_OAEP(PSA_ALG_SHA_256));
+    psa_set_key_type(&key_attributes, PSA_KEY_TYPE_RSA_KEY_PAIR);
+
+    status = psa_import_key(&key_attributes, *p, (end - *p), &ctx->key_id);
+    return (int)status;
+}
+
+#endif /* BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED */
+
+#if defined(BOOTUTIL_CRYPTO_RSA_SIGN_ENABLED)
+/*
+ * Parse a RSA public key with format specified in RFC3447 A.1.1
+ *
+ * The key is meant to be used for PSS signature verification hence algorithm and usage are hardcoded
+ */
+static int
+bootutil_rsa_parse_public_key(bootutil_rsa_context *ctx, uint8_t **p, uint8_t *end)
+{
+    psa_status_t status = PSA_ERROR_INVALID_ARGUMENT;
+    psa_key_attributes_t key_attributes = psa_key_attributes_init();
+
+    /* Set attributes and import key */
+    psa_set_key_usage_flags(&key_attributes, PSA_KEY_USAGE_VERIFY_HASH);
+    psa_set_key_algorithm(&key_attributes, PSA_ALG_RSA_PSS(PSA_ALG_SHA_256));
+    psa_set_key_type(&key_attributes, PSA_KEY_TYPE_RSA_PUBLIC_KEY);
+
+    status = psa_import_key(&key_attributes, *p, (end - *p), &ctx->key_id);
+    return (int)status;
+}
+
+/* Get the modulus (N) length in bytes */
+static size_t bootutil_rsa_get_len(const bootutil_rsa_context *ctx)
+{
+    psa_key_attributes_t key_attributes = psa_key_attributes_init();
+    psa_status_t status = psa_get_key_attributes(ctx->key_id, &key_attributes);
+    if (status != PSA_SUCCESS) {
+        return 0;
+    }
+    return PSA_BITS_TO_BYTES(psa_get_key_bits(&key_attributes));
+}
+
+/* PSA Crypto has a dedicated API for RSASSA-PSS verification */
+static inline int bootutil_rsassa_pss_verify(const bootutil_rsa_context *ctx,
+    uint8_t *hash, size_t hlen, uint8_t *sig, size_t slen)
+{
+    return (int) psa_verify_hash(ctx->key_id, PSA_ALG_RSA_PSS(PSA_ALG_SHA_256),
+                                 hash, hlen, sig, slen);
+}
+#endif /* BOOTUTIL_CRYPTO_RSA_SIGN_ENABLED */
+
+#elif defined(MCUBOOT_USE_MBED_TLS)
+
+typedef mbedtls_rsa_context bootutil_rsa_context;
+
+static inline void bootutil_rsa_init(bootutil_rsa_context *ctx)
+{
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+    mbedtls_rsa_init(ctx);
+    mbedtls_rsa_set_padding(ctx, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256);
+#else
+    mbedtls_rsa_init(ctx, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256);
+#endif
+}
+
+static inline void bootutil_rsa_drop(bootutil_rsa_context *ctx)
+{
+    mbedtls_rsa_free(ctx);
+}
+
+#if defined(BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED) && (MBEDTLS_VERSION_NUMBER >= 0x03000000)
+static int fake_rng(void *p_rng, unsigned char *output, size_t len);
+#endif /* BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED && MBEDTLS_VERSION_NUMBER >= 3.0 */
+
+#if defined(BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED)
+static inline int bootutil_rsa_oaep_decrypt(
+    bootutil_rsa_context *ctx,
+    size_t *olen,
+    const uint8_t *input,
+    uint8_t *output,
+    size_t output_max_len)
+{
+    int rc = -1;
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+    rc = mbedtls_rsa_rsaes_oaep_decrypt(ctx, fake_rng, NULL,
+            NULL, 0, olen, input, output, output_max_len);
+#else
+    rc = mbedtls_rsa_rsaes_oaep_decrypt(ctx, NULL, NULL, MBEDTLS_RSA_PRIVATE,
+            NULL, 0, olen, input, output, output_max_len);
+#endif
+    return rc;
+}
+
+/*
+ * Parse a RSA private key with format specified in RFC3447 A.1.2
+ */
+static int
+bootutil_rsa_parse_private_key(bootutil_rsa_context *ctx, uint8_t **p, uint8_t *end)
+{
+    size_t len;
+
+    if (mbedtls_asn1_get_tag(p, end, &len,
+                MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE) != 0) {
+        return -1;
+    }
+
+    if (*p + len != end) {
+        return -2;
+    }
+
+    /* Non-optional fields. */
+    if ( /* version */
+        mbedtls_asn1_get_int(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(ver)) != 0 ||
+         /* public modulus */
+        mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(N)) != 0 ||
+         /* public exponent */
+        mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(E)) != 0 ||
+         /* private exponent */
+        mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(D)) != 0 ||
+         /* primes */
+        mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(P)) != 0 ||
+        mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(Q)) != 0) {
+
+        return -3;
+    }
+
+#if !defined(MBEDTLS_RSA_NO_CRT)
+    /*
+     * DP/DQ/QP are only used inside mbedTLS if it was built with the
+     * Chinese Remainder Theorem enabled (default). In case it is disabled
+     * we parse, or if not available, we calculate those values.
+     */
+    if (*p < end) {
+        if ( /* d mod (p-1) and d mod (q-1) */
+            mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(DP)) != 0 ||
+            mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(DQ)) != 0 ||
+             /* q ^ (-1) mod p */
+            mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(QP)) != 0) {
+
+            return -4;
+        }
+    } else {
+        if (mbedtls_rsa_deduce_crt(&ctx->MBEDTLS_CONTEXT_MEMBER(P),
+                                   &ctx->MBEDTLS_CONTEXT_MEMBER(Q),
+                                   &ctx->MBEDTLS_CONTEXT_MEMBER(D),
+                                   &ctx->MBEDTLS_CONTEXT_MEMBER(DP),
+                                   &ctx->MBEDTLS_CONTEXT_MEMBER(DQ),
+                                   &ctx->MBEDTLS_CONTEXT_MEMBER(QP)) != 0) {
+            return -5;
+        }
+    }
+#endif /* !MBEDTLS_RSA_NO_CRT */
+
+    ctx->MBEDTLS_CONTEXT_MEMBER(len) = mbedtls_mpi_size(&ctx->MBEDTLS_CONTEXT_MEMBER(N));
+
+    if (mbedtls_rsa_check_privkey(ctx) != 0) {
+        return -6;
+    }
+
+    return 0;
+}
+#endif /* BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED */
+
+#if defined(BOOTUTIL_CRYPTO_RSA_SIGN_ENABLED)
+/*
+ * Parse a RSA public key with format specified in RFC3447 A.1.1
+ */
+static int
+bootutil_rsa_parse_public_key(bootutil_rsa_context *ctx, uint8_t **p, uint8_t *end)
+{
+    int rc;
+    size_t len;
+
+    if ((rc = mbedtls_asn1_get_tag(p, end, &len,
+          MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE)) != 0) {
+        return -1;
+    }
+
+    if (*p + len != end) {
+        return -2;
+    }
+
+    if ((rc = mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(N))) != 0 ||
+        (rc = mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(E))) != 0) {
+        return -3;
+    }
+
+    ctx->MBEDTLS_CONTEXT_MEMBER(len) = mbedtls_mpi_size(&ctx->MBEDTLS_CONTEXT_MEMBER(N));
+
+    if (*p != end) {
+        return -4;
+    }
+
+    /* The Mbed TLS version is more than 2.6.1 */
+#if MBEDTLS_VERSION_NUMBER > 0x02060100
+    rc = mbedtls_rsa_import(ctx, &ctx->MBEDTLS_CONTEXT_MEMBER(N), NULL,
+                            NULL, NULL, &ctx->MBEDTLS_CONTEXT_MEMBER(E));
+    if (rc != 0) {
+        return -5;
+    }
+#endif
+
+    rc = mbedtls_rsa_check_pubkey(ctx);
+    if (rc != 0) {
+        return -6;
+    }
+
+    ctx->MBEDTLS_CONTEXT_MEMBER(len) = mbedtls_mpi_size(&ctx->MBEDTLS_CONTEXT_MEMBER(N));
+
+    return 0;
+}
+
+/* Get the modulus (N) length in bytes */
+static inline size_t bootutil_rsa_get_len(const bootutil_rsa_context *ctx)
+{
+    return mbedtls_rsa_get_len(ctx);
+}
+
+/* Performs modular exponentiation using the public key output = input^E mod N */
+static inline int bootutil_rsa_public(bootutil_rsa_context *ctx, const uint8_t *input, uint8_t *output)
+{
+    return mbedtls_rsa_public(ctx, input, output);
+}
+#endif /* BOOTUTIL_CRYPTO_RSA_SIGN_ENABLED */
+
+#endif /* MCUBOOT_USE_MBED_TLS */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOOTUTIL_CRYPTO_RSA_H_ */

--- a/boot/bootutil/include/bootutil/crypto/rsa.h
+++ b/boot/bootutil/include/bootutil/crypto/rsa.h
@@ -92,7 +92,7 @@ static int bootutil_rsa_oaep_decrypt(
     psa_status_t status = PSA_ERROR_INVALID_ARGUMENT;
 
     /* Perform an additional defensive check to compare the modulus of the RSA
-     * key to the expected input to the decryption function, i.e. TLV_ENC_RSA_SZ
+     * key to the expected input of the decryption function, i.e. TLV_ENC_RSA_SZ
      */
     psa_key_attributes_t key_attr =  psa_key_attributes_init();
     status = psa_get_key_attributes(ctx->key_id, &key_attr);

--- a/boot/bootutil/include/bootutil/crypto/sha256.h
+++ b/boot/bootutil/include/bootutil/crypto/sha256.h
@@ -71,14 +71,10 @@ extern "C" {
 
 typedef psa_hash_operation_t bootutil_sha256_context;
 
-static inline void bootutil_sha256_init(bootutil_sha256_context *ctx)
+static inline int bootutil_sha256_init(bootutil_sha256_context *ctx)
 {
     *ctx = psa_hash_operation_init();
-    psa_status_t status = psa_hash_setup(ctx, PSA_ALG_SHA_256);
-    if (status != PSA_SUCCESS) {
-        MCUBOOT_LOG_ERR("Failed setting up a hash operation for PSA Crypto APIs");
-        while(1) {}
-    }
+    return (int)psa_hash_setup(ctx, PSA_ALG_SHA_256);
 }
 
 static inline void bootutil_sha256_drop(bootutil_sha256_context *ctx)
@@ -105,10 +101,10 @@ static inline int bootutil_sha256_finish(bootutil_sha256_context *ctx,
 
 typedef mbedtls_sha256_context bootutil_sha256_context;
 
-static inline void bootutil_sha256_init(bootutil_sha256_context *ctx)
+static inline int bootutil_sha256_init(bootutil_sha256_context *ctx)
 {
     mbedtls_sha256_init(ctx);
-    (void)mbedtls_sha256_starts_ret(ctx, 0);
+    return mbedtls_sha256_starts_ret(ctx, 0);
 }
 
 static inline void bootutil_sha256_drop(bootutil_sha256_context *ctx)
@@ -135,9 +131,10 @@ static inline int bootutil_sha256_finish(bootutil_sha256_context *ctx,
 
 #if defined(MCUBOOT_USE_TINYCRYPT)
 typedef struct tc_sha256_state_struct bootutil_sha256_context;
-static inline void bootutil_sha256_init(bootutil_sha256_context *ctx)
+static inline int bootutil_sha256_init(bootutil_sha256_context *ctx)
 {
     tc_sha256_init(ctx);
+    return 0;
 }
 
 static inline void bootutil_sha256_drop(bootutil_sha256_context *ctx)
@@ -160,9 +157,10 @@ static inline int bootutil_sha256_finish(bootutil_sha256_context *ctx,
 #endif /* MCUBOOT_USE_TINYCRYPT */
 
 #if defined(MCUBOOT_USE_CC310)
-static inline void bootutil_sha256_init(bootutil_sha256_context *ctx)
+static inline int bootutil_sha256_init(bootutil_sha256_context *ctx)
 {
     cc310_sha256_init(ctx);
+    return 0;
 }
 
 static inline void bootutil_sha256_drop(bootutil_sha256_context *ctx)

--- a/boot/bootutil/include/bootutil/crypto/sha256.h
+++ b/boot/bootutil/include/bootutil/crypto/sha256.h
@@ -3,50 +3,62 @@
  *
  * Copyright (c) 2017-2019 Linaro LTD
  * Copyright (c) 2017-2019 JUUL Labs
- * Copyright (c) 2021 Arm Limited
+ * Copyright (c) 2021-2023 Arm Limited
  */
 
 /*
  * This module provides a thin abstraction over some of the crypto
  * primitives to make it easier to swap out the used crypto library.
  *
- * At this point, there are two choices: MCUBOOT_USE_MBED_TLS, or
- * MCUBOOT_USE_TINYCRYPT.  It is a compile error there is not exactly
- * one of these defined.
+ * At this point, the choices are: MCUBOOT_USE_MBED_TLS, MCUBOOT_USE_TINYCRYPT,
+ * MCUBOOT_USE_PSA_CRYPTO, MCUBOOT_USE_CC310. Note that support for MCUBOOT_USE_PSA_CRYPTO
+ * is still experimental and it might not support all the crypto abstractions
+ * that MCUBOOT_USE_MBED_TLS supports. For this reason, it's allowed to have
+ * both of them defined, and for crypto modules that support both abstractions,
+ * the MCUBOOT_USE_PSA_CRYPTO will take precedence.
  */
 
 #ifndef __BOOTUTIL_CRYPTO_SHA256_H_
 #define __BOOTUTIL_CRYPTO_SHA256_H_
 
 #include "mcuboot_config/mcuboot_config.h"
+#include "mcuboot_config/mcuboot_logging.h"
 
-#if (defined(MCUBOOT_USE_MBED_TLS) + \
+#if defined(MCUBOOT_USE_PSA_CRYPTO) || defined(MCUBOOT_USE_MBED_TLS)
+#define MCUBOOT_USE_PSA_OR_MBED_TLS
+#endif /* MCUBOOT_USE_PSA_CRYPTO || MCUBOOT_USE_MBED_TLS */
+
+#if (defined(MCUBOOT_USE_PSA_OR_MBED_TLS) + \
      defined(MCUBOOT_USE_TINYCRYPT) + \
      defined(MCUBOOT_USE_CC310)) != 1
-    #error "One crypto backend must be defined: either CC310, MBED_TLS or TINYCRYPT"
+    #error "One crypto backend must be defined: either CC310/MBED_TLS/TINYCRYPT/PSA_CRYPTO"
 #endif
 
-#if defined(MCUBOOT_USE_MBED_TLS)
-    #include <mbedtls/sha256.h>
-    #include <mbedtls/version.h>
-    #if MBEDTLS_VERSION_NUMBER >= 0x03000000
-        #include <mbedtls/compat-2.x.h>
-    #endif
-    #define BOOTUTIL_CRYPTO_SHA256_BLOCK_SIZE (64)
-    #define BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE (32)
+/* Universal defines for SHA-256 */
+#define BOOTUTIL_CRYPTO_SHA256_BLOCK_SIZE (64)
+#define BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE (32)
+
+#if defined(MCUBOOT_USE_PSA_CRYPTO)
+
+#include <psa/crypto.h>
+
+#elif defined(MCUBOOT_USE_MBED_TLS)
+
+#include <mbedtls/sha256.h>
+#include <mbedtls/version.h>
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+#include <mbedtls/compat-2.x.h>
+#endif
+
 #endif /* MCUBOOT_USE_MBED_TLS */
 
 #if defined(MCUBOOT_USE_TINYCRYPT)
     #include <tinycrypt/sha256.h>
     #include <tinycrypt/constants.h>
-    #define BOOTUTIL_CRYPTO_SHA256_BLOCK_SIZE TC_SHA256_BLOCK_SIZE
-    #define BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE TC_SHA256_DIGEST_SIZE
 #endif /* MCUBOOT_USE_TINYCRYPT */
 
 #if defined(MCUBOOT_USE_CC310)
     #include <cc310_glue.h>
-    #define BOOTUTIL_CRYPTO_SHA256_BLOCK_SIZE (64)
-    #define BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE (32)
 #endif /* MCUBOOT_USE_CC310 */
 
 #include <stdint.h>
@@ -55,7 +67,42 @@
 extern "C" {
 #endif
 
-#if defined(MCUBOOT_USE_MBED_TLS)
+#if defined(MCUBOOT_USE_PSA_CRYPTO)
+
+typedef psa_hash_operation_t bootutil_sha256_context;
+
+static inline void bootutil_sha256_init(bootutil_sha256_context *ctx)
+{
+    *ctx = psa_hash_operation_init();
+    psa_status_t status = psa_hash_setup(ctx, PSA_ALG_SHA_256);
+    if (status != PSA_SUCCESS) {
+        MCUBOOT_LOG_ERR("Failed setting up a hash operation for PSA Crypto APIs");
+        while(1) {}
+    }
+}
+
+static inline void bootutil_sha256_drop(bootutil_sha256_context *ctx)
+{
+    (void)psa_hash_abort(ctx);
+}
+
+static inline int bootutil_sha256_update(bootutil_sha256_context *ctx,
+                                         const void *data,
+                                         uint32_t data_len)
+{
+    return (int)psa_hash_update(ctx, data, data_len);
+}
+
+static inline int bootutil_sha256_finish(bootutil_sha256_context *ctx,
+                                          uint8_t *output)
+{
+    size_t hash_length = 0;
+    /* Assumes the output buffer is at least the expected size of the hash */
+    return (int)psa_hash_finish(ctx, output, PSA_HASH_LENGTH(PSA_ALG_SHA_256), &hash_length);
+}
+
+#elif defined(MCUBOOT_USE_MBED_TLS)
+
 typedef mbedtls_sha256_context bootutil_sha256_context;
 
 static inline void bootutil_sha256_init(bootutil_sha256_context *ctx)
@@ -83,6 +130,7 @@ static inline int bootutil_sha256_finish(bootutil_sha256_context *ctx,
 {
     return mbedtls_sha256_finish_ret(ctx, output);
 }
+
 #endif /* MCUBOOT_USE_MBED_TLS */
 
 #if defined(MCUBOOT_USE_TINYCRYPT)

--- a/boot/bootutil/include/bootutil/crypto/sha256.h
+++ b/boot/bootutil/include/bootutil/crypto/sha256.h
@@ -77,9 +77,9 @@ static inline int bootutil_sha256_init(bootutil_sha256_context *ctx)
     return (int)psa_hash_setup(ctx, PSA_ALG_SHA_256);
 }
 
-static inline void bootutil_sha256_drop(bootutil_sha256_context *ctx)
+static inline int bootutil_sha256_drop(bootutil_sha256_context *ctx)
 {
-    (void)psa_hash_abort(ctx);
+    return (int)psa_hash_abort(ctx);
 }
 
 static inline int bootutil_sha256_update(bootutil_sha256_context *ctx,
@@ -107,11 +107,12 @@ static inline int bootutil_sha256_init(bootutil_sha256_context *ctx)
     return mbedtls_sha256_starts_ret(ctx, 0);
 }
 
-static inline void bootutil_sha256_drop(bootutil_sha256_context *ctx)
+static inline int bootutil_sha256_drop(bootutil_sha256_context *ctx)
 {
     /* XXX: config defines MBEDTLS_PLATFORM_NO_STD_FUNCTIONS so no need to free */
     /* (void)mbedtls_sha256_free(ctx); */
     (void)ctx;
+    return 0;
 }
 
 static inline int bootutil_sha256_update(bootutil_sha256_context *ctx,
@@ -137,9 +138,10 @@ static inline int bootutil_sha256_init(bootutil_sha256_context *ctx)
     return 0;
 }
 
-static inline void bootutil_sha256_drop(bootutil_sha256_context *ctx)
+static inline int bootutil_sha256_drop(bootutil_sha256_context *ctx)
 {
     (void)ctx;
+    return 0;
 }
 
 static inline int bootutil_sha256_update(bootutil_sha256_context *ctx,
@@ -163,10 +165,11 @@ static inline int bootutil_sha256_init(bootutil_sha256_context *ctx)
     return 0;
 }
 
-static inline void bootutil_sha256_drop(bootutil_sha256_context *ctx)
+static inline int bootutil_sha256_drop(bootutil_sha256_context *ctx)
 {
     (void)ctx;
     nrf_cc310_disable();
+    return 0;
 }
 
 static inline int bootutil_sha256_update(bootutil_sha256_context *ctx,

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2017-2019 Linaro LTD
  * Copyright (c) 2016-2019 JUUL Labs
- * Copyright (c) 2019-2021 Arm Limited
+ * Copyright (c) 2019-2023 Arm Limited
  * Copyright (c) 2020-2023 Nordic Semiconductor ASA
  *
  * Original license:
@@ -440,7 +440,7 @@ boot_swap_type_multi(int image_index)
                 table->image_ok_secondary_slot == secondary_slot.image_ok) &&
             (table->copy_done_primary_slot == BOOT_FLAG_ANY  ||
                 table->copy_done_primary_slot == primary_slot.copy_done)) {
-            BOOT_LOG_INF("Swap type: %s",
+            BOOT_LOG_INF("Image index: %d, Swap type: %s", image_index,
                          table->swap_type == BOOT_SWAP_TYPE_TEST   ? "test"   :
                          table->swap_type == BOOT_SWAP_TYPE_PERM   ? "perm"   :
                          table->swap_type == BOOT_SWAP_TYPE_REVERT ? "revert" :
@@ -454,7 +454,7 @@ boot_swap_type_multi(int image_index)
         }
     }
 
-    BOOT_LOG_INF("Swap type: none");
+    BOOT_LOG_INF("Image index: %d, Swap type: none", image_index);
     return BOOT_SWAP_TYPE_NONE;
 }
 

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (c) 2018-2019 JUUL Labs
- * Copyright (c) 2019-2021 Arm Limited
+ * Copyright (c) 2019-2023 Arm Limited
  */
 
 #include "mcuboot_config/mcuboot_config.h"
@@ -13,13 +13,8 @@
 #include <string.h>
 
 #if defined(MCUBOOT_ENCRYPT_RSA)
-#include "mbedtls/rsa.h"
-#if MBEDTLS_VERSION_NUMBER >= 0x03000000
-#include "rsa_alt_helpers.h"
-#else
-#include "mbedtls/rsa_internal.h"
-#endif
-#include "mbedtls/asn1.h"
+#define BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED
+#include "bootutil/crypto/rsa.h"
 #endif
 
 #if defined(MCUBOOT_ENCRYPT_KW)
@@ -92,74 +87,6 @@ done:
     return rc;
 }
 #endif /* MCUBOOT_ENCRYPT_KW */
-
-#if defined(MCUBOOT_ENCRYPT_RSA)
-static int
-parse_rsa_enckey(mbedtls_rsa_context *ctx, uint8_t **p, uint8_t *end)
-{
-    size_t len;
-
-    if (mbedtls_asn1_get_tag(p, end, &len,
-                MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE) != 0) {
-        return -1;
-    }
-
-    if (*p + len != end) {
-        return -2;
-    }
-
-    /* Non-optional fields. */
-    if ( /* version */
-        mbedtls_asn1_get_int(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(ver)) != 0 ||
-         /* public modulus */
-        mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(N)) != 0 ||
-         /* public exponent */
-        mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(E)) != 0 ||
-         /* private exponent */
-        mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(D)) != 0 ||
-         /* primes */
-        mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(P)) != 0 ||
-        mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(Q)) != 0) {
-
-        return -3;
-    }
-
-#if !defined(MBEDTLS_RSA_NO_CRT)
-    /*
-     * DP/DQ/QP are only used inside mbedTLS if it was built with the
-     * Chinese Remainder Theorem enabled (default). In case it is disabled
-     * we parse, or if not available, we calculate those values.
-     */
-    if (*p < end) {
-        if ( /* d mod (p-1) and d mod (q-1) */
-            mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(DP)) != 0 ||
-            mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(DQ)) != 0 ||
-             /* q ^ (-1) mod p */
-            mbedtls_asn1_get_mpi(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(QP)) != 0) {
-
-            return -4;
-        }
-    } else {
-        if (mbedtls_rsa_deduce_crt(&ctx->MBEDTLS_CONTEXT_MEMBER(P),
-                                   &ctx->MBEDTLS_CONTEXT_MEMBER(Q),
-                                   &ctx->MBEDTLS_CONTEXT_MEMBER(D),
-                                   &ctx->MBEDTLS_CONTEXT_MEMBER(DP),
-                                   &ctx->MBEDTLS_CONTEXT_MEMBER(DQ),
-                                   &ctx->MBEDTLS_CONTEXT_MEMBER(QP)) != 0) {
-            return -5;
-        }
-    }
-#endif
-
-    ctx->MBEDTLS_CONTEXT_MEMBER(len) = mbedtls_mpi_size(&ctx->MBEDTLS_CONTEXT_MEMBER(N));
-
-    if (mbedtls_rsa_check_privkey(ctx) != 0) {
-        return -6;
-    }
-
-    return 0;
-}
-#endif
 
 #if defined(MCUBOOT_ENCRYPT_EC256)
 static const uint8_t ec_pubkey_oid[] = MBEDTLS_OID_EC_ALG_UNRESTRICTED;
@@ -460,8 +387,8 @@ _Static_assert(EC_CIPHERKEY_INDEX + BOOT_ENC_KEY_SIZE == EXPECTED_ENC_LEN,
         "Please fix ECIES-X25519 component indexes");
 #endif
 
-#if defined(MCUBOOT_ENCRYPT_RSA) || \
-    (defined(MCUBOOT_ENCRYPT_EC256) && defined(MCUBOOT_USE_MBED_TLS))
+#if ( (defined(MCUBOOT_ENCRYPT_RSA) && defined(MCUBOOT_USE_MBED_TLS) && !defined(MCUBOOT_USE_PSA_CRYPTO)) || \
+      (defined(MCUBOOT_ENCRYPT_EC256) && defined(MCUBOOT_USE_MBED_TLS)) )
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000
 static int fake_rng(void *p_rng, unsigned char *output, size_t len)
 {
@@ -474,9 +401,9 @@ static int fake_rng(void *p_rng, unsigned char *output, size_t len)
 
     return 0;
 }
-#endif
-#endif /* defined(MCUBOOT_ENCRYPT_RSA) ||
-          defined(MCUBOOT_ENCRYPT_EC256) && defined(MCUBOOT_USE_MBED_TLS) */
+#endif /* MBEDTLS_VERSION_NUMBER */
+#endif /* (MCUBOOT_ENCRYPT_RSA && MCUBOOT_USE_MBED_TLS && !MCUBOOT_USE_PSA_CRYPTO) ||
+          (MCUBOOT_ENCRYPT_EC256 && MCUBOOT_USE_MBED_TLS) */
 
 /*
  * Decrypt an encryption key TLV.
@@ -488,7 +415,7 @@ int
 boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey)
 {
 #if defined(MCUBOOT_ENCRYPT_RSA)
-    mbedtls_rsa_context rsa;
+    bootutil_rsa_context rsa;
     uint8_t *cp;
     uint8_t *cpend;
     size_t olen;
@@ -515,28 +442,22 @@ boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey)
 
 #if defined(MCUBOOT_ENCRYPT_RSA)
 
-#if MBEDTLS_VERSION_NUMBER >= 0x03000000
-    mbedtls_rsa_init(&rsa);
-    mbedtls_rsa_set_padding(&rsa, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256);
-#else
-    mbedtls_rsa_init(&rsa, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256);
-#endif
+    bootutil_rsa_init(&rsa);
     cp = (uint8_t *)bootutil_enc_key.key;
     cpend = cp + *bootutil_enc_key.len;
 
-    rc = parse_rsa_enckey(&rsa, &cp, cpend);
+    /* The enckey is encrypted through RSA so for decryption we need the private key */
+    rc = bootutil_rsa_parse_private_key(&rsa, &cp, cpend);
     if (rc) {
-        mbedtls_rsa_free(&rsa);
+        bootutil_rsa_drop(&rsa);
         return rc;
     }
-#if MBEDTLS_VERSION_NUMBER >= 0x03000000
-    rc = mbedtls_rsa_rsaes_oaep_decrypt(&rsa, fake_rng, NULL,
-            NULL, 0, &olen, buf, enckey, BOOT_ENC_KEY_SIZE);
-#else
-    rc = mbedtls_rsa_rsaes_oaep_decrypt(&rsa, NULL, NULL, MBEDTLS_RSA_PRIVATE,
-            NULL, 0, &olen, buf, enckey, BOOT_ENC_KEY_SIZE);
-#endif
-    mbedtls_rsa_free(&rsa);
+
+    rc = bootutil_rsa_oaep_decrypt(&rsa, &olen, buf, enckey, BOOT_ENC_KEY_SIZE);
+    bootutil_rsa_drop(&rsa);
+    if (rc) {
+        return rc;
+    }
 
 #endif /* defined(MCUBOOT_ENCRYPT_RSA) */
 

--- a/boot/bootutil/src/image_rsa.c
+++ b/boot/bootutil/src/image_rsa.c
@@ -38,7 +38,7 @@
 #include "bootutil/crypto/rsa.h"
 
 /* PSA Crypto APIs provide an integrated API to perform the verification
- * while for other crypto backend we need to implement each step at this
+ * while for other crypto backends we need to implement each step at this
  * abstraction level
  */
 #if !defined(MCUBOOT_USE_PSA_CRYPTO)

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2016-2020 Linaro LTD
  * Copyright (c) 2016-2019 JUUL Labs
- * Copyright (c) 2019-2021 Arm Limited
+ * Copyright (c) 2019-2023 Arm Limited
  *
  * Original license:
  *
@@ -1116,10 +1116,10 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
     assert(rc == 0);
 #endif
 
-    BOOT_LOG_INF("Image upgrade secondary slot -> primary slot");
-    BOOT_LOG_INF("Erasing the primary slot");
-
     image_index = BOOT_CURR_IMG(state);
+
+    BOOT_LOG_INF("Image %d upgrade secondary slot -> primary slot", image_index);
+    BOOT_LOG_INF("Erasing the primary slot");
 
     rc = flash_area_open(FLASH_AREA_IMAGE_PRIMARY(image_index),
             &fap_primary_slot);
@@ -2845,15 +2845,15 @@ boot_load_image_to_sram(struct boot_loader_state *state)
 
         rc = boot_verify_ram_load_address(state);
         if (rc != 0) {
-            BOOT_LOG_INF("Image RAM load address 0x%x is invalid.", img_dst);
+            BOOT_LOG_INF("Image %d RAM load address 0x%x is invalid.", BOOT_CURR_IMG(state), img_dst);
             return rc;
         }
 
 #if (BOOT_IMAGE_NUMBER > 1)
         rc = boot_check_ram_load_overlapping(state);
         if (rc != 0) {
-            BOOT_LOG_INF("Image RAM loading to address 0x%x would overlap with\
-                         another image.", img_dst);
+            BOOT_LOG_INF("Image %d RAM loading to address 0x%x would overlap with\
+                         another image.", BOOT_CURR_IMG(state), img_dst);
             return rc;
         }
 #endif
@@ -2871,9 +2871,9 @@ boot_load_image_to_sram(struct boot_loader_state *state)
         rc = boot_copy_image_to_sram(state, active_slot, img_dst, img_sz);
 #endif
         if (rc != 0) {
-            BOOT_LOG_INF("RAM loading to 0x%x is failed.", img_dst);
+            BOOT_LOG_INF("Image %d RAM loading to 0x%x is failed.", BOOT_CURR_IMG(state), img_dst);
         } else {
-            BOOT_LOG_INF("RAM loading to 0x%x is succeeded.", img_dst);
+            BOOT_LOG_INF("Image %d RAM loading to 0x%x is succeeded.", BOOT_CURR_IMG(state), img_dst);
         }
     } else {
         /* Only images that support IMAGE_F_RAM_LOAD are allowed if
@@ -2902,7 +2902,8 @@ boot_remove_image_from_sram(struct boot_loader_state *state)
 {
     (void)state;
 
-    BOOT_LOG_INF("Removing image from SRAM at address 0x%x",
+    BOOT_LOG_INF("Removing image %d from SRAM at address 0x%x",
+                 BOOT_CURR_IMG(state),
                  state->slot_usage[BOOT_CURR_IMG(state)].img_dst);
 
     memset((void*)(IMAGE_RAM_BASE + state->slot_usage[BOOT_CURR_IMG(state)].img_dst),
@@ -3215,8 +3216,7 @@ boot_update_hw_rollback_protection(struct boot_loader_state *state)
                                           state->slot_usage[BOOT_CURR_IMG(state)].active_slot,
                                           boot_img_hdr(state, state->slot_usage[BOOT_CURR_IMG(state)].active_slot));
         if (rc != 0) {
-            BOOT_LOG_ERR("Security counter update failed after image "
-                            "validation.");
+            BOOT_LOG_ERR("Security counter update failed after image %d validation.", BOOT_CURR_IMG(state));
             return rc;
         }
 #if defined(MCUBOOT_DIRECT_XIP) && defined(MCUBOOT_DIRECT_XIP_REVERT)

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1175,8 +1175,8 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
     }
 #endif
 
-    BOOT_LOG_INF("Copying the secondary slot to the primary slot: 0x%zx bytes",
-                 size);
+    BOOT_LOG_INF("Image %d copying the secondary slot to the primary slot: 0x%zx bytes",
+                 image_index, size);
     rc = boot_copy_region(state, fap_secondary_slot, fap_primary_slot, 0, 0, size);
     if (rc != 0) {
         return rc;
@@ -1981,7 +1981,7 @@ check_downgrade_prevention(struct boot_loader_state *state)
     }
     if (rc < 0) {
         /* Image in slot 0 prevents downgrade, delete image in slot 1 */
-        BOOT_LOG_INF("Image in slot 1 erased due to downgrade prevention");
+        BOOT_LOG_INF("Image %d in slot 1 erased due to downgrade prevention", BOOT_CURR_IMG(state));
         flash_area_erase(BOOT_IMG(state, 1).area, 0,
                          flash_area_get_size(BOOT_IMG(state, 1).area));
     } else {
@@ -2733,7 +2733,8 @@ boot_copy_image_to_sram(struct boot_loader_state *state, int slot,
     /* Direct copy from flash to its new location in SRAM. */
     rc = flash_area_read(fap_src, 0, (void *)(IMAGE_RAM_BASE + img_dst), img_sz);
     if (rc != 0) {
-        BOOT_LOG_INF("Error whilst copying image from Flash to SRAM: %d", rc);
+        BOOT_LOG_INF("Error whilst copying image %d from Flash to SRAM: %d",
+                     BOOT_CURR_IMG(state), rc);
     }
 
     flash_area_close(fap_src);

--- a/boot/espressif/include/crypto_config/rsa.cmake
+++ b/boot/espressif/include/crypto_config/rsa.cmake
@@ -15,6 +15,7 @@ if (DEFINED CONFIG_ESP_USE_MBEDTLS)
         ${MBEDTLS_DIR}/library/rsa.c
         ${MBEDTLS_DIR}/library/bignum.c
         ${MBEDTLS_DIR}/library/asn1parse.c
+        ${MBEDTLS_DIR}/library/md.c
         ${MBEDTLS_DIR}/library/memory_buffer_alloc.c
         )
     if (DEFINED MBEDTLS_CONFIG_FILE)

--- a/ext/mbedtls-asn1/include/mbedtls/version.h
+++ b/ext/mbedtls-asn1/include/mbedtls/version.h
@@ -1,0 +1,90 @@
+/**
+ * \file version.h
+ *
+ * \brief Run-time version information
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/*
+ * This set of run-time variables can be used to determine the version number of
+ * the Mbed TLS library used. Compile-time version defines for the same can be
+ * found in build_info.h
+ */
+#ifndef MBEDTLS_VERSION_H
+#define MBEDTLS_VERSION_H
+
+#include "mbedtls/build_info.h"
+
+#if defined(MBEDTLS_VERSION_C)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Get the version number.
+ *
+ * \return          The constructed version number in the format
+ *                  MMNNPP00 (Major, Minor, Patch).
+ */
+unsigned int mbedtls_version_get_number( void );
+
+/**
+ * Get the version string ("x.y.z").
+ *
+ * \param string    The string that will receive the value.
+ *                  (Should be at least 9 bytes in size)
+ */
+void mbedtls_version_get_string( char *string );
+
+/**
+ * Get the full version string ("mbed TLS x.y.z").
+ *
+ * \param string    The string that will receive the value. The mbed TLS version
+ *                  string will use 18 bytes AT MOST including a terminating
+ *                  null byte.
+ *                  (So the buffer should be at least 18 bytes to receive this
+ *                  version string).
+ */
+void mbedtls_version_get_string_full( char *string );
+
+/**
+ * \brief           Check if support for a feature was compiled into this
+ *                  mbed TLS binary. This allows you to see at runtime if the
+ *                  library was for instance compiled with or without
+ *                  Multi-threading support.
+ *
+ * \note            only checks against defines in the sections "System
+ *                  support", "mbed TLS modules" and "mbed TLS feature
+ *                  support" in mbedtls_config.h
+ *
+ * \param feature   The string for the define to check (e.g. "MBEDTLS_AES_C")
+ *
+ * \return          0 if the feature is present,
+ *                  -1 if the feature is not present and
+ *                  -2 if support for feature checking as a whole was not
+ *                  compiled in.
+ */
+int mbedtls_version_check_feature( const char *feature );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MBEDTLS_VERSION_C */
+
+#endif /* version.h */

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -103,6 +103,8 @@ fn main() {
         conf.file("../../ext/mbedtls/library/platform.c");
         conf.file("../../ext/mbedtls/library/platform_util.c");
         conf.file("../../ext/mbedtls/library/asn1parse.c");
+        conf.file("../../ext/mbedtls/library/md.c");
+
     } else if sig_ecdsa {
         conf.conf.define("MCUBOOT_SIGN_EC256", None);
         conf.conf.define("MCUBOOT_USE_TINYCRYPT", None);


### PR DESCRIPTION
With this PR, we want to add optional support for a new backend to implement cryptographic APIs based on the [ PSA Crypto APIs](https://armmbed.github.io/mbed-crypto/html/). We start by adding support for it in the RSA encryption/signing APIs and in the SHA256 hashing APIs. A follow up PR enabling this new backend with the existing simulator tests will be opened later. This PR covers only:

* The cryptographic changes by adding a generic backend option called `MCUBOOT_USE_PSA_CRYPTO` for RSA and SHA256
* Refactors the RSA module which in the current implementation is strongly coupled with mbed TLS APIs, separating it similarly to other modules in a generic abstraction layer (rsa.h) that allows interfacing with arbitrary crypto libraries that follow the interface.

An additional small change to common prints in `bootutil` to show the `image_index` is added as well as, although unrelated from the rest of the patches, we found it was helping in our debugging efforts throughout development., so it probably makes no harm to have it here.