### PR TITLE
nuttx: switch to flash_area_get_sector

### DIFF
--- a/boot/nuttx/include/flash_map_backend/flash_map_backend.h
+++ b/boot/nuttx/include/flash_map_backend/flash_map_backend.h
@@ -107,12 +107,13 @@ static inline uint8_t flash_area_get_device_id(const struct flash_area *fa)
 }
 
 /****************************************************************************
- * Name: flash_area_sector_from_off
+ * Name: flash_area_get_sector
  *
  * Description:
  *   Retrieve the flash sector a given offset belongs to.
  *
  * Input Parameters:
+ *   fap - flash area structure
  *   off - address offset.
  *   sector - flash sector
  *
@@ -121,7 +122,8 @@ static inline uint8_t flash_area_get_device_id(const struct flash_area *fa)
  *
  ****************************************************************************/
 
-int flash_area_sector_from_off(off_t off, struct flash_sector *fs);
+int flash_area_get_sector(const struct flash_area *fap, off_t off,
+                          struct flash_sector *fs);
 
 /****************************************************************************
  * Name: flash_area_get_off

--- a/boot/nuttx/src/flash_map_backend/flash_map_backend.c
+++ b/boot/nuttx/src/flash_map_backend/flash_map_backend.c
@@ -812,12 +812,13 @@ int flash_area_id_from_image_offset(uint32_t offset)
 }
 
 /****************************************************************************
- * Name: flash_area_sector_from_off
+ * Name: flash_area_get_sector
  *
  * Description:
  *   Retrieve the flash sector a given offset belongs to.
  *
  * Input Parameters:
+ *   fap - flash area structure
  *   off - address offset.
  *   sector - flash sector
  *
@@ -826,15 +827,17 @@ int flash_area_id_from_image_offset(uint32_t offset)
  *
  ****************************************************************************/
 
-int flash_area_sector_from_off(off_t off, struct flash_sector *fs)
+int flash_area_get_sector(const struct flash_area *fap, off_t off,
+                          struct flash_sector *fs)
 {
-  struct flash_device_s *dev = lookup_flash_device_by_offset(off);
+  off_t offset = fap->fa_off + off;
+  struct flash_device_s *dev = lookup_flash_device_by_offset(offset);
   if (dev == NULL)
-   {
-    return -errno;
-   }
+    {
+      return -errno;
+    }
 
-  fs->fs_off = (off / dev->mtdgeo.erasesize) * dev->mtdgeo.erasesize;
+  fs->fs_off = (offset / dev->mtdgeo.erasesize) * dev->mtdgeo.erasesize;
   fs->fs_size = dev->mtdgeo.erasesize;
 
   return 0;


### PR DESCRIPTION
Function `flash_area_sector_from_off` is replaced with newly used `flash_area_get_sector` to cope with calls in bootutil_misc.c file.

This is required for CONFIG_MCUBOOT_SWAP_USING_MOVE to work correctly.

This is basically a follow up to #1727 that worked but with older version of mcuboot as `flash_area_sector_from_off` was
replaced with `flash_area_get_sector` few months ago and I was not aware of this change.