### PR TITLE
zephyr: Fall back to minimal C library

### DIFF
--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -33,3 +33,5 @@ CONFIG_LOG_DEFAULT_LEVEL=0
 CONFIG_MCUBOOT_LOG_LEVEL_INF=y
 ### Decrease footprint by ~4 KB in comparison to CBPRINTF_COMPLETE=y
 CONFIG_CBPRINTF_NANO=y
+### Use the minimal C library to reduce flash usage
+CONFIG_MINIMAL_LIBC=y


### PR DESCRIPTION
Changes back to the minimal C library instead of picolibc to reduce flash usage

(Test using nrf52840dk_nrf52840)
Flash usage without this: 34198
RAM usage without this: 23808
Flash usage with this: 32022
RAM usage with this: 23820
Flash change: -2.125KiB
RAM change: +12B
