### PR TITLE
zephyr: use cmsis_core.h header

### DIFF
--- a/boot/zephyr/arm_cleanup.c
+++ b/boot/zephyr/arm_cleanup.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <zephyr/toolchain.h>
 
+#include <cmsis_core.h>
 #if CONFIG_CPU_HAS_NXP_MPU
 #include <fsl_sysmpu.h>
 #endif

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -27,11 +27,7 @@
 #include <soc.h>
 #include <zephyr/linker/linker-defs.h>
 
-#if defined(CONFIG_CPU_AARCH32_CORTEX_A) || defined(CONFIG_CPU_AARCH32_CORTEX_R)
-#include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
-#elif defined(CONFIG_CPU_CORTEX_M)
-#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
-#endif
+#include <cmsis_core.h>
 
 #include "target.h"
 


### PR DESCRIPTION
CMSIS glue code is now provided by the CMSIS Zephyr module in <cmsis_core.h>. Header is generic for M/A/R.