### PR TITLE
boot/bootutil: Split private image API out of image.h

### DIFF
--- a/boot/bootutil/include/bootutil/boot_hooks.h
+++ b/boot/bootutil/include/bootutil/boot_hooks.h
@@ -34,6 +34,9 @@
 #ifndef H_BOOTUTIL_HOOKS
 #define H_BOOTUTIL_HOOKS
 
+#include <bootutil/image.h>
+#include <bootutil/image_api_priv.h>
+
 #ifdef MCUBOOT_IMAGE_ACCESS_HOOKS
 
 #define BOOT_HOOK_CALL(f, ret_default, ...) f(__VA_ARGS__)

--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -30,7 +30,6 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
-#include "bootutil/fault_injection_hardening.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -192,13 +191,6 @@ struct image_tlv {
 _Static_assert(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
                "struct image_header not required size");
 
-struct enc_key_data;
-fih_ret bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
-                              struct image_header *hdr,
-                              const struct flash_area *fap,
-                              uint8_t *tmp_buf, uint32_t tmp_buf_sz,
-                              uint8_t *seed, int seed_len, uint8_t *out_hash);
-
 struct image_tlv_iter {
     const struct image_header *hdr;
     const struct flash_area *fap;
@@ -208,18 +200,6 @@ struct image_tlv_iter {
     uint32_t tlv_off;
     uint32_t tlv_end;
 };
-
-int bootutil_tlv_iter_begin(struct image_tlv_iter *it,
-                            const struct image_header *hdr,
-                            const struct flash_area *fap, uint16_t type,
-                            bool prot);
-int bootutil_tlv_iter_next(struct image_tlv_iter *it, uint32_t *off,
-                           uint16_t *len, uint16_t *type);
-int bootutil_tlv_iter_is_prot(struct image_tlv_iter *it, uint32_t off);
-
-int32_t bootutil_get_img_security_cnt(struct image_header *hdr,
-                                      const struct flash_area *fap,
-                                      uint32_t *security_cnt);
 
 #ifdef __cplusplus
 }

--- a/boot/bootutil/include/bootutil/image_api_priv.h
+++ b/boot/bootutil/include/bootutil/image_api_priv.h
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2016-2019 Linaro LTD
+ * Copyright (c) 2016-2019 JUUL Labs
+ * Copyright (c) 2019-2023 Arm Limited
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * Original license:
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_IMAGE_API_PRIV_
+#define H_IMAGE_API_PRIV_
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <bootutil/image.h>
+#include <bootutil/fault_injection_hardening.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct enc_key_data;
+fih_ret bootutil_img_validate(struct enc_key_data *enc_state, int image_index,
+                              struct image_header *hdr,
+                              const struct flash_area *fap,
+                              uint8_t *tmp_buf, uint32_t tmp_buf_sz,
+                              uint8_t *seed, int seed_len, uint8_t *out_hash);
+
+int bootutil_tlv_iter_begin(struct image_tlv_iter *it,
+                            const struct image_header *hdr,
+                            const struct flash_area *fap, uint16_t type,
+                            bool prot);
+int bootutil_tlv_iter_next(struct image_tlv_iter *it, uint32_t *off,
+                           uint16_t *len, uint16_t *type);
+
+int32_t bootutil_get_img_security_cnt(struct image_header *hdr,
+                                      const struct flash_area *fap,
+                                      uint32_t *security_cnt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -34,6 +34,7 @@
 
 #include "bootutil/image.h"
 #include "bootutil/crypto/sha.h"
+#include "bootutil/image_api_priv.h"
 #include "bootutil/sign_key.h"
 #include "bootutil/security_cnt.h"
 #include "bootutil/fault_injection_hardening.h"


### PR DESCRIPTION
image.h will now only contain applicaiton image related structures and defines.
The split has been done to reduce need for including extra headers, for example FIH support and mcuboot_config.h into software that needs the same defining as MCUboot but implements own functions.