### PR TITLE
mynewt: Make sysinit() call configurable

### DIFF
--- a/boot/mynewt/src/main.c
+++ b/boot/mynewt/src/main.c
@@ -229,7 +229,7 @@ main(void)
 #endif
 
 #if defined(MCUBOOT_SERIAL) || defined(MCUBOOT_HAVE_LOGGING) || \
-        MYNEWT_VAL(CRYPTO) || MYNEWT_VAL(HASH)
+        MYNEWT_VAL(CRYPTO) || MYNEWT_VAL(HASH) || MYNEWT_VAL(BOOT_MYNEWT_SYSINIT)
     /* initialize uart/crypto without os */
     os_dev_initialize_all(OS_DEV_INIT_PRIMARY);
     os_dev_initialize_all(OS_DEV_INIT_SECONDARY);

--- a/boot/mynewt/syscfg.yml
+++ b/boot/mynewt/syscfg.yml
@@ -31,6 +31,14 @@ syscfg.defs:
     BOOT_PREBOOT:
         description: 'Call boot_preboot() function before booting application'
         value:
+    BOOT_MYNEWT_SYSINIT:
+        description: >
+            When not 0 performs device initialization and calls newt
+            generated sysinit() function.
+            Note: this functionality is implicitly turned on when one of the
+            following settings are not 0:
+            MCUBOOT_SERIAL, MCUBOOT_HAVE_LOGGING, CRYPTO, HASH
+        value: 0
 
 syscfg.vals:
     SYSINIT_CONSTRAIN_INIT: 0


### PR DESCRIPTION
In same cases (loging, hash, crypto) main function called newt tool generated sysinit() function to create
uart device and crypto.

Now user can specify that sysinit should be called for other cases if needed. This can be useful if some other package should be included in the build and it has package initialization function.