### PR TITLE
zephyr: fix link to Zephyr application docs

### DIFF
--- a/samples/zephyr/hello-world/CMakeLists.txt
+++ b/samples/zephyr/hello-world/CMakeLists.txt
@@ -12,7 +12,7 @@
 cmake_minimum_required(VERSION 3.8)
 
 # find_package(Zephyr) in order to load application boilerplate:
-# http://docs.zephyrproject.org/application/application.html
+# https://docs.zephyrproject.org/latest/develop/application/index.html
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(NONE)
 


### PR DESCRIPTION
Updates a broken link to Zephyr application docs in the hello-world example.