### PR TITLE
zephyr: Stay in serial recovery by default if no application

### DIFF
--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -187,6 +187,7 @@ config BOOT_SERIAL_BOOT_MODE
 
 config BOOT_SERIAL_NO_APPLICATION
 	bool "Stay in bootloader if no application"
+	default y
 	help
 	  Allows for entering serial recovery mode if there is no bootable
 	  application that the bootloader can jump to.


### PR DESCRIPTION
This enables the serial recovery no application boot entrance method by default which means that if there is no application that can be booted, the device will remain in serial recovery mode instead of locking up with a fatal error.


Open for comments on if this is a good/bad idea.