### PR TITLE
bootutil/crypto: Do not include import key with PSA

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/ecdsa.h
+++ b/boot/bootutil/include/bootutil/crypto/ecdsa.h
@@ -74,7 +74,8 @@
 extern "C" {
 #endif
 
-#if defined(MCUBOOT_USE_TINYCRYPT) || defined(MCUBOOT_USE_MBED_TLS) || defined(MCUBOOT_USE_CC310)
+#if (defined(MCUBOOT_USE_TINYCRYPT) || defined(MCUBOOT_USE_MBED_TLS) || \
+     defined(MCUBOOT_USE_CC310)) && !defined(MCUBOOT_USE_PSA_CRYPTO)
 /*
  * Declaring these like this adds NULL termination.
  */
@@ -124,7 +125,7 @@ static int bootutil_import_key(uint8_t **cp, uint8_t *end)
 
     return 0;
 }
-#endif /* MCUBOOT_USE_TINYCRYPT || MCUBOOT_USE_MBED_TLS || MCUBOOT_USE_CC310 */
+#endif /* (MCUBOOT_USE_TINYCRYPT || MCUBOOT_USE_MBED_TLS || MCUBOOT_USE_CC310) && !MCUBOOT_USE_PSA_CRYPTO */
 
 #if defined(MCUBOOT_USE_TINYCRYPT)
 #ifndef MCUBOOT_ECDSA_NEED_ASN1_SIG


### PR DESCRIPTION
This fixes a build error when PSA Crypto API is being used as it has no need for bootutil_import_key but it's included currently since it's allowed to have both Mbed TLS and PSA defined.
