### PR TITLE
boot_serial: minor fixes in 'erase_range()' log output and for 'bs_list()'

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -240,7 +240,7 @@ bs_list_img_ver(char *dst, int maxlen, struct image_version *ver)
  * List images.
  */
 static void
-bs_list(char *buf, int len)
+bs_list(void)
 {
     struct image_header hdr;
     uint32_t slot, area_id;
@@ -521,7 +521,7 @@ bs_set(char *buf, int len)
 out:
     if (rc == 0) {
         /* Success - return updated list of images */
-        bs_list(buf, len);
+        bs_list();
     } else {
         /* Error code, only return the error */
         zcbor_map_start_encode(cbor_state, 10);
@@ -551,7 +551,7 @@ static void
 bs_list_set(uint8_t op, char *buf, int len)
 {
     if (op == NMGR_OP_READ) {
-        bs_list(buf, len);
+        bs_list();
     } else {
 #ifdef MCUBOOT_SERIAL_IMG_GRP_IMAGE_STATE
         bs_set(buf, len);

--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -596,8 +596,8 @@ static off_t erase_range(const struct flash_area *fap, off_t start, off_t end)
     }
 
     size = flash_sector_get_off(&sect) + flash_sector_get_size(&sect) - start;
-    BOOT_LOG_INF("Erasing range 0x%jx:0x%jx", (intmax_t)start,
-		 (intmax_t)(start + size - 1));
+    BOOT_LOG_INF("Erasing range 0x%jx:0x%jx", (intmax_t)(fap->fa_off + start),
+		 (intmax_t)(fap->fa_off + start + size - 1));
 
     rc = flash_area_erase(fap, start, size);
     if (rc != 0) {
@@ -781,7 +781,8 @@ bs_upload(char *buf, int len)
         rem_bytes = 0;
     }
 
-    BOOT_LOG_INF("Writing at 0x%x until 0x%x", curr_off, curr_off + img_chunk_len);
+    BOOT_LOG_INF("Writing at 0x%lx until 0x%lx", fap->fa_off + curr_off,
+                 fap->fa_off + curr_off + img_chunk_len);
     /* Write flash aligned chunk, note that img_chunk_len now holds aligned length */
 #if defined(MCUBOOT_SERIAL_UNALIGNED_BUFFER_SIZE) && MCUBOOT_SERIAL_UNALIGNED_BUFFER_SIZE > 0
     if (flash_area_align(fap) > 1 &&

--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -596,8 +596,13 @@ static off_t erase_range(const struct flash_area *fap, off_t start, off_t end)
     }
 
     size = flash_sector_get_off(&sect) + flash_sector_get_size(&sect) - start;
+#if defined(__ZEPHYR__) && defined(CONFIG_MINIMAL_LIBC) && defined(CONFIG_CBPRINTF_NANO)
+    BOOT_LOG_INF("Erasing range 0x%lx:0x%lx", (fap->fa_off + start),
+		 (fap->fa_off + start + size - 1));
+#else
     BOOT_LOG_INF("Erasing range 0x%jx:0x%jx", (intmax_t)(fap->fa_off + start),
 		 (intmax_t)(fap->fa_off + start + size - 1));
+#endif
 
     rc = flash_area_erase(fap, start, size);
     if (rc != 0) {


### PR DESCRIPTION
This short series includes 3 minor fixes for `boot_serial`:

1. drop redundant parameters from `bs_list()`
The `buf` and `len` parameters aren't used inside `bs_list()` function.

2. boot_serial: include flash area offset in log info
Currently, log info in `erase_range()` and `bs_upload()` shows range being erased/written relative to selected flash area which might be misleading. Include flash area offset in output so that the absolute addresses of the range being erased/written are shown.

3. don't use `%j` length modifier with Zephyr's minimal libc
The Zephyr's 'Minimal C library' doesn't support the `%j` length modifier when `cbprintf` is configured with minimum features.