### PR TITLE
zephyr: single_loader: Fix typo

### DIFF
--- a/boot/zephyr/single_loader.c
+++ b/boot/zephyr/single_loader.c
@@ -350,7 +350,7 @@ decrypt_image_inplace(const struct flash_area *fa_p,
     memset(&_bs, 0, sizeof(struct boot_status));
 
     /* Get size from last sector to know page/sector erase size */
-    rc = flash_area_get_sector(fap, boot_status_off(fa_p), &sector);
+    rc = flash_area_get_sector(fa_p, boot_status_off(fa_p), &sector);
 
 
     image_index = BOOT_CURR_IMG(state);


### PR DESCRIPTION
Fixes a typo with a variable name.