### PR TITLE
zephyr/boot_serial_extension: Fix zcbor header path

### DIFF
--- a/boot/zephyr/boot_serial_extensions.c
+++ b/boot/zephyr/boot_serial_extensions.c
@@ -13,7 +13,7 @@
 
 #include "bootutil/bootutil_log.h"
 #include "../boot_serial/src/boot_serial_priv.h"
-#include "../boot_serial/src/zcbor_encode.h"
+#include <zcbor_encode.h>
 
 #include "bootutil/image.h"
 #include "bootutil/bootutil_public.h"


### PR DESCRIPTION
Include directory path is now set by CMake.