### PR TITLE
boot: zephyr: setup watchdog

### DIFF
--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -287,20 +287,7 @@
 #error "No NRFX WDT instances enabled"
 #endif /* defined(CONFIG_NRFX_WDT0) && defined(CONFIG_NRFX_WDT1) */
 
-#elif CONFIG_IWDG_STM32 /* CONFIG_NRFX_WDT */
-#include <zephyr/device.h>
-#include <zephyr/drivers/watchdog.h>
-
-#define MCUBOOT_WATCHDOG_FEED() \
-    do {                        \
-        const struct device* wdt =                                  \
-            DEVICE_DT_GET_OR_NULL(DT_INST(0, st_stm32_watchdog));   \
-        if (device_is_ready(wdt)) {                                 \
-            wdt_feed(wdt, 0);                                       \
-        }                                                           \
-    } while (0)
-
-#elif DT_NODE_HAS_STATUS(DT_ALIAS(watchdog0), okay) /* CONFIG_IWDG_STM32 */
+#elif DT_NODE_HAS_STATUS(DT_ALIAS(watchdog0), okay) /* CONFIG_NRFX_WDT */
 #include <zephyr/device.h>
 #include <zephyr/drivers/watchdog.h>
 

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -304,6 +304,15 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/watchdog.h>
 
+#define MCUBOOT_WATCHDOG_SETUP()                              \
+    do {                                                      \
+        const struct device* wdt =                            \
+            DEVICE_DT_GET(DT_ALIAS(watchdog0));               \
+        if (device_is_ready(wdt)) {                           \
+            wdt_setup(wdt, 0);                                \
+        }                                                     \
+    } while (0)
+
 #define MCUBOOT_WATCHDOG_FEED()                               \
     do {                                                      \
         const struct device* wdt =                            \
@@ -325,6 +334,10 @@
     } while (0)
 
 #endif /* CONFIG_BOOT_WATCHDOG_FEED */
+
+#ifndef MCUBOOT_WATCHDOG_SETUP
+#define MCUBOOT_WATCHDOG_SETUP()
+#endif
 
 #define MCUBOOT_CPU_IDLE() \
   if (!IS_ENABLED(CONFIG_MULTITHREADING)) { \

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -509,6 +509,7 @@ void main(void)
     uint32_t reset_cause;
 #endif
 
+    MCUBOOT_WATCHDOG_SETUP();
     MCUBOOT_WATCHDOG_FEED();
 
 #if !defined(MCUBOOT_DIRECT_XIP)


### PR DESCRIPTION
The Zephyr watchdog API defines a setup function. This function needs to be executed before the watchdog is functional in some cases. This commit adds MCUBOOT_WATCHDOG_SETUP when using the generic watchdog0 alias otherwise it is an empty define.

Fixes https://github.com/mcu-tools/mcuboot/issues/1659