### PR TITLE
boot: zephyr: add support for lpcxpresso55s28

### DIFF
--- a/boot/zephyr/boards/lpcxpresso55s28.conf
+++ b/boot/zephyr/boards/lpcxpresso55s28.conf
@@ -1,0 +1,6 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+#LPC does not support the MCUBoot swap mode.
+CONFIG_BOOT_UPGRADE_ONLY=y
+CONFIG_BOOT_MAX_IMG_SECTORS=512


### PR DESCRIPTION
Add default configuration for lpcxpresso55s28.