### PR TITLE
sim: Add hw rollback protection tests

### DIFF
--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -43,6 +43,7 @@ jobs:
         - "sig-rsa validate-primary-slot direct-xip"
         - "sig-rsa validate-primary-slot ram-load multiimage"
         - "sig-rsa validate-primary-slot direct-xip multiimage"
+        - "sig-ecdsa hw-rollback-protection multiimage"
     runs-on: ubuntu-latest
     env:
       MULTI_FEATURES: ${{ matrix.features }}

--- a/boot/bootutil/include/bootutil/caps.h
+++ b/boot/bootutil/include/bootutil/caps.h
@@ -50,6 +50,7 @@ uint32_t bootutil_get_caps(void);
 #define BOOTUTIL_CAP_AES256                 (1<<14)
 #define BOOTUTIL_CAP_RAM_LOAD               (1<<15)
 #define BOOTUTIL_CAP_DIRECT_XIP             (1<<16)
+#define BOOTUTIL_CAP_HW_ROLLBACK_PROT       (1<<17)
 
 /*
  * Query the number of images this bootloader is configured for.  This

--- a/boot/bootutil/src/caps.c
+++ b/boot/bootutil/src/caps.c
@@ -75,6 +75,9 @@ uint32_t bootutil_get_caps(void)
 #if defined(MCUBOOT_DIRECT_XIP)
     res |= BOOTUTIL_CAP_DIRECT_XIP;
 #endif
+#if defined(MCUBOOT_HW_ROLLBACK_PROT)
+    res |= BOOTUTIL_CAP_HW_ROLLBACK_PROT;
+#endif
 
     return res;
 }

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -494,7 +494,7 @@ bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
              * stored security counter value.
              */
             fih_rc = fih_ret_encode_zero_equality(img_security_cnt <
-                                   fih_int_decode(security_cnt));
+                                   (uint32_t)fih_int_decode(security_cnt));
             if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
                 FIH_SET(fih_rc, FIH_FAILURE);
                 goto out;

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -30,6 +30,7 @@ ram-load = ["mcuboot-sys/ram-load"]
 direct-xip = ["mcuboot-sys/direct-xip"]
 downgrade-prevention = ["mcuboot-sys/downgrade-prevention"]
 max-align-32 = ["mcuboot-sys/max-align-32"]
+hw-rollback-protection = ["mcuboot-sys/hw-rollback-protection"]
 
 [dependencies]
 byteorder = "1.4"

--- a/sim/mcuboot-sys/Cargo.toml
+++ b/sim/mcuboot-sys/Cargo.toml
@@ -83,6 +83,9 @@ downgrade-prevention = []
 # Support images with 32-byte maximum write alignment value.
 max-align-32 = []
 
