### PR TITLE
Enable PSA Crypto API tests in the simulator

### DIFF
--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -31,6 +31,7 @@ direct-xip = ["mcuboot-sys/direct-xip"]
 downgrade-prevention = ["mcuboot-sys/downgrade-prevention"]
 max-align-32 = ["mcuboot-sys/max-align-32"]
 hw-rollback-protection = ["mcuboot-sys/hw-rollback-protection"]
+psa-crypto-api = ["mcuboot-sys/psa-crypto-api"]
 
 [dependencies]
 byteorder = "1.4"

--- a/sim/mcuboot-sys/Cargo.toml
+++ b/sim/mcuboot-sys/Cargo.toml
@@ -86,6 +86,9 @@ max-align-32 = []
 # Enable hardware rollback protection
 hw-rollback-protection = []
 
+# Enable the PSA Crypto APIs where supported for cryptography related operations.
+psa-crypto-api = []
+
 [build-dependencies]
 cc = "1.0.25"
 

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 
 fn main() {
     // Feature flags.
+    let psa_crypto_api = env::var("CARGO_FEATURE_PSA_CRYPTO_API").is_ok();
     let sig_rsa = env::var("CARGO_FEATURE_SIG_RSA").is_ok();
     let sig_rsa3072 = env::var("CARGO_FEATURE_SIG_RSA3072").is_ok();
     let sig_ecdsa = env::var("CARGO_FEATURE_SIG_ECDSA").is_ok();
@@ -85,6 +86,66 @@ fn main() {
     if vec![sig_rsa, sig_rsa3072, sig_ecdsa, sig_ed25519].iter()
         .fold(0, |sum, &v| sum + v as i32) > 1 {
         panic!("mcuboot does not support more than one sig type at the same time");
+    }
+
+    if psa_crypto_api {
+        if sig_ecdsa || enc_ec256 || enc_x25519 ||
+                enc_aes256_ec256 || sig_ecdsa_mbedtls || enc_aes256_x25519 ||
+                enc_kw  || enc_aes256_kw {
+            conf.file("csupport/psa_crypto_init_stub.c");
+        } else {
+            conf.conf.define("MCUBOOT_USE_PSA_CRYPTO", None);
+            conf.file("../../ext/mbedtls/library/aes.c");
+            conf.file("../../ext/mbedtls/library/aesni.c");
+            conf.file("../../ext/mbedtls/library/aria.c");
+            conf.file("../../ext/mbedtls/library/asn1write.c");
+            conf.file("../../ext/mbedtls/library/base64.c");
+            conf.file("../../ext/mbedtls/library/camellia.c");
+            conf.file("../../ext/mbedtls/library/ccm.c");
+            conf.file("../../ext/mbedtls/library/chacha20.c");
+            conf.file("../../ext/mbedtls/library/chachapoly.c");
+            conf.file("../../ext/mbedtls/library/cipher.c");
+            conf.file("../../ext/mbedtls/library/cipher_wrap.c");
+            conf.file("../../ext/mbedtls/library/ctr_drbg.c");
+            conf.file("../../ext/mbedtls/library/des.c");
+            conf.file("../../ext/mbedtls/library/ecdsa.c");
+            conf.file("../../ext/mbedtls/library/ecp.c");
+            conf.file("../../ext/mbedtls/library/ecp_curves.c");
+            conf.file("../../ext/mbedtls/library/entropy.c");
+            conf.file("../../ext/mbedtls/library/entropy_poll.c");
+            conf.file("../../ext/mbedtls/library/gcm.c");
+            conf.file("../../ext/mbedtls/library/md5.c");
+            conf.file("../../ext/mbedtls/library/nist_kw.c");
+            conf.file("../../ext/mbedtls/library/oid.c");
+            conf.file("../../ext/mbedtls/library/pem.c");
+            conf.file("../../ext/mbedtls/library/pk.c");
+            conf.file("../../ext/mbedtls/library/pkcs5.c");
+            conf.file("../../ext/mbedtls/library/pkcs12.c");
+            conf.file("../../ext/mbedtls/library/pkparse.c");
+            conf.file("../../ext/mbedtls/library/pk_wrap.c");
+            conf.file("../../ext/mbedtls/library/pkwrite.c");
+            conf.file("../../ext/mbedtls/library/poly1305.c");
+            conf.file("../../ext/mbedtls/library/psa_crypto.c");
+            conf.file("../../ext/mbedtls/library/psa_crypto_cipher.c");
+            conf.file("../../ext/mbedtls/library/psa_crypto_client.c");
+            conf.file("../../ext/mbedtls/library/psa_crypto_driver_wrappers.c");
+            conf.file("../../ext/mbedtls/library/psa_crypto_ecp.c");
+            conf.file("../../ext/mbedtls/library/psa_crypto_hash.c");
+            conf.file("../../ext/mbedtls/library/psa_crypto_mac.c");
+            conf.file("../../ext/mbedtls/library/psa_crypto_rsa.c");
+            conf.file("../../ext/mbedtls/library/psa_crypto_slot_management.c");
+            conf.file("../../ext/mbedtls/library/psa_crypto_storage.c");
+            conf.file("../../ext/mbedtls/library/psa_its_file.c");
+            conf.file("../../ext/mbedtls/library/ripemd160.c");
+            conf.file("../../ext/mbedtls/library/rsa_alt_helpers.c");
+            conf.file("../../ext/mbedtls/library/sha1.c");
+            conf.file("../../ext/mbedtls/library/sha512.c");
+            conf.file("../../ext/mbedtls/tests/src/random.c");
+            conf.conf.include("../../ext/mbedtls/library");
+        }
+
+        conf.conf.include("../../ext/mbedtls/tests/include/");
+        conf.file("../../ext/mbedtls/tests/src/fake_external_rng_for_test.c");
     }
 
     if sig_rsa || sig_rsa3072 {

--- a/sim/mcuboot-sys/csupport/config-add-psa-crypto.h
+++ b/sim/mcuboot-sys/csupport/config-add-psa-crypto.h
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Arm Limited
+ */
+
+#ifndef MCUBOOT_MBEDTLS_CONFIG_ADD_PSA_CRYPTO_H
+#define MCUBOOT_MBEDTLS_CONFIG_ADD_PSA_CRYPTO_H
+
+#include "mbedtls/build_info.h"
+
+/* Enable PSA Crypto Core without support for the permanent storage
+ * Don't define MBEDTLS_PSA_CRYPTO_STORAGE_C to make sure that support
+ * for permanent keys is not enabled, as it is not usually required during boot
+ */
+#define MBEDTLS_PSA_CRYPTO_C
+#define MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
+
+#if defined(MCUBOOT_ENCRYPT_RSA) || defined(MCUBOOT_SIGN_RSA)
+    #define MBEDTLS_PK_C
+    #define MBEDTLS_CTR_DRBG_C
+    #define MBEDTLS_CIPHER_C
+    #define MBEDTLS_ENTROPY_C
+    #define MBEDTLS_PK_PARSE_C
+    #define MBEDTLS_PK_WRITE_C
+#endif /* MCUBOOT_ENCRYPT_RSA || MCUBOOT_SIGN_RSA */
+
+#if defined(MCUBOOT_ENCRYPT_EC256) || defined(MCUBOOT_ENCRYPT_X25519)
+    #define MBEDTLS_PLATFORM_FREE_MACRO free
+    #define MBEDTLS_PLATFORM_CALLOC_MACRO calloc
+#endif /* MCUBOOT_ENCRYPT_EC256 || MCUBOOT_ENCRYPT_X25519 */
+
+#if !defined(MCUBOOT_ENCRYPT_X25519)
+    #define MBEDTLS_PSA_BUILTIN_CIPHER 1
+#endif /* MCUBOOT_ENCRYPT_X25519 */
+
+#if defined(MCUBOOT_ENCRYPT_KW)
+    #define MBEDTLS_PSA_CRYPTO_CONFIG
+    #define MBEDTLS_POLY1305_C
+#endif /* MCUBOOT_ENCRYPT_KW */
+
+#if MBEDTLS_VERSION_NUMBER == 0x03000000
+/* This PSA define is available only with more recent versions of 3.x */
+#define PSA_KEY_ID_NULL                         ((psa_key_id_t)0)   // not overly happy with this being here
+#endif /* MBEDTLS_VERSION_NUMBER == 0x03000000 */
+
+#endif /* MCUBOOT_MBEDTLS_CONFIG_ADD_PSA_CRYPTO_H */

--- a/sim/mcuboot-sys/csupport/config-rsa-kw.h
+++ b/sim/mcuboot-sys/csupport/config-rsa-kw.h
@@ -1,7 +1,7 @@
 /*
  *  Minimal configuration for using TLS in the bootloader
  *
- *  Copyright (C) 2006-2021, ARM Limited, All Rights Reserved
+ *  Copyright (C) 2006-2023, ARM Limited, All Rights Reserved
  *  Copyright (C) 2016, Linaro Ltd
  *  SPDX-License-Identifier: Apache-2.0
  *
@@ -28,6 +28,10 @@
 
 #ifndef MCUBOOT_MBEDTLS_CONFIG_RSA_KW
 #define MCUBOOT_MBEDTLS_CONFIG_RSA_KW
+
+#if defined(MCUBOOT_USE_PSA_CRYPTO)
+#include "config-add-psa-crypto.h"
+#endif /* defined(MCUBOOT_USE_PSA_CRYPTO) */
 
 #ifdef CONFIG_MCUBOOT_SERIAL
 /* Mcuboot uses mbedts-base64 for serial protocol encoding. */

--- a/sim/mcuboot-sys/csupport/config-rsa.h
+++ b/sim/mcuboot-sys/csupport/config-rsa.h
@@ -1,7 +1,7 @@
 /*
  *  Minimal configuration for using TLS in the bootloader
  *
- *  Copyright (C) 2006-2021, ARM Limited, All Rights Reserved
+ *  Copyright (C) 2006-2023, ARM Limited, All Rights Reserved
  *  Copyright (C) 2016, Linaro Ltd
  *  SPDX-License-Identifier: Apache-2.0
  *
@@ -28,6 +28,10 @@
 
 #ifndef MCUBOOT_MBEDTLS_CONFIG_RSA
 #define MCUBOOT_MBEDTLS_CONFIG_RSA
+
+#if defined(MCUBOOT_USE_PSA_CRYPTO)
+#include "config-add-psa-crypto.h"
+#endif
 
 #ifdef CONFIG_MCUBOOT_SERIAL
 /* Mcuboot uses mbedts-base64 for serial protocol encoding. */
@@ -66,9 +70,6 @@
 #define MBEDTLS_SHA256_C
 #define MBEDTLS_SHA224_C
 #define MBEDTLS_AES_C
-
-/* Save RAM by adjusting to our exact needs */
-#define MBEDTLS_ECP_MAX_BITS             2048
 
 #if (CONFIG_BOOT_SIGNATURE_TYPE_RSA_LEN == 3072)
 #define MBEDTLS_MPI_MAX_SIZE              384

--- a/sim/mcuboot-sys/csupport/psa_crypto_init_stub.c
+++ b/sim/mcuboot-sys/csupport/psa_crypto_init_stub.c
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Arm Limited
+ */
+
+/* This file, and the methods within are required when PSA Crypto API is enabled
+ * (--features psa-crypto-api), but the selected combination of features does
+ * not rely on any PSA Crypto APIs, and will not be adding any of them to the build.
+ */
+
+#include <bootutil/bootutil_log.h>
+
+int psa_crypto_init()
+{
+    BOOT_LOG_SIM("psa_crypto_init() is being stubbed.\n");
+    return 0;
+}
+
+void mbedtls_test_enable_insecure_external_rng(){
+    BOOT_LOG_SIM("mbedtls_test_enable_insecure_external_rng() is being stubbed.\n");
+}


### PR DESCRIPTION
In this PR, code is introduced to allow the simulator to interface with PSA Crypto functionality. When enabled with `--features psa-crypto-api`, the simulator will use all possible PSA enabled functions, and where PSA functionality is not available, will continue to use MBed TLS functions. 