### PR TITLE
boot: bootutil: Add boot information

### DIFF
--- a/boot/bootutil/include/bootutil/boot_record.h
+++ b/boot/bootutil/include/bootutil/boot_record.h
@@ -59,13 +59,17 @@ int boot_save_boot_status(uint8_t sw_module,
  * Add application specific data to the shared memory area between the
  * bootloader and runtime SW.
  *
- * @param[in]  hdr        Pointer to the image header stored in RAM.
- * @param[in]  fap        Pointer to the flash area where image is stored.
+ * @param[in]  hdr           Pointer to the image header stored in RAM.
+ * @param[in]  fap           Pointer to the flash area where image is stored.
+ * @param[in]  slot          The currently active slot being booted.
+ * @param[in]  max_app_size  The maximum size of an image that can be loaded.
  *
- * @return                0 on success; nonzero on failure.
+ * @return                    0 on success; nonzero on failure.
  */
 int boot_save_shared_data(const struct image_header *hdr,
-                          const struct flash_area *fap);
+                          const struct flash_area *fap,
+                          const uint8_t active_slot,
+                          const int max_app_size);
 
 #ifdef __cplusplus
 }

--- a/boot/bootutil/include/bootutil/boot_record.h
+++ b/boot/bootutil/include/bootutil/boot_record.h
@@ -25,6 +25,16 @@
 extern "C" {
 #endif
 
+/** Error codes for using the shared memory area. */
+enum shared_memory_status {
+    SHARED_MEMORY_OK           = 0,
+    SHARED_MEMORY_OVERFLOW,
+    SHARED_MEMORY_OVERWRITE,
+    SHARED_MEMORY_GEN_ERROR,
+    SHARED_MEMORY_WRITE_ERROR,
+    SHARED_MEMORY_READ_ERROR,
+};
+
 /**
  * @brief Add a data item to the shared data area between bootloader and
  *        runtime SW

--- a/boot/bootutil/include/bootutil/boot_status.h
+++ b/boot/bootutil/include/bootutil/boot_status.h
@@ -85,6 +85,7 @@ extern "C" {
  * consumer of shared data in runtime SW.
  */
 #define TLV_MAJOR_IAS      0x1
+#define TLV_MAJOR_BLINFO   0x2
 
 /* Initial attestation: Claim per SW components / SW modules */
 /* Bits: 0-2 */
@@ -105,6 +106,36 @@ extern "C" {
 #define GET_IAS_CLAIM(tlv_type)  (GET_MINOR(tlv_type) & CLAIM_MASK)
 #define SET_IAS_MINOR(sw_module, claim) \
         (((uint16_t)(sw_module) << MODULE_POS) | (claim))
+
+/* Bootloader information */
+#define BLINFO_MODE                 0x00
+#define BLINFO_SIGNATURE_TYPE       0x01
+#define BLINFO_RECOVERY             0x02
+#define BLINFO_RUNNING_SLOT         0x03
+#define BLINFO_BOOTLOADER_VERSION   0x04
+#define BLINFO_MAX_APPLICATION_SIZE 0x05
+
+enum mcuboot_mode {
+    MCUBOOT_MODE_SINGLE_SLOT,
+    MCUBOOT_MODE_SWAP_USING_SCRATCH,
+    MCUBOOT_MODE_UPGRADE_ONLY,
+    MCUBOOT_MODE_SWAP_USING_MOVE,
+    MCUBOOT_MODE_DIRECT_XIP,
+    MCUBOOT_MODE_RAM_LOAD
+};
+
+enum mcuboot_signature_type {
+    MCUBOOT_SIGNATURE_TYPE_NONE,
+    MCUBOOT_SIGNATURE_TYPE_RSA,
+    MCUBOOT_SIGNATURE_TYPE_ECDSA_P256,
+    MCUBOOT_SIGNATURE_TYPE_ED25519
+};
+
+enum mcuboot_recovery_mode {
+    MCUBOOT_RECOVERY_MODE_NONE,
+    MCUBOOT_RECOVERY_MODE_SERIAL_RECOVERY,
+    MCUBOOT_RECOVERY_MODE_DFU,
+};
 
 /**
  * Shared data TLV header.  All fields in little endian.

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -542,4 +542,26 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
     flash_area_close(fap_sec);
 }
 
+int app_max_size(struct boot_loader_state *state)
+{
+    uint32_t sz = 0;
+    uint32_t sector_sz;
+    uint32_t trailer_sz;
+    uint32_t first_trailer_idx;
+
+    sector_sz = boot_img_sector_size(state, BOOT_PRIMARY_SLOT, 0);
+    trailer_sz = boot_trailer_sz(BOOT_WRITE_SZ(state));
+    first_trailer_idx = boot_img_num_sectors(state, BOOT_PRIMARY_SLOT) - 1;
+
+    while (1) {
+        sz += sector_sz;
+        if  (sz >= trailer_sz) {
+            break;
+        }
+        first_trailer_idx--;
+    }
+
+    return (first_trailer_idx * sector_sz);
+}
+
 #endif

--- a/boot/bootutil/src/swap_priv.h
+++ b/boot/bootutil/src/swap_priv.h
@@ -101,4 +101,9 @@ static inline size_t boot_scratch_area_size(const struct boot_loader_state *stat
 
 #endif /* defined(MCUBOOT_SWAP_USING_SCRATCH) || defined(MCUBOOT_SWAP_USING_MOVE) */
 
+/**
+ * Returns the maximum size of an application that can be loaded to a slot.
+ */
+int app_max_size(struct boot_loader_state *state);
+
 #endif /* H_SWAP_PRIV_ */

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -743,6 +743,118 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
 }
 #endif /* !MCUBOOT_OVERWRITE_ONLY */
 
+int app_max_size(struct boot_loader_state *state)
+{
+    size_t num_sectors_primary;
+    size_t num_sectors_secondary;
+    size_t sz0, sz1;
+    size_t primary_slot_sz, secondary_slot_sz;
+#ifndef MCUBOOT_OVERWRITE_ONLY
+    size_t scratch_sz;
+#endif
+    size_t i, j;
+    int8_t smaller;
+
+    num_sectors_primary = boot_img_num_sectors(state, BOOT_PRIMARY_SLOT);
+    num_sectors_secondary = boot_img_num_sectors(state, BOOT_SECONDARY_SLOT);
+
+#ifndef MCUBOOT_OVERWRITE_ONLY
+    scratch_sz = boot_scratch_area_size(state);
+#endif
+
+    /*
+     * The following loop scans all sectors in a linear fashion, assuring that
+     * for each possible sector in each slot, it is able to fit in the other
+     * slot's sector or sectors. Slot's should be compatible as long as any
+     * number of a slot's sectors are able to fit into another, which only
+     * excludes cases where sector sizes are not a multiple of each other.
+     */
+    i = sz0 = primary_slot_sz = 0;
+    j = sz1 = secondary_slot_sz = 0;
+    smaller = 0;
+    while (i < num_sectors_primary || j < num_sectors_secondary) {
+        if (sz0 == sz1) {
+            sz0 += boot_img_sector_size(state, BOOT_PRIMARY_SLOT, i);
+            sz1 += boot_img_sector_size(state, BOOT_SECONDARY_SLOT, j);
+            i++;
+            j++;
+        } else if (sz0 < sz1) {
+            sz0 += boot_img_sector_size(state, BOOT_PRIMARY_SLOT, i);
+            /* Guarantee that multiple sectors of the secondary slot
+             * fit into the primary slot.
+             */
+            if (smaller == 2) {
+                BOOT_LOG_WRN("Cannot upgrade: slots have non-compatible sectors");
+                return 0;
+            }
+            smaller = 1;
+            i++;
+        } else {
+            sz1 += boot_img_sector_size(state, BOOT_SECONDARY_SLOT, j);
+            /* Guarantee that multiple sectors of the primary slot
+             * fit into the secondary slot.
+             */
+            if (smaller == 1) {
+                BOOT_LOG_WRN("Cannot upgrade: slots have non-compatible sectors");
+                return 0;
+            }
+            smaller = 2;
+            j++;
+        }
+#ifndef MCUBOOT_OVERWRITE_ONLY
+        if (sz0 == sz1) {
+            primary_slot_sz += sz0;
+            secondary_slot_sz += sz1;
+            /* Scratch has to fit each swap operation to the size of the larger
+             * sector among the primary slot and the secondary slot.
+             */
+            if (sz0 > scratch_sz || sz1 > scratch_sz) {
+                BOOT_LOG_WRN("Cannot upgrade: not all sectors fit inside scratch");
+                return 0;
+            }
+            smaller = sz0 = sz1 = 0;
+        }
+#endif
+    }
+
+#ifdef MCUBOOT_OVERWRITE_ONLY
+    return (sz1 < sz0 ? sz1 : sz0);
+#else
+    return (secondary_slot_sz < primary_slot_sz ? secondary_slot_sz : primary_slot_sz);
+#endif
+}
+#else
+int app_max_size(struct boot_loader_state *state)
+{
+    const struct flash_area *fap;
+    int fa_id;
+    int rc;
+    uint32_t active_slot;
+    int primary_sz, secondary_sz;
+
+    active_slot = state->slot_usage[BOOT_CURR_IMG(state)].active_slot;
+
+    fa_id = flash_area_id_from_multi_image_slot(BOOT_CURR_IMG(state), active_slot);
+    rc = flash_area_open(fa_id, &fap);
+    assert(rc == 0);
+    primary_sz = flash_area_get_size(fap);
+    flash_area_close(fap);
+
+    if (active_slot == BOOT_PRIMARY_SLOT) {
+        active_slot = BOOT_SECONDARY_SLOT;
+    } else {
+        active_slot = BOOT_PRIMARY_SLOT;
+    }
+
+    fa_id = flash_area_id_from_multi_image_slot(BOOT_CURR_IMG(state), active_slot);
+    rc = flash_area_open(fa_id, &fap);
+    assert(rc == 0);
+    secondary_sz = flash_area_get_size(fap);
+    flash_area_close(fap);
+
+    return (secondary_sz < primary_sz ? secondary_sz : primary_sz);
+}
+
 #endif /* !MCUBOOT_DIRECT_XIP && !MCUBOOT_RAM_LOAD */
 
 #endif /* !MCUBOOT_SWAP_USING_MOVE */

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -217,6 +217,15 @@
 #define MCUBOOT_SERIAL_IMG_GRP_IMAGE_STATE
 #endif
 
+#ifdef CONFIG_MCUBOOT_SERIAL
+#define MCUBOOT_SERIAL_RECOVERY
+#endif
+
+#if (defined(CONFIG_BOOT_USB_DFU_WAIT) || \
+     defined(CONFIG_BOOT_USB_DFU_GPIO))
+#define MCUBOOT_USB_DFU
+#endif
+
 /*
  * The option enables code, currently in boot_serial, that attempts
  * to erase flash progressively, as update fragments are received,

--- a/docs/design.md
+++ b/docs/design.md
@@ -1360,7 +1360,12 @@ specific data using the same shared data area as for the measured boot. For
 this, the target must provide a definition for the `boot_save_shared_data()`
 function which is declared in `boot/bootutil/include/bootutil/boot_record.h`.
 The `boot_add_data_to_shared_area()` function can be used for adding new TLV
-entries to the shared data area.
+entries to the shared data area. Alternatively, setting the
+`MCUBOOT_DATA_SHARING_BOOTINFO` option will provide a default function for
+this which saves information such as the maximum application size, bootloader
+version (if available), running slot number, if recovery is part of MCUboot
+and the signature type. Details of the TLVs for this information can be found
+in `boot/bootutil/include/bootutil/boot_status.h` with `BLINFO_` prefixes.
 
 ## [Testing in CI](#testing-in-ci)
 

--- a/docs/release-notes.d/data-sharing.md
+++ b/docs/release-notes.d/data-sharing.md
@@ -1,0 +1,2 @@
+- Added currently running slot ID and maximum application size to
+  shared data function definition.


### PR DESCRIPTION
Adds TLV defines and optional function for use with the bootloader shared data feature.
