### PR TITLE
MCUBoot: Multi memory load feature

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -80,10 +80,19 @@ struct image_trailer {
 /* you must have pre-allocated all the entries within this structure */
 fih_ret boot_go(struct boot_rsp *rsp);
 fih_ret boot_go_for_image_id(struct boot_rsp *rsp, uint32_t image_id);
+fih_ret boot_go_for_image_id_flash(struct boot_rsp *rsp, uint32_t image_id);
+
+#if defined(MCUBOOT_DIRECT_XIP) || defined(MCUBOOT_RAM_LOAD)
+fih_ret boot_go_for_image_id_ram(struct boot_rsp *rsp, uint32_t image_id);
+#endif
 
 struct boot_loader_state;
 void boot_state_clear(struct boot_loader_state *state);
-fih_ret context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp);
+fih_ret context_boot_go_flash(struct boot_loader_state *state, struct boot_rsp *rsp);
+
+#if defined(MCUBOOT_DIRECT_XIP) || defined(MCUBOOT_RAM_LOAD)
+fih_ret context_boot_go_ram(struct boot_loader_state *state, struct boot_rsp *rsp);
+#endif
 
 #define SPLIT_GO_OK                 (0)
 #define SPLIT_GO_NON_MATCHING       (-1)

--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -155,6 +155,24 @@ struct image_tlv {
 #define MUST_DECRYPT(fap, idx, hdr) \
     (flash_area_get_id(fap) == FLASH_AREA_IMAGE_SECONDARY(idx) && IS_ENCRYPTED(hdr))
 
+#if defined(MCUBOOT_RAM_LOAD)
+#define IS_RAM_BOOTABLE(hdr)                                       \
+    ((((hdr)->ih_flags & IMAGE_F_RAM_LOAD) == IMAGE_F_RAM_LOAD) && \
+     ((hdr)->ih_load_addr != 0U) && ((hdr)->ih_load_addr != (uintptr_t)(-1)))
+#else
+#define IS_RAM_BOOTABLE(hdr) (false)
+#endif
+
+#if defined(MCUBOOT_RAM_LOAD) || defined(MCUBOOT_DIRECT_XIP)
+#define IS_RAM_BOOT_STAGE()   \
+    ({                        \
+        extern bool boot_ram; \
+        boot_ram;             \
+    })
+#else
+#define IS_RAM_BOOT_STAGE() false
+#endif
+
 _Static_assert(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
                "struct image_header not required size");
 

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -76,7 +76,7 @@ boot_read_image_header(struct boot_loader_state *state, int slot,
     return rc;
 }
 
-#if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)
+#if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD) || defined(MCUBOOT_MULTI_MEMORY_LOAD)
 /**
  * Reads the status of a partially-completed swap, if any.  This is necessary
  * to recover in case the boot lodaer was reset in the middle of a swap
@@ -743,6 +743,6 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
 }
 #endif /* !MCUBOOT_OVERWRITE_ONLY */
 
-#endif /* !MCUBOOT_DIRECT_XIP && !MCUBOOT_RAM_LOAD */
+#endif /* !MCUBOOT_DIRECT_XIP && !MCUBOOT_RAM_LOAD || MCUBOOT_MULTI_MEMORY_LOAD */
 
 #endif /* !MCUBOOT_SWAP_USING_MOVE */

--- a/ci/fih_test_docker/fi_tester_gdb.sh
+++ b/ci/fih_test_docker/fi_tester_gdb.sh
@@ -41,7 +41,7 @@ function skip_instruction {
     cat >commands.gdb <<EOF
 target remote localhost: 1234
 file $IMAGE_DIR/bl2.axf
-b boot_go_for_image_id if image_id == 0
+b boot_go_for_image_id_flash if image_id == 0
 continue
 delete breakpoints 1
 b *$SKIP_ADDRESS

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -274,7 +274,11 @@ int invoke_boot_go(struct sim_context *ctx, struct area_desc *adesc,
         (void) image_id;
 #endif /* BOOT_IMAGE_NUMBER > 1 */
 
-        res = context_boot_go(state, rsp);
+#if defined(MCUBOOT_DIRECT_XIP) || defined(MCUBOOT_RAM_LOAD)
+        res = context_boot_go_ram(state, rsp);
+#else
+        res = context_boot_go_flash(state, rsp);
+#endif
         sim_reset_flash_areas();
         sim_reset_context();
         free(state);


### PR DESCRIPTION
Implement multi memory boot feature

In the current implementation, the ability to launch several applications using different memory modes has been added.
Use cases: multi core and ram app boot alongside with flash based applications

MCUBOOT_MULTI_MEMORY_LOAD
--- Feature: partial multi-image boot for RAM based applications
--- Feature: partial multi-image boot for Flash applications

These changes were made to make MCUBoot able to work with flash and ram images independently.
The use case that we need to support, a multi image configuration:

Application_1 boots from RAM
Application_2 boots from FLASH
Application_N boots from FLASH
Example:

```
image_boot_config_t image_boot_config[BOOT_IMAGE_NUMBER] = {
    {
        .mode = IMAGE_BOOT_MODE_RAM,
        .address = 0x08012000,
        .size = 0x00010000,
    },
    {
        .mode = IMAGE_BOOT_MODE_FLASH,
        .address = 0x10002000,
        .size = 0x00008000,
    },
};

/* Perform MCUboot */
for (uint32_t id = 0U; id < (uint32_t)BOOT_IMAGE_NUMBER; id++) {
    BOOT_LOG_INF("Processing img id: %d", id);
#if !defined(MCUBOOT_RAM_LOAD) || defined(MCUBOOT_MULTI_MEMORY_LOAD)
    if (image_boot_config[id].mode == IMAGE_BOOT_MODE_FLASH) {
        FIH_CALL(boot_go_for_image_id, fih_rc, &rsp[id], id);
    } else
#endif
    {
#if defined(MCUBOOT_RAM_LOAD)
        FIH_CALL(boot_go_for_image_id_ram, fih_rc, &rsp[id], id);
#endif
    }
}
```