### PR TITLE
zephyr: Fix build for non-arm archs

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -27,7 +27,9 @@
 #include <soc.h>
 #include <zephyr/linker/linker-defs.h>
 
+#if defined(CONFIG_ARM)
 #include <cmsis_core.h>
+#endif
 
 #include "target.h"
 


### PR DESCRIPTION
Guards the inclusion of cmsis_core header for
ARM targets only.

Fixes #1799