### PR TITLE
docs: release: Add notes on Zephyr USB fixes and boot serial echo

### DIFF
--- a/docs/release-notes.d/boot-serial-echo.md
+++ b/docs/release-notes.d/boot-serial-echo.md
@@ -1,0 +1,1 @@
+- Boot serial: Add response to echo command if support is not enabled, previously the command would have been accepted but no response indicating that the command is not supported would have been sent.

--- a/docs/release-notes.d/zephyr-usb.md
+++ b/docs/release-notes.d/zephyr-usb.md
@@ -1,0 +1,2 @@
+- Zephyr: Add USB CDC serial recovery check that now causes a build failure if console is enabled and device is the same as the USB CDC device.
+- Zephyr: Add USB CDC serial recovery check that now causes a build failure if the main thread priority is below 0 (cooperative thread), this would prevent USB CDC from working as the driver would not have been able to fire callbacks.


### PR DESCRIPTION
Adds 3 notes, 2 for zephyr USB CDC ACM fixes and 1 for a boot serial echo fix