### PR TITLE
boot_serial: Fix include

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -67,10 +67,7 @@
 #include "boot_serial/boot_serial.h"
 #include "boot_serial_priv.h"
 #include "mcuboot_config/mcuboot_config.h"
-
-#ifdef MCUBOOT_ERASE_PROGRESSIVELY
-#include "bootutil_priv.h"
-#endif
+#include "../src/bootutil_priv.h"
 
 #ifdef MCUBOOT_ENC_IMAGES
 #include "boot_serial/boot_serial_encryption.h"


### PR DESCRIPTION
Fixes an include which is needed for multiple options by just always including it, and fixing the path so it can be included.