### PR TITLE
boot: zephyr: don't allow GPIO entrance in timeout based serial recovery

### DIFF
--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -141,7 +141,7 @@ menu "Entrance methods"
 menuconfig BOOT_SERIAL_ENTRANCE_GPIO
 	bool "GPIO"
 	default y
-	depends on GPIO
+	depends on GPIO && !BOOT_SERIAL_WAIT_FOR_DFU
 	help
 	  Use a GPIO to enter serial recovery mode.
 


### PR DESCRIPTION
If a timeout based serial recovery is selected, there is no point in keeping support for GPIO based entrance method. These two ways for entering serial recovery should be mutually exclusive, same as it's done in USB DFU based recovery (Kconfig symbols: `BOOT_USB_DFU_GPIO` and `BOOT_USB_DFU_WAIT`).