### PR TITLE
boot_serial: Fix issues with single slot mode/encrypted images

### DIFF
--- a/docs/release-notes.d/bs-encrypted-list.md
+++ b/docs/release-notes.d/bs-encrypted-list.md
@@ -1,0 +1,4 @@
+- Fixed issue with serial recovery not showing image details for
+  decrypted images.
+- Fixes issue with serial recovery in single slot mode wrongly
+  iterating over 2 image slots.


### PR DESCRIPTION
Fixes 2 issues, one whereby multiple slots were checked despite operating in single slot mode, and another whereby decrypted images would not appear on serial recovery image listing, due to assuming that the images were still encrypted.