### PR TITLE
fix FIH return value for EC256 and add FIH for ED25519

### DIFF
--- a/boot/bootutil/src/image_ec256.c
+++ b/boot/bootutil/src/image_ec256.c
@@ -35,7 +35,7 @@
 #include "bootutil/fault_injection_hardening.h"
 #include "bootutil/crypto/ecdsa_p256.h"
 
-fih_int
+fih_ret
 bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
                     uint8_t key_id)
 {
@@ -51,11 +51,16 @@ bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
 
     rc = bootutil_ecdsa_p256_parse_public_key(&ctx, &pubkey, end);
     if (rc) {
-        FIH_SET(fih_rc, FIH_FAILURE);
-        FIH_RET(fih_rc);
+        goto out;
     }
 
-    FIH_CALL(bootutil_ecdsa_p256_verify, fih_rc, &ctx, pubkey, end-pubkey, hash, hlen, sig, slen);
+    rc = bootutil_ecdsa_p256_verify(&ctx, pubkey, end-pubkey, hash, hlen, sig, slen);
+    fih_rc = fih_ret_encode_zero_equality(rc);
+    if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
+        FIH_SET(fih_rc, FIH_FAILURE);
+    }
+
+out:
     bootutil_ecdsa_p256_drop(&ctx);
 
     FIH_RET(fih_rc);

--- a/boot/bootutil/src/image_ed25519.c
+++ b/boot/bootutil/src/image_ed25519.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (c) 2019 JUUL Labs
- * Copyright (c) 2021 Arm Limited
+ * Copyright (c) 2021-2023 Arm Limited
  */
 
 #include <string.h>
@@ -64,16 +64,18 @@ bootutil_import_key(uint8_t **cp, uint8_t *end)
     return 0;
 }
 
-int
+fih_ret
 bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
   uint8_t key_id)
 {
     int rc;
+    FIH_DECLARE(fih_rc, FIH_FAILURE);
     uint8_t *pubkey;
     uint8_t *end;
 
     if (hlen != 32 || slen != 64) {
-        return -1;
+        FIH_SET(fih_rc, FIH_FAILURE);
+        goto out;
     }
 
     pubkey = (uint8_t *)bootutil_keys[key_id].key;
@@ -81,15 +83,22 @@ bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
 
     rc = bootutil_import_key(&pubkey, end);
     if (rc) {
-        return -1;
+        FIH_SET(fih_rc, FIH_FAILURE);
+        goto out;
     }
 
     rc = ED25519_verify(hash, 32, sig, pubkey);
+
     if (rc == 0) {
-        return -2;
+        /* if verify returns 0, there was an error. */
+        FIH_SET(fih_rc, FIH_FAILURE);
+        goto out;
     }
 
-    return 0;
+    FIH_SET(fih_rc, FIH_SUCCESS);
+out:
+
+    FIH_RET(fih_rc);
 }
 
 #endif /* MCUBOOT_SIGN_ED25519 */


### PR DESCRIPTION
There was an issue with bootutil_verify_sig for EC256 when the return type was not correct when FIH was enabled. ED25519 FIH support has also been added. 