### PR TITLE
boot: Add MCUBOOT_HW_KEY support for image encryption

### DIFF
--- a/boot/bootutil/include/bootutil/enc_key.h
+++ b/boot/bootutil/include/bootutil/enc_key.h
@@ -32,6 +32,7 @@
 #include <flash_map_backend/flash_map_backend.h>
 #include "bootutil/crypto/aes_ctr.h"
 #include "bootutil/image.h"
+#include "bootutil/sign_key.h"
 #include "bootutil/enc_key_public.h"
 
 #ifdef __cplusplus
@@ -45,7 +46,17 @@ struct enc_key_data {
     bootutil_aes_ctr_context aes_ctr;
 };
 
-extern const struct bootutil_key bootutil_enc_key;
+/**
+ * Retrieve the private key for image encryption.
+ *
+ * @param[out]  private_key  structure to store the private key and
+ *                           its length.
+ *
+ * @return                   0 on success; nonzero on failure.
+ *
+ */
+int boot_enc_retrieve_private_key(struct bootutil_key **private_key);
+
 struct boot_status;
 
 int boot_enc_init(struct enc_key_data *enc_state, uint8_t slot);

--- a/boot/cypress/MCUBootApp/keys.c
+++ b/boot/cypress/MCUBootApp/keys.c
@@ -167,3 +167,12 @@ const struct bootutil_key bootutil_enc_key = {
     .key = enc_priv_key,
     .len = &enc_priv_key_len,
 };
+
+#if !defined(MCUBOOT_HW_KEY) && defined(MCUBOOT_ENC_IMAGES)
+int boot_enc_retrieve_private_key(struct bootutil_key **private_key)
+{
+    *private_key = (struct bootutil_key *)&bootutil_enc_key;
+
+    return 0;
+}
+#endif /* !MCUBOOT_HW_KEY && MCUBOOT_ENC_IMAGES */

--- a/boot/mbed/app_enc_keys.c
+++ b/boot/mbed/app_enc_keys.c
@@ -69,3 +69,12 @@ const struct bootutil_key bootutil_enc_key = {
 #endif
 
 #endif
+
+#if !defined(MCUBOOT_HW_KEY) && defined(MCUBOOT_ENC_IMAGES)
+int boot_enc_retrieve_private_key(struct bootutil_key **private_key)
+{
+    *private_key = (struct bootutil_key *)&bootutil_enc_key;
+
+    return 0;
+}
+#endif /* !MCUBOOT_HW_KEY && MCUBOOT_ENC_IMAGES */

--- a/boot/zephyr/keys.c
+++ b/boot/zephyr/keys.c
@@ -86,3 +86,12 @@ const struct bootutil_key bootutil_enc_key = {
 #elif defined(MCUBOOT_ENCRYPT_KW)
 #error "Encrypted images with AES-KW is not implemented yet."
 #endif
+
+#if !defined(MCUBOOT_HW_KEY) && defined(MCUBOOT_ENC_IMAGES)
+int boot_enc_retrieve_private_key(struct bootutil_key **private_key)
+{
+    *private_key = (struct bootutil_key *)&bootutil_enc_key;
+
+    return 0;
+}
+#endif /* !MCUBOOT_HW_KEY && MCUBOOT_ENC_IMAGES */

--- a/ci/mynewt_keys/enc_kw/src/keys.c
+++ b/ci/mynewt_keys/enc_kw/src/keys.c
@@ -28,3 +28,12 @@ const struct bootutil_key bootutil_enc_key = {
     .key = enc_key,
     .len = &enc_key_len,
 };
+
+#if !defined(MCUBOOT_HW_KEY) && defined(MCUBOOT_ENC_IMAGES)
+int boot_enc_retrieve_private_key(struct bootutil_key **private_key)
+{
+    *private_key = (struct bootutil_key *)&bootutil_enc_key;
+
+    return 0;
+}
+#endif /* !MCUBOOT_HW_KEY && MCUBOOT_ENC_IMAGES */

--- a/ci/mynewt_keys/enc_rsa/src/keys.c
+++ b/ci/mynewt_keys/enc_rsa/src/keys.c
@@ -126,3 +126,12 @@ const struct bootutil_key bootutil_enc_key = {
     .key = enc_key,
     .len = &enc_key_len,
 };
+
+#if !defined(MCUBOOT_HW_KEY) && defined(MCUBOOT_ENC_IMAGES)
+int boot_enc_retrieve_private_key(struct bootutil_key **private_key)
+{
+    *private_key = (struct bootutil_key *)&bootutil_enc_key;
+
+    return 0;
+}
+#endif /* !MCUBOOT_HW_KEY && MCUBOOT_ENC_IMAGES */

--- a/docs/release-notes.d/bootutil-enc-hw-keys.md
+++ b/docs/release-notes.d/bootutil-enc-hw-keys.md
@@ -1,0 +1,2 @@
+- Added support for retrieving hw embed private keys for image encryption
+  (The private key can be retrieved from trusted sources like OTP, TPM.).

--- a/sim/mcuboot-sys/csupport/keys.c
+++ b/sim/mcuboot-sys/csupport/keys.c
@@ -328,3 +328,12 @@ const struct bootutil_key bootutil_enc_key = {
     .len = &enc_key_len,
 };
 #endif
+
+#if !defined(MCUBOOT_HW_KEY) && defined(MCUBOOT_ENC_IMAGES)
+int boot_enc_retrieve_private_key(struct bootutil_key **private_key)
+{
+    *private_key = (struct bootutil_key *)&bootutil_enc_key;
+
+    return 0;
+}
+#endif /* !MCUBOOT_HW_KEY && MCUBOOT_ENC_IMAGES */


### PR DESCRIPTION
Currently encryption supports only private key embed in mcuboot itself. To support MCUBOOT_HW_KEY for image encryption boot_retrieve_private_key() hook is added.

This hook helps retrieving private key from trusted sources like OTP, TPM.