### PR TITLE
samples: zephyr: Use the default MCUBoot PEM key file.

### DIFF
--- a/samples/zephyr/hello-world/prj.conf
+++ b/samples/zephyr/hello-world/prj.conf
@@ -7,3 +7,6 @@ CONFIG_STDOUT_CONSOLE=y
 
 # Enable Zephyr application to be booted by MCUboot
 CONFIG_BOOTLOADER_MCUBOOT=y
+
+# Use the default MCUBoot PEM key file (BOOT_SIGNATURE_KEY_FILE)
+CONFIG_MCUBOOT_SIGNATURE_KEY_FILE="bootloader/mcuboot/root-rsa-2048.pem"


### PR DESCRIPTION
Use the default MCUBoot PEM key file in hello-world project settings.
Without it the application is not verified by MCUBoot.