### PR TITLE
bootutil: Disable MCUBOOT_BOOT_MAX_ALIGN assert for non-swap modes

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil_public.h
+++ b/boot/bootutil/include/bootutil/bootutil_public.h
@@ -85,8 +85,10 @@ extern "C" {
 
 #ifdef MCUBOOT_BOOT_MAX_ALIGN
 
+#if defined(MCUBOOT_SWAP_USING_MOVE) || defined(MCUBOOT_SWAP_USING_SCRATCH)
 _Static_assert(MCUBOOT_BOOT_MAX_ALIGN >= 8 && MCUBOOT_BOOT_MAX_ALIGN <= 32,
-               "Unsupported value for MCUBOOT_BOOT_MAX_ALIGN");
+               "Unsupported value for MCUBOOT_BOOT_MAX_ALIGN for SWAP upgrade modes");
+#endif
 
 #define BOOT_MAX_ALIGN          MCUBOOT_BOOT_MAX_ALIGN
 #define BOOT_MAGIC_ALIGN_SIZE   ALIGN_UP(BOOT_MAGIC_SZ, BOOT_MAX_ALIGN)


### PR DESCRIPTION
- Assert should be checked only for SWAP update modes.
- Allow platforms with page size >32 Bytes (e.g. LPC) to use MCUBoot, at least for non-SWAP update modes.