### PR TITLE
boot: zephyr: add support for LPC55Sxx

### DIFF
--- a/boot/zephyr/boards/lpcxpresso55s06.conf
+++ b/boot/zephyr/boards/lpcxpresso55s06.conf
@@ -1,0 +1,6 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+#LPC does not support the MCUBoot swap mode.
+CONFIG_BOOT_UPGRADE_ONLY=y
+CONFIG_BOOT_MAX_IMG_SECTORS=256

--- a/boot/zephyr/boards/lpcxpresso55s16.conf
+++ b/boot/zephyr/boards/lpcxpresso55s16.conf
@@ -1,0 +1,6 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+#LPC does not support the MCUBoot swap mode.
+CONFIG_BOOT_UPGRADE_ONLY=y
+CONFIG_BOOT_MAX_IMG_SECTORS=256

--- a/boot/zephyr/boards/lpcxpresso55s36.conf
+++ b/boot/zephyr/boards/lpcxpresso55s36.conf
@@ -1,0 +1,6 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+#LPC does not support the MCUBoot swap mode.
+CONFIG_BOOT_UPGRADE_ONLY=y
+CONFIG_BOOT_MAX_IMG_SECTORS=256

--- a/boot/zephyr/boards/lpcxpresso55s69_cpu0.conf
+++ b/boot/zephyr/boards/lpcxpresso55s69_cpu0.conf
@@ -1,0 +1,6 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+#LPC does not support the MCUBoot swap mode.
+CONFIG_BOOT_UPGRADE_ONLY=y
+CONFIG_BOOT_MAX_IMG_SECTORS=512


### PR DESCRIPTION
Add configuration for LPC55Sxx to MCUBoot.
It supports the upgrade only mode.