### PR TITLE
add the option to use custom definitions for all crypto inline functions

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/aes_ctr.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_ctr.h
@@ -15,8 +15,9 @@
 #include "mcuboot_config/mcuboot_config.h"
 
 #if (defined(MCUBOOT_USE_MBED_TLS) + \
-     defined(MCUBOOT_USE_TINYCRYPT)) != 1
-    #error "One crypto backend must be defined: either MBED_TLS or TINYCRYPT"
+     defined(MCUBOOT_USE_TINYCRYPT) + \
+     defined (MCUBOOT_USE_CUSTOM_CRYPT)) != 1
+    #error "One crypto backend must be defined: either MBED_TLS, TINYCRYPT or CUSTOM_CRYPT"
 #endif
 
 #if defined(MCUBOOT_USE_MBED_TLS)
@@ -37,6 +38,10 @@
     #define BOOTUTIL_CRYPTO_AES_CTR_KEY_SIZE TC_AES_KEY_SIZE
     #define BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE TC_AES_BLOCK_SIZE
 #endif /* MCUBOOT_USE_TINYCRYPT */
+
+#if defined (MCUBOOT_USE_CUSTOM_CRYPT)
+    #include "aes_ctr_custom.h"
+#endif /* MCUBOOT_USE_CUSTOM_CRYPT */
 
 #include <stdint.h>
 

--- a/boot/bootutil/include/bootutil/crypto/aes_kw.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_kw.h
@@ -13,8 +13,9 @@
 #include "mcuboot_config/mcuboot_config.h"
 
 #if (defined(MCUBOOT_USE_MBED_TLS) + \
-     defined(MCUBOOT_USE_TINYCRYPT)) != 1
-    #error "One crypto backend must be defined: either MBED_TLS or TINYCRYPT"
+     defined(MCUBOOT_USE_TINYCRYPT) + \
+     defined (MCUBOOT_USE_CUSTOM_CRYPT)) != 1
+    #error "One crypto backend must be defined: either MBED_TLS, TINYCRYPT or CUSTOM_CRYPT"
 #endif
 
 #if defined(MCUBOOT_USE_MBED_TLS)
@@ -29,6 +30,10 @@
     #include <tinycrypt/aes.h>
     #include <tinycrypt/constants.h>
 #endif /* MCUBOOT_USE_TINYCRYPT */
+
+#if  defined (MCUBOOT_USE_CUSTOM_CRYPT)
+    #include "aes_kw_custom.h"
+#endif /* MCUBOOT_USE_CUSTOM_CRYPT */
 
 #include <stdint.h>
 

--- a/boot/bootutil/include/bootutil/crypto/ecdh_p256.h
+++ b/boot/bootutil/include/bootutil/crypto/ecdh_p256.h
@@ -13,8 +13,9 @@
 #include "mcuboot_config/mcuboot_config.h"
 
 #if (defined(MCUBOOT_USE_MBED_TLS) + \
-     defined(MCUBOOT_USE_TINYCRYPT)) != 1
-    #error "One crypto backend must be defined: either MBED_TLS or TINYCRYPT"
+     defined(MCUBOOT_USE_TINYCRYPT) + \
+     defined (MCUBOOT_USE_CUSTOM_CRYPT)) != 1
+    #error "One crypto backend must be defined: either MBED_TLS, TINYCRYPT or CUSTOM_CRYPT"
 #endif
 
 #if defined(MCUBOOT_USE_MBED_TLS)
@@ -29,6 +30,9 @@
     #define BOOTUTIL_CRYPTO_ECDH_P256_HASH_SIZE (4 * 8)
 #endif /* MCUBOOT_USE_TINYCRYPT */
 
+#if  defined (MCUBOOT_USE_CUSTOM_CRYPT)
+    #include "ecdh_p256_custom.h"
+#endif /* MCUBOOT_USE_CUSTOM_CRYPT */
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/boot/bootutil/include/bootutil/crypto/ecdh_x25519.h
+++ b/boot/bootutil/include/bootutil/crypto/ecdh_x25519.h
@@ -13,10 +13,14 @@
 #include "mcuboot_config/mcuboot_config.h"
 
 #if (defined(MCUBOOT_USE_MBED_TLS) + \
-     defined(MCUBOOT_USE_TINYCRYPT)) != 1
-    #error "One crypto backend must be defined: either MBED_TLS or TINYCRYPT"
+     defined(MCUBOOT_USE_TINYCRYPT) + \
+     defined (MCUBOOT_USE_CUSTOM_CRYPT)) != 1
+    #error "One crypto backend must be defined: either MBED_TLS, TINYCRYPT or CUSTOM_CRYPT"
 #endif
 
+#if  defined(MCUBOOT_USE_CUSTOM_CRYPT)
+    #include "ecdh_x25519_custom.h"
+#endif /* MCUBOOT_USE_CUSTOM_CRYPT */
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/boot/bootutil/include/bootutil/crypto/ecdsa.h
+++ b/boot/bootutil/include/bootutil/crypto/ecdsa.h
@@ -34,8 +34,9 @@
 
 #if (defined(MCUBOOT_USE_TINYCRYPT) + \
      defined(MCUBOOT_USE_CC310) + \