+# Enable hardware rollback protection
+hw-rollback-protection = []
+
 [build-dependencies]
 cc = "1.0.25"
 

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -34,6 +34,7 @@ fn main() {
     let ram_load = env::var("CARGO_FEATURE_RAM_LOAD").is_ok();
     let direct_xip = env::var("CARGO_FEATURE_DIRECT_XIP").is_ok();
     let max_align_32 = env::var("CARGO_FEATURE_MAX_ALIGN_32").is_ok();
+    let hw_rollback_protection = env::var("CARGO_FEATURE_HW_ROLLBACK_PROTECTION").is_ok();
 
     let mut conf = CachedBuild::new();
     conf.conf.define("__BOOTSIM__", None);
@@ -73,6 +74,11 @@ fn main() {
 
     if direct_xip {
         conf.conf.define("MCUBOOT_DIRECT_XIP", None);
+    }
+
+    if hw_rollback_protection {
+        conf.conf.define("MCUBOOT_HW_ROLLBACK_PROT", None);
+        conf.file("csupport/security_cnt.c");
     }
 
     // Currently no more than one sig type can be used simultaneously.

--- a/sim/mcuboot-sys/csupport/security_cnt.c
+++ b/sim/mcuboot-sys/csupport/security_cnt.c
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2023 Arm Limited
+ */
+
+#include "bootutil/security_cnt.h"
+#include "mcuboot_config/mcuboot_logging.h"
+#include "bootutil/fault_injection_hardening.h"
+
+/*
+ * Since the simulator is executing unit tests in parallel,
+ * the storage area where the security counter values reside
+ * has to be managed per thread from Rust's side.
+ */
+#ifdef MCUBOOT_HW_ROLLBACK_PROT
+
+int sim_set_nv_counter_for_image(uint32_t image_index, uint32_t security_counter_value);
+
+int sim_get_nv_counter_for_image(uint32_t image_index, uint32_t* data);
+
+fih_ret boot_nv_security_counter_init(void) {
+    return FIH_SUCCESS;
+}
+
+fih_ret boot_nv_security_counter_get(uint32_t image_id, fih_int *security_cnt) {
+    uint32_t counter = 0;
+    FIH_DECLARE(fih_rc, FIH_FAILURE);
+    fih_rc = fih_ret_encode_zero_equality(sim_get_nv_counter_for_image(image_id, &counter));
+
+    MCUBOOT_LOG_INF("Read security counter value (%d) for image: %d\n", counter, image_id);
+    *security_cnt = fih_int_encode(counter);
+
+    FIH_RET(fih_rc);
+}
+
+int32_t boot_nv_security_counter_update(uint32_t image_id, uint32_t img_security_cnt) {
+    MCUBOOT_LOG_INF("Writing security counter value (%d) for image: %d\n", img_security_cnt, image_id);
+
+    return sim_set_nv_counter_for_image(image_id, img_security_cnt);
+}
+
+#endif /* MCUBOOT_HW_ROLLBACK_PROT */

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-2021 Linaro LTD
 // Copyright (c) 2017-2019 JUUL Labs
-// Copyright (c) 2019-2021 Arm Limited
+// Copyright (c) 2019-2023 Arm Limited
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -148,6 +148,16 @@ pub fn kw_encrypt(kek: &[u8], seckey: &[u8], keylen: u32) -> Result<Vec<u8>, &'s
         }
         Err("Failed to encrypt buffer")
     }
+}
+
+pub fn set_security_counter(image_index: u32, security_counter_value: u32) {
+    api::sim_set_nv_counter_for_image(image_index, security_counter_value);
+}
+
+pub fn get_security_counter(image_index: u32) -> u32 {
+    let mut counter_val: u32 = 0;
+    api::sim_get_nv_counter_for_image(image_index, &mut counter_val as *mut u32);
+    return counter_val;
 }
 
 mod raw {

--- a/sim/src/caps.rs
+++ b/sim/src/caps.rs
@@ -27,6 +27,7 @@ pub enum Caps {
     Aes256               = (1 << 14),
     RamLoad              = (1 << 15),
     DirectXip            = (1 << 16),
+    HwRollbackProtection = (1 << 17),
 }
 
 impl Caps {

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-2021 Linaro LTD
 // Copyright (c) 2017-2019 JUUL Labs
+// Copyright (c) 2023 Arm Limited
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -67,6 +68,8 @@ sim_test!(downgrade_prevention, make_image(&REV_DEPS, true), run_nodowngrade());
 sim_test!(direct_xip_first, make_no_upgrade_image(&NO_DEPS), run_direct_xip());
 sim_test!(ram_load_first, make_no_upgrade_image(&NO_DEPS), run_ram_load());
 sim_test!(ram_load_split, make_no_upgrade_image(&NO_DEPS), run_split_ram_load());
+sim_test!(hw_prot_failed_security_cnt_check, make_image_with_security_counter(Some(0)), run_hw_rollback_prot());
+sim_test!(hw_prot_missing_security_cnt, make_image_with_security_counter(None), run_hw_rollback_prot());
 
 // Test various combinations of incorrect dependencies.
 test_shell!(dependency_combos, r, {


### PR DESCRIPTION
This PR adds testing capabilities to the hw-rollback-protection feature of MCUboot. The non-volatile storage for the security counters is implemented on Rust's side due to the parallel nature of the tests. There is also a fix for a build error when comparing the security counter values during the simulator build. 