### PR TITLE
boot: zephyr: add support for mimxrt101x_evk

### DIFF
--- a/boot/zephyr/boards/mimxrt1010_evk.conf
+++ b/boot/zephyr/boards/mimxrt1010_evk.conf
@@ -1,0 +1,4 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BOOT_MAX_IMG_SECTORS=2048

--- a/boot/zephyr/boards/mimxrt1015_evk.conf
+++ b/boot/zephyr/boards/mimxrt1015_evk.conf
@@ -1,0 +1,4 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BOOT_MAX_IMG_SECTORS=2048


### PR DESCRIPTION
Add the default configuration for mimxrt1010_evk and mimxrt1015_evk.