### PR TITLE
zephyr: serial_recovery: Fix broken CDC device selection

### DIFF
--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -199,17 +199,21 @@ boot_uart_fifo_getline(char **line)
 static int
 boot_uart_fifo_init(void)
 {
+
+#if defined(CONFIG_BOOT_SERIAL_UART)
+
 #if DT_HAS_CHOSEN(zephyr_uart_mcumgr)
 	uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_uart_mcumgr));
 #else
-
-#if defined(CONFIG_BOOT_SERIAL_UART)
 	uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+#endif
+
 #elif defined(CONFIG_BOOT_SERIAL_CDC_ACM)
         uart_dev = DEVICE_DT_GET_ONE(zephyr_cdc_acm_uart);
+#else
+#error No serial recovery device selected
 #endif
 
-#endif
 
 	if (!device_is_ready(uart_dev)) {
 		return (-1);


### PR DESCRIPTION
When using CDC only and CONFIG_SERIAL is not enabled in Zephyr, but there is chosen zephyr,mcumgr-uart, the chosen takes precedence over CDC and directs MCUmgr to that uart. This causes two issues: first the CDC is ignored if chosen exists, and makes build fail because drivers are not built.