### PR TITLE
boot_serial: Fix include paths for zephyr builds

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -26,7 +26,6 @@
 #include "sysflash/sysflash.h"
 
 #include "bootutil/bootutil_log.h"
-#include "zcbor_encode.h"
 
 #ifdef __ZEPHYR__
 #include <zephyr/sys/reboot.h>
@@ -37,13 +36,16 @@
 #include <zephyr/sys/crc.h>
 #include <zephyr/sys/base64.h>
 #include <hal/hal_flash.h>
+#include <zcbor_encode.h>
 #elif __ESPRESSIF__
+#include "zcbor_encode.h"
 #include <bootloader_utility.h>
 #include <esp_rom_sys.h>
 #include <esp_crc.h>
 #include <endian.h>
 #include <mbedtls/base64.h>
 #else
+#include "zcbor_encode.h"
 #include <bsp/bsp.h>
 #include <hal/hal_system.h>
 #include <hal/hal_flash.h>

--- a/boot/boot_serial/src/serial_recovery_cbor.c
+++ b/boot/boot_serial/src/serial_recovery_cbor.c
@@ -15,7 +15,13 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
+
+#ifdef __ZEPHYR__
+#include <zcbor_decode.h>
+#else
 #include "zcbor_decode.h"
+#endif
+
 #include "serial_recovery_cbor.h"
 
 #if DEFAULT_MAX_QTY != 3

--- a/boot/boot_serial/src/serial_recovery_cbor.h
+++ b/boot/boot_serial/src/serial_recovery_cbor.h
@@ -18,7 +18,13 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
+
+#ifdef __ZEPHYR__
+#include <zcbor_decode.h>
+#else
 #include "zcbor_decode.h"
+#endif
+
 #include "serial_recovery_cbor_types.h"
 
 #if DEFAULT_MAX_QTY != 3

--- a/boot/boot_serial/src/serial_recovery_cbor_types.h
+++ b/boot/boot_serial/src/serial_recovery_cbor_types.h
@@ -18,7 +18,12 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
+
+#ifdef __ZEPHYR__
+#include <zcbor_decode.h>
+#else
 #include "zcbor_decode.h"
+#endif
 
 /** Which value for --default-max-qty this file was created with.
  *

--- a/boot/boot_serial/src/serial_recovery_echo.c
+++ b/boot/boot_serial/src/serial_recovery_echo.c
@@ -8,7 +8,13 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
+
+#ifdef __ZEPHYR__
+#include <zcbor_decode.h>
+#else
 #include "zcbor_decode.h"
+#endif
+
 #include "serial_recovery_echo.h"
 
 #if DEFAULT_MAX_QTY != 3

--- a/boot/boot_serial/src/serial_recovery_echo.h
+++ b/boot/boot_serial/src/serial_recovery_echo.h
@@ -11,7 +11,13 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
+
+#ifdef __ZEPHYR__
+#include <zcbor_decode.h>
+#else
 #include "zcbor_decode.h"
+#endif
+
 #include "serial_recovery_echo_types.h"
 
 #if DEFAULT_MAX_QTY != 3

--- a/boot/boot_serial/src/serial_recovery_echo_types.h
+++ b/boot/boot_serial/src/serial_recovery_echo_types.h
@@ -11,7 +11,12 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
+
+#ifdef __ZEPHYR__
+#include <zcbor_decode.h>
+#else
 #include "zcbor_decode.h"
+#endif
 
 /** Which value for --default-max-qty this file was created with.
  *


### PR DESCRIPTION
Fixes include paths for zephyr builds to use the system zcbor_* files rather than the local files.