### PR TITLE
sim: Increase test coverage for ram-load

### DIFF
--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -44,6 +44,8 @@ jobs:
         - "sig-rsa validate-primary-slot ram-load multiimage"
         - "sig-rsa validate-primary-slot direct-xip multiimage"
         - "sig-ecdsa hw-rollback-protection multiimage"
+        - "ram-load enc-aes256-kw multiimage"
+        - "ram-load enc-aes256-kw sig-ecdsa-mbedtls multiimage"
     runs-on: ubuntu-latest
     env:
       MULTI_FEATURES: ${{ matrix.features }}

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1835,8 +1835,11 @@ fn install_image(flash: &mut SimMultiFlash, slot: &SlotInfo, len: ImageSize,
     // an encrypted image, re-read to use for verification, erase + flash
     // un-encrypted. In the secondary slot the image is written un-encrypted,
     // and if encryption is requested, it follows an erase + flash encrypted.
-
-    if slot.index == 0 {
+    //
+    // In the case of ram-load when encryption is enabled both slots have to
+    // be encrypted so in the event when the image is in the primary slot
+    // the verification will fail as the image is not encrypted.
+    if slot.index == 0 && !Caps::RamLoad.present() {
         let enc_copy: Option<Vec<u8>>;
 
         if is_encrypted {

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-2019 Linaro LTD
 // Copyright (c) 2017-2019 JUUL Labs
-// Copyright (c) 2019 Arm Limited
+// Copyright (c) 2019-2023 Arm Limited
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -30,6 +30,7 @@ pub use crate::{
     image::{
         ImagesBuilder,
         Images,
+        ImageManipulation,
         show_sizes,
     },
 };
@@ -201,7 +202,7 @@ impl RunStatus {
 
         failed |= bad_secondary_slot_image.run_signfail_upgrade();
 
-        let images = run.clone().make_no_upgrade_image(&NO_DEPS);
+        let images = run.clone().make_no_upgrade_image(&NO_DEPS, ImageManipulation::None);
         failed |= images.run_norevert_newimage();
 
         let images = run.make_image(&NO_DEPS, true);

--- a/sim/src/tlv.rs
+++ b/sim/src/tlv.rs
@@ -112,6 +112,10 @@ pub trait ManifestGen {
 
     /// Set the security counter to the specified value.
     fn set_security_counter(&mut self, security_cnt: Option<u32>);
+
+    /// Sets the ignore_ram_load_flag so that can be validated when it is missing,
+    /// it will not load successfully.
+    fn set_ignore_ram_load_flag(&mut self);
 }
 
 #[derive(Debug, Default)]
@@ -124,6 +128,8 @@ pub struct TlvGen {
     /// Should this signature be corrupted.
     gen_corrupted: bool,
     security_cnt: Option<u32>,
+    /// Ignore RAM_LOAD flag
+    ignore_ram_load_flag: bool,
 }
 
 #[derive(Debug)]
@@ -318,7 +324,7 @@ impl ManifestGen for TlvGen {
     /// Retrieve the header flags for this configuration.  This can be called at any time.
     fn get_flags(&self) -> u32 {
         // For the RamLoad case, add in the flag for this feature.
-        if Caps::RamLoad.present() {
+        if Caps::RamLoad.present() && !self.ignore_ram_load_flag {
             self.flags | (TlvFlags::RAM_LOAD as u32)
         } else {
             self.flags
@@ -792,6 +798,10 @@ impl ManifestGen for TlvGen {
 
     fn set_security_counter(&mut self, security_cnt: Option<u32>) {
         self.security_cnt = security_cnt;
+    }
+
+    fn set_ignore_ram_load_flag(&mut self) {
+        self.ignore_ram_load_flag = true;
     }
 }
 


### PR DESCRIPTION
This PR adds new test cases to the simulator to test the ram-load feature of MCUboot. New test variations have also been added for the simulator CI.