### PR TITLE
Fix CI after mynewt update

### DIFF
--- a/ci/mynewt_install.sh
+++ b/ci/mynewt_install.sh
@@ -34,6 +34,10 @@ shallow_clone_mynewt() {
     mkdir -p repos/apache-mynewt-core
     git clone --depth=1 https://github.com/apache/mynewt-core repos/apache-mynewt-core
     [[ $? -ne 0 ]] && exit 1
+
+    # nrfx is now taken from original repository
+    git clone --depth=1 --branch v2.8.0 https://github.com/NordicSemiconductor/nrfx.git repos/nordic-nrfx
+    [[ $? -ne 0 ]] && exit 1
 }
 
 arm_toolchain_install() {


### PR DESCRIPTION
ci: mynewt: Download nrfx from separate repository

Mynewt used to have copy of nrfx.
Now nrfx is taken from original repository and since some CI targets want to build for NRF MCUs nrfx repository nees to be downloaded.