### PR TITLE
nuttx: add support for swap without scratch area

### DIFF
--- a/boot/nuttx/include/flash_map_backend/flash_map_backend.h
+++ b/boot/nuttx/include/flash_map_backend/flash_map_backend.h
@@ -107,6 +107,23 @@ static inline uint8_t flash_area_get_device_id(const struct flash_area *fa)
 }
 
 /****************************************************************************
+ * Name: flash_area_sector_from_off
+ *
+ * Description:
+ *   Retrieve the flash sector a given offset belongs to.
+ *
+ * Input Parameters:
+ *   off - address offset.
+ *   sector - flash sector
+ *
+ * Returned Value:
+ *   Returns 0 on success, or an error code on failure.
+ *
+ ****************************************************************************/
+
+int flash_area_sector_from_off(off_t off, struct flash_sector *fs);
+
+/****************************************************************************
  * Name: flash_area_get_off
  *
  * Description:

--- a/boot/nuttx/include/mcuboot_config/mcuboot_config.h
+++ b/boot/nuttx/include/mcuboot_config/mcuboot_config.h
@@ -58,6 +58,12 @@
  * the default upgrade mode.
  */
 
+/* Use image swap without using scratch area.*/
+
+#ifdef CONFIG_MCUBOOT_SWAP_USING_MOVE
+#  define MCUBOOT_SWAP_USING_MOVE 1
+#endif
+
 /* Enable the overwrite-only code path. */
 
 #ifdef CONFIG_MCUBOOT_OVERWRITE_ONLY

--- a/boot/nuttx/src/flash_map_backend/flash_map_backend.c
+++ b/boot/nuttx/src/flash_map_backend/flash_map_backend.c
@@ -810,3 +810,32 @@ int flash_area_id_from_image_offset(uint32_t offset)
 
   return ERROR; /* flash_area_open will fail on that */
 }
+
+/****************************************************************************
+ * Name: flash_area_sector_from_off
+ *
+ * Description:
+ *   Retrieve the flash sector a given offset belongs to.
+ *
+ * Input Parameters:
+ *   off - address offset.
+ *   sector - flash sector
+ *
+ * Returned Value:
+ *   Returns 0 on success, or an error code on failure.
+ *
+ ****************************************************************************/
+
+int flash_area_sector_from_off(off_t off, struct flash_sector *fs)
+{
+  struct flash_device_s *dev = lookup_flash_device_by_offset(off);
+  if (dev == NULL)
+   {
+    return -errno;
+   }
+
+  fs->fs_off = (off / dev->mtdgeo.erasesize) * dev->mtdgeo.erasesize;
+  fs->fs_size = dev->mtdgeo.erasesize;
+
+  return 0;
+}


### PR DESCRIPTION
Definition of MCUBOOT_SWAP_USING_MOVE in case swap without scratch area is configured in NuttX was missing from mcuboot_config.h file.

Also necessary function `flash_area_sector_from_off()` is defined and declared in order to support swap without scratch.