### PR TITLE
bootutil: replace C specific static assert

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -29,6 +29,7 @@
 #define H_BOOTUTIL_
 
 #include <inttypes.h>
+#include <assert.h>
 #include "bootutil/fault_injection_hardening.h"
 #include "bootutil/bootutil_public.h"
 
@@ -42,7 +43,7 @@ extern "C" {
 #define BOOT_IMAGE_NUMBER          1
 #endif
 
-_Static_assert(BOOT_IMAGE_NUMBER > 0, "Invalid value for BOOT_IMAGE_NUMBER");
+static_assert(BOOT_IMAGE_NUMBER > 0, "Invalid value for BOOT_IMAGE_NUMBER");
 
 struct image_header;
 /**

--- a/boot/bootutil/include/bootutil/bootutil_public.h
+++ b/boot/bootutil/include/bootutil/bootutil_public.h
@@ -85,7 +85,7 @@ extern "C" {
 
 #ifdef MCUBOOT_BOOT_MAX_ALIGN
 
-_Static_assert(MCUBOOT_BOOT_MAX_ALIGN >= 8 && MCUBOOT_BOOT_MAX_ALIGN <= 32,
+static_assert(MCUBOOT_BOOT_MAX_ALIGN >= 8 && MCUBOOT_BOOT_MAX_ALIGN <= 32,
                "Unsupported value for MCUBOOT_BOOT_MAX_ALIGN");
 
 #define BOOT_MAX_ALIGN          MCUBOOT_BOOT_MAX_ALIGN

--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -30,6 +30,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <assert.h>
 #include "bootutil/fault_injection_hardening.h"
 
 #ifdef __cplusplus
@@ -160,7 +161,7 @@ struct image_tlv {
 #define MUST_DECRYPT(fap, idx, hdr) \
     (flash_area_get_id(fap) == FLASH_AREA_IMAGE_SECONDARY(idx) && IS_ENCRYPTED(hdr))
 
-_Static_assert(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
+static_assert(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
                "struct image_header not required size");
 
 struct enc_key_data;

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -29,6 +29,7 @@
 #define H_BOOTUTIL_PRIV_
 
 #include <string.h>
+#include <assert.h>
 
 #include "sysflash/sysflash.h"
 
@@ -160,7 +161,7 @@ extern const union boot_img_magic_t boot_img_magic;
 #define BOOT_IMG_ALIGN  (boot_img_magic.align)
 #endif
 
-_Static_assert(sizeof(boot_img_magic) == BOOT_MAGIC_SZ, "Invalid size for image magic");
+static_assert(sizeof(boot_img_magic) == BOOT_MAGIC_SZ, "Invalid size for image magic");
 
 #if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)
 #define ARE_SLOTS_EQUIVALENT()    0

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -11,6 +11,7 @@
 #include <stddef.h>
 #include <inttypes.h>
 #include <string.h>
+#include <assert.h>
 
 #if defined(MCUBOOT_ENCRYPT_RSA)
 #define BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED
@@ -376,14 +377,14 @@ boot_enc_set_key(struct enc_key_data *enc_state, uint8_t slot,
 #    define EC_PUBK_INDEX       (0)
 #    define EC_TAG_INDEX        (65)
 #    define EC_CIPHERKEY_INDEX  (65 + 32)
-_Static_assert(EC_CIPHERKEY_INDEX + BOOT_ENC_KEY_SIZE == EXPECTED_ENC_LEN,
+static_assert(EC_CIPHERKEY_INDEX + BOOT_ENC_KEY_SIZE == EXPECTED_ENC_LEN,
         "Please fix ECIES-P256 component indexes");
 #elif defined(MCUBOOT_ENCRYPT_X25519)
 #    define EXPECTED_ENC_TLV    IMAGE_TLV_ENC_X25519
 #    define EC_PUBK_INDEX       (0)
 #    define EC_TAG_INDEX        (32)
 #    define EC_CIPHERKEY_INDEX  (32 + 32)
-_Static_assert(EC_CIPHERKEY_INDEX + BOOT_ENC_KEY_SIZE == EXPECTED_ENC_LEN,
+static_assert(EC_CIPHERKEY_INDEX + BOOT_ENC_KEY_SIZE == EXPECTED_ENC_LEN,
         "Please fix ECIES-X25519 component indexes");
 #endif
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -35,6 +35,7 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 #include "bootutil/bootutil.h"
 #include "bootutil/bootutil_public.h"
 #include "bootutil/image.h"
@@ -346,7 +347,7 @@ boot_initialize_area(struct boot_loader_state *state, int flash_area)
 #ifdef MCUBOOT_USE_FLASH_AREA_GET_SECTORS
     rc = flash_area_get_sectors(flash_area, &num_sectors, out_sectors);
 #else
-    _Static_assert(sizeof(int) <= sizeof(uint32_t), "Fix needed");
+    static_assert(sizeof(int) <= sizeof(uint32_t), "Fix needed");
     rc = flash_area_to_sectors(flash_area, (int *)&num_sectors, out_sectors);
 #endif /* defined(MCUBOOT_USE_FLASH_AREA_GET_SECTORS) */
     if (rc != 0) {

--- a/boot/espressif/port/esp_mcuboot.c
+++ b/boot/espressif/port/esp_mcuboot.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 #include <bootutil/bootutil.h>
 #include <bootutil/bootutil_log.h>
@@ -45,7 +46,7 @@
 
 #define FLASH_BUFFER_SIZE           256 /* SPI Flash block size */
 
-_Static_assert(IS_ALIGNED(FLASH_BUFFER_SIZE, 4), "Buffer size for SPI Flash operations must be 4-byte aligned.");
+static_assert(IS_ALIGNED(FLASH_BUFFER_SIZE, 4), "Buffer size for SPI Flash operations must be 4-byte aligned.");
 
 #define BOOTLOADER_START_ADDRESS CONFIG_BOOTLOADER_OFFSET_IN_FLASH
 #define BOOTLOADER_SIZE CONFIG_ESP_BOOTLOADER_SIZE

--- a/boot/zcbor/src/zcbor_common.c
+++ b/boot/zcbor/src/zcbor_common.c
@@ -13,12 +13,13 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+#include <assert.h>
 #include "zcbor_common.h"
 
-_Static_assert((sizeof(size_t) == sizeof(void *)),
+static_assert((sizeof(size_t) == sizeof(void *)),
 	"This code needs size_t to be the same length as pointers.");
 
-_Static_assert((sizeof(zcbor_state_t) >= sizeof(struct zcbor_state_constant)),
+static_assert((sizeof(zcbor_state_t) >= sizeof(struct zcbor_state_constant)),
 	"This code needs zcbor_state_t to be at least as large as zcbor_backups_t.");
 
 bool zcbor_new_backup(zcbor_state_t *state, uint_fast32_t new_elem_count)

--- a/boot/zcbor/src/zcbor_encode.c
+++ b/boot/zcbor/src/zcbor_encode.c
@@ -13,10 +13,11 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
+#include <assert.h>
 #include "zcbor_encode.h"
 #include "zcbor_common.h"
 
-_Static_assert((sizeof(size_t) == sizeof(void *)),
+static_assert((sizeof(size_t) == sizeof(void *)),
 	"This code needs size_t to be the same length as pointers.");
 
 

--- a/ext/fiat/src/curve25519.c
+++ b/ext/fiat/src/curve25519.c
@@ -114,7 +114,7 @@ typedef uint32_t fe_limb_t;
   } while (0)
 
 //FIXME: use Zephyr macro
-_Static_assert(sizeof(fe) == sizeof(fe_limb_t) * FE_NUM_LIMBS,
+static_assert(sizeof(fe) == sizeof(fe_limb_t) * FE_NUM_LIMBS,
                "fe_limb_t[FE_NUM_LIMBS] is inconsistent with fe");
 
 static void fe_frombytes_strict(fe *h, const uint8_t s[32]) {
@@ -234,7 +234,7 @@ static void fe_copy(fe *h, const fe *f) {
 
 static void fe_copy_lt(fe_loose *h, const fe *f) {
   //FIXME: use Zephyr macro
-  _Static_assert(sizeof(fe_loose) == sizeof(fe), "fe and fe_loose mismatch");
+  static_assert(sizeof(fe_loose) == sizeof(fe), "fe and fe_loose mismatch");
   memmove(h, f, sizeof(fe));
 }
 


### PR DESCRIPTION
### Defect detected

__Static_assert_ defined in C11.

### Error log
Compilation raises the following compilation error in this line:

[https://github.com/mcu-tools/mcuboot/blob/main/boot/bootutil/include/bootutil/image.h#L163-L164]([](https://github.com/mcu-tools/mcuboot/blob/main/boot/bootutil/include/bootutil/image.h#L163-L164))

```
mcuboot/boot/bootutil/include/bootutil/image.h:163:15: error: expected constructor, destructor, or type conversion before '(' token
  163 | _Static_assert(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
      |               ^
compilation terminated due to -Wfatal-errors.

```

### Proposed Fix
Following modification fixes the issue.

```
static_assert((sizeof(struct image_header)) == IMAGE_HEADER_SIZE, 
                "struct image_header not required size\n");
```

### Change Log
Change added in this commit e3cbbece365d54514b1a909507820818a3125f3c

### Comments
Please @d3zd3z can you check this?