-     defined(MCUBOOT_USE_PSA_OR_MBED_TLS)) != 1
-    #error "One crypto backend must be defined: either CC310/TINYCRYPT/MBED_TLS/PSA_CRYPTO"
+     defined(MCUBOOT_USE_PSA_OR_MBED_TLS) +\
+     defined (MCUBOOT_USE_CUSTOM_CRYPT)) != 1
+    #error "One crypto backend must be defined: either CC310/TINYCRYPT/MBED_TLS/PSA_CRYPTO/CUSTOM_CRYPT"
 #endif
 
 #if defined(MCUBOOT_USE_TINYCRYPT)
@@ -62,6 +63,10 @@
 #define NUM_ECC_BYTES (256 / 8)
 #endif
 
+#if  defined (MCUBOOT_USE_CUSTOM_CRYPT)
+    #include "ecdsa_custom.h"
+#endif /* MCUBOOT_USE_CUSTOM_CRYPT */
+
 /* Universal defines */
 #define BOOTUTIL_CRYPTO_ECDSA_P256_HASH_SIZE (32)
 
@@ -74,7 +79,7 @@
 extern "C" {
 #endif
 
-#if (defined(MCUBOOT_USE_TINYCRYPT) || defined(MCUBOOT_USE_MBED_TLS) || \
+#if (defined(MCUBOOT_USE_TINYCRYPT) || defined(MCUBOOT_USE_MBED_TLS) ||\
      defined(MCUBOOT_USE_CC310)) && !defined(MCUBOOT_USE_PSA_CRYPTO)
 /*
  * Declaring these like this adds NULL termination.

--- a/boot/bootutil/include/bootutil/crypto/hmac_sha256.h
+++ b/boot/bootutil/include/bootutil/crypto/hmac_sha256.h
@@ -13,8 +13,9 @@
 #include "mcuboot_config/mcuboot_config.h"
 
 #if (defined(MCUBOOT_USE_MBED_TLS) + \
-     defined(MCUBOOT_USE_TINYCRYPT)) != 1
-    #error "One crypto backend must be defined: either MBED_TLS or TINYCRYPT"
+     defined(MCUBOOT_USE_TINYCRYPT) + \
+     defined (MCUBOOT_USE_CUSTOM_CRYPT)) != 1
+    #error "One crypto backend must be defined: either MBED_TLS, TINYCRYPT or CUSTOM_CRYPT"
 #endif
 
 #if defined(MCUBOOT_USE_MBED_TLS)
@@ -30,6 +31,10 @@
     #include <tinycrypt/constants.h>
     #include <tinycrypt/hmac.h>
 #endif /* MCUBOOT_USE_TINYCRYPT */
+
+#if  defined (MCUBOOT_USE_CUSTOM_CRYPT)
+    #include "hmac_sha256_custom.h"
+#endif /* MCUBOOT_USE_CUSTOM_CRYPT */
 
 #include <stdint.h>
 

--- a/boot/bootutil/include/bootutil/crypto/rsa.h
+++ b/boot/bootutil/include/bootutil/crypto/rsa.h
@@ -28,7 +28,7 @@
 
 #include "mcuboot_config/mcuboot_config.h"
 
-#if defined(MCUBOOT_USE_PSA_CRYPTO) || defined(MCUBOOT_USE_MBED_TLS)
+#if defined(MCUBOOT_USE_PSA_CRYPTO) || defined(MCUBOOT_USE_MBED_TLS) || defined(MCUBOOT_USE_CUSTOM_CRYPT)
 #define MCUBOOT_USE_PSA_OR_MBED_TLS
 #endif /* MCUBOOT_USE_PSA_CRYPTO || MCUBOOT_USE_MBED_TLS */
 
@@ -57,6 +57,9 @@
 
 #endif /* MCUBOOT_USE_MBED_TLS */
 
+#if defined(MCUBOOT_USE_CUSTOM_CRYPT)
+    #include "rsa_custom.h"
+#endif /* MCUBOOT_USE_CUSTOM_CRYPT */
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/boot/bootutil/include/bootutil/crypto/sha.h
+++ b/boot/bootutil/include/bootutil/crypto/sha.h
@@ -30,7 +30,8 @@
 
 #if (defined(MCUBOOT_USE_PSA_OR_MBED_TLS) + \
      defined(MCUBOOT_USE_TINYCRYPT) + \
-     defined(MCUBOOT_USE_CC310)) != 1
+     defined(MCUBOOT_USE_CC310) +\
+     defined (MCUBOOT_USE_CUSTOM_CRYPT)) != 1
     #error "One crypto backend must be defined: either CC310/MBED_TLS/TINYCRYPT/PSA_CRYPTO"
 #endif
 
@@ -68,6 +69,10 @@
 #if defined(MCUBOOT_USE_CC310)
     #include <cc310_glue.h>
 #endif /* MCUBOOT_USE_CC310 */
+
+#if defined (MCUBOOT_USE_CUSTOM_CRYPT)
+    #include "sha_custom.h"
+#endif /* MCUBOOT_USE_CUSTOM_CRYPT */
 
 #include <stdint.h>
 


### PR DESCRIPTION
As previously discussed in #1478 , this adds a define named `MCUBOOT_USE_CUSTOM_CRYPT`. 
Using that define, `headername_custom.h` will be included in the crypto headers instead of enabling any pre defined code path.
Since the include calls throughout mcuboot are clean already, it is actually enough to implement only the used algorithms. So if e.g. RSA is not used, a definition of `rsa_custom.h` is NOT necessary.