### PR TITLE
boot_serial: Fix issue with queued commands

### DIFF
--- a/docs/release-notes.d/serial-timeoout-fix.md
+++ b/docs/release-notes.d/serial-timeoout-fix.md
@@ -1,0 +1,4 @@
+- Fixed an issue with boot_serial repeats not being processed when
+  output was sent, this would lead to a divergence of commands
+  whereby later commands being sent would have the previous command
+  output sent instead.


### PR DESCRIPTION
    Fixes an issue whereby multiple commands are received and some
    are still being processed. This generally arises when a response
    takes a long time (e.g. when image decryption is required),
    duplicate commands will now send multiple responses but avoids
    the bug of future commands being sent to which previous responses
    are received.

Fixes #1812