### PR TITLE
zephyr: Restore default log level of info

### DIFF
--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -32,5 +32,7 @@ CONFIG_LOG=y
 CONFIG_LOG_MODE_MINIMAL=y # former CONFIG_MODE_MINIMAL
 ### Ensure Zephyr logging changes don't use more resources
 CONFIG_LOG_DEFAULT_LEVEL=0
+### Use info log level by default
+CONFIG_MCUBOOT_LOG_LEVEL_INF=y
 ### Decrease footprint by ~4 KB in comparison to CBPRINTF_COMPLETE=y
 CONFIG_CBPRINTF_NANO=y


### PR DESCRIPTION
The default log level has changed to "default", restore it back to info.