### PR TITLE
imgtool: Fixed missing dependency to 'pyyaml' (for dumpinfo)

### DIFF
--- a/scripts/imgtool.nix
+++ b/scripts/imgtool.nix
@@ -21,6 +21,7 @@ let
       python37.pkgs.intelhex
       python37.pkgs.setuptools
       python37.pkgs.cbor2
+      python37.pkgs.pyyaml
     ]
   );
 in

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,3 +2,4 @@ cryptography>=2.6
 intelhex
 click
 cbor2
+pyyaml

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -18,6 +18,7 @@ setuptools.setup(
         'intelhex>=2.2.1',
         'click',
         'cbor2',
+        'pyyaml'
     ],
     entry_points={
         "console_scripts": ["imgtool=imgtool.main:imgtool"]


### PR DESCRIPTION
imgtool's dumpinfo depends to pyyaml package, so add it to requirements.