### PR TITLE
bootutil: Fix for flash_area_id_to_image

### DIFF
--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -463,7 +463,7 @@ static int flash_area_id_to_image(int id)
 #if BOOT_IMAGE_NUMBER > 2
 #error "BOOT_IMAGE_NUMBER > 2 requires change to flash_area_id_to_image"
 #elif BOOT_IMAGE_NUMBER > 1
-    if (FLASH_AREA_IMAGE_SECONDARY(0) == id || (FLASH_AREA_IMAGE_SECONDARY(1) == id)) {
+    if (FLASH_AREA_IMAGE_PRIMARY(1) == id || (FLASH_AREA_IMAGE_SECONDARY(1) == id)) {
         return 1;
     }
 #else


### PR DESCRIPTION
The function was incorrectly identifying partition of secondary slot of image 0 as belonging to image 1, at the same time failing to identify partition of primary slot of image 1.