### PR TITLE
imgtool: make "align" command line parameter optional

### DIFF
--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -377,7 +377,7 @@ class BasedIntParamType(click.ParamType):
               'keyword to automatically generate it from the image version.')
 @click.option('-v', '--version', callback=validate_version,  required=True)
 @click.option('--align', type=click.Choice(['1', '2', '4', '8', '16', '32']),
-              required=True)
+              required=False)
 @click.option('--max-align', type=click.Choice(['8', '16', '32']),
               required=False,
               help='Maximum flash alignment. Set if flash alignment of the '


### PR DESCRIPTION
"Align" parameter should be optional:
- it has a default value.
- it is not used for non-swap update modes.