### PR TITLE
zephyr: arm: Update reading the flash image reset vector

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -141,8 +141,12 @@ int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
 
 uint8_t flash_area_get_device_id(const struct flash_area *fa)
 {
-	(void)fa;
-	return FLASH_DEVICE_ID;
+#if defined(CONFIG_ARM)
+    return fa->fa_id;
+#else
+    (void)fa;
+    return FLASH_DEVICE_ID;
+#endif
 }
 
 #define ERASED_VAL 0xff

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -157,16 +157,26 @@ static void do_boot(struct boot_rsp *rsp)
     /* Get ram address for image */
     vt = (struct arm_vector_table *)(rsp->br_hdr->ih_load_addr + rsp->br_hdr->ih_hdr_size);
 #else
-    uintptr_t flash_base;
     int rc;
+    const struct flash_area *fap;
+    static uint32_t dst[2];
 
     /* Jump to flash image */
-    rc = flash_device_base(rsp->br_flash_dev_id, &flash_base);
+    rc = flash_area_open(rsp->br_flash_dev_id, &fap);
     assert(rc == 0);
 
-    vt = (struct arm_vector_table *)(flash_base +
-                                     rsp->br_image_off +
-                                     rsp->br_hdr->ih_hdr_size);
+    rc = flash_area_read(fap, rsp->br_hdr->ih_hdr_size, dst, sizeof(dst));
+    assert(rc == 0);
+#ifndef CONFIG_ASSERT
+    /* Enter a lock up as asserts are disabled */
+    if (rc != 0) {
+        while (1);
+    }
+#endif
+
+    flash_area_close(fap);
+
+    vt = (struct arm_vector_table *)dst;
 #endif
 
     if (IS_ENABLED(CONFIG_SYSTEM_TIMER_HAS_DISABLE_SUPPORT)) {


### PR DESCRIPTION
This change uses the flash functions to read the applications reset vector. This allows flexibility on where the application image is programmed.
The current implementation in Zephyr for ARM does not allow the use-case where the application is programmed to a different flash device than where mcuboot is programmed and running from.

This was tested on NXP ARM platforms for the case where the Zephyr and mcuboot are in the same flash device and for the case where Zephyr and mcuboot are on different flash devices.
