### PR TITLE
boot_serial: fix misuse of 'matched' param from zcbor_map_decode_bulk()

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -440,7 +440,7 @@ bs_set(char *buf, int len)
     ok = zcbor_map_decode_bulk(zsd, image_set_state_decode, ARRAY_SIZE(image_set_state_decode),
                                &decoded) == 0;
 
-    if (!ok || len != decoded) {
+    if (!ok) {
         rc = MGMT_ERR_EINVAL;
         goto out;
     }


### PR DESCRIPTION
The `matched` param in `zcbor_map_decode_bulk()` function is `pointer to the counter of matched keys`, not length of payload buffer. Reference: https://github.com/mcu-tools/mcuboot/blob/main/boot/boot_serial/src/zcbor_bulk.h#L96, fixes: fac2cabe98d8.