### PR TITLE
boot_serial: Fix build for 64-bit architectures

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -1037,7 +1037,7 @@ boot_serial_output(void)
     char encoded_buf[BASE64_ENCODE_SIZE(sizeof(buf))];
 
     data = bs_obuf;
-    len = (uint32_t)cbor_state->payload_mut - (uint32_t)bs_obuf;
+    len = (uintptr_t)cbor_state->payload_mut - (uintptr_t)bs_obuf;
 
     bs_hdr->nh_op++;
     bs_hdr->nh_flags = 0;


### PR DESCRIPTION
Typecasting pointer variables to uint32_t
instead of uintptr_t was causing build error
on 64-bit architecture.

This is useful, because I am currently working
on implementing support for 64-bit native target
in Apache Mynewt. There is unit test for boot_serial and it cannot be compiled without this changes.