### PR TITLE
boot/bootutil: give the hash of the received key to boot_retrieve_public_key_hash

### DIFF
--- a/boot/bootutil/include/bootutil/sign_key.h
+++ b/boot/bootutil/include/bootutil/sign_key.h
@@ -51,6 +51,7 @@ extern struct bootutil_key bootutil_keys[];
  * Retrieve the hash of the corresponding public key for image authentication.
  *
  * @param[in]      image_index      Index of the image to be authenticated.
+ * @param[in]      actual_key_hash  hash of the key to test
  * @param[out]     public_key_hash  Buffer to store the key-hash in.
  * @param[in,out]  key_hash_size    As input the size of the buffer. As output
  *                                  the actual key-hash length.
@@ -58,6 +59,7 @@ extern struct bootutil_key bootutil_keys[];
  * @return                          0 on success; nonzero on failure.
  */
 int boot_retrieve_public_key_hash(uint8_t image_index,
+                                  const uint8_t *actual_key_hash,
                                   uint8_t *public_key_hash,
                                   size_t *key_hash_size);
 #endif /* !MCUBOOT_HW_KEY */

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -245,7 +245,7 @@ bootutil_find_key(uint8_t image_index, uint8_t *key, uint16_t key_len)
     bootutil_sha_finish(&sha_ctx, hash);
     bootutil_sha_drop(&sha_ctx);
 
-    rc = boot_retrieve_public_key_hash(image_index, key_hash, &key_hash_size);
+    rc = boot_retrieve_public_key_hash(image_index, hash, key_hash, &key_hash_size);
     if (rc) {
         return -1;
     }


### PR DESCRIPTION
MCUBOOT_HW_KEY already allows to put your own signature key management into the bootloader, independent of mcuboot. In the moment boot_retrieve_public_key_hash is limited to exactly one key hash, since it is only called once and there is no way for the called function to determine whether it will be returning an accepted hash.    
Adding the hash itself to the call enables the project specific code to look for a fitting hash instead of just returning one. This way two things can be accomplished: 

1. Multiple HW keys can be used since now iterating through a list of hashes is feasible
2. Automatic revocation (see #221 ) can be added since the function now knows which key was used and might decide to invalidate other keys based on that fact

The key revocation scheme I plan to use based on this patch is based on a sorted list of key hashes. Normally the first entry is expected to be used for signing. If an entry deeper down the list is used, this indicates that the private keys up to that entry have been compromised and they should be invalidated. 
Invalidation itself is HW specfic. For example on an STM32 it is possible to overwrite already written flash with zeros, which can be used to delete a non zero validity flag.