### PR TITLE
imgtool: dumpinfo: Fixed support for the custom alignment

### DIFF
--- a/scripts/imgtool/dumpinfo.py
+++ b/scripts/imgtool/dumpinfo.py
@@ -138,7 +138,7 @@ def dump_imginfo(imgfile, outfile=None, silent=False):
             max_align = 8
         elif trailer_magic[-len(BOOT_MAGIC_2):] == BOOT_MAGIC_2:
             # The alignment value is encoded in the magic field
-            max_align = int(trailer_magic[:2], 0)
+            max_align = int.from_bytes(trailer_magic[:2], "little")
         else:
             # Invalid magic: the rest of the image trailer cannot be processed.
             print("Warning: the trailer magic value is invalid!")


### PR DESCRIPTION
Fixed support for the custom alignment (in case if BOOT_MAGIC_2 is provided). Current version fails to parse it with an error:

ValueError: invalid literal for int() with base 0: b'...

Using the same solution as 'swap_size' parsing as a fix.