### PR TITLE
boot_serial: Fix issue with zcbor setup

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -135,8 +135,8 @@ static zcbor_state_t cbor_state[2];
 
 void reset_cbor_state(void)
 {
-    zcbor_new_encode_state(cbor_state, 2, (uint8_t *)bs_obuf,
-        (size_t)bs_obuf + sizeof(bs_obuf), 0);
+    zcbor_new_encode_state(cbor_state, 2, (uint8_t *)bs_obuf, sizeof(bs_obuf),
+                           0);
 }
 
 /**

--- a/docs/release-notes.d/zcbor-fix.md
+++ b/docs/release-notes.d/zcbor-fix.md
@@ -1,0 +1,3 @@
+- Fixed an issue with the boot_serial zcbor setup encoder function
+  wrongly including the buffer address in the size which caused
+  serial recovery to fail on some platforms.


### PR DESCRIPTION
    Fixes an issue with providing the wrong size to the zcbor setup
    encoder function.

Issue found by @danieldegrasse 