### PR TITLE
zephyr: io: trivial fixes after I/O functions separation (if MCUBOOT_INDICATION_LED enabled)

### DIFF
--- a/boot/zephyr/include/io/io.h
+++ b/boot/zephyr/include/io/io.h
@@ -35,6 +35,11 @@ extern "C" {
 void io_led_init(void);
 
 /*
+ * Sets value of the configured LED.
+ */
+void io_led_set(int value);
+
+/*
  * Checks if GPIO is set in the required way to remain in serial recovery mode
  *
  * @retval	false for normal boot, true for serial recovery boot

--- a/boot/zephyr/io.c
+++ b/boot/zephyr/io.c
@@ -28,6 +28,7 @@
 #include <zephyr/linker/linker-defs.h>
 
 #include "target.h"
+#include "bootutil/bootutil_log.h"
 
 #if defined(CONFIG_BOOT_SERIAL_PIN_RESET) || defined(CONFIG_BOOT_FIRMWARE_LOADER_PIN_RESET)
 #include <zephyr/drivers/hwinfo.h>
@@ -77,6 +78,8 @@ static const struct gpio_dt_spec led0 = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
 /* A build error here means your board isn't set up to drive an LED. */
 #error "Unsupported board: led0 devicetree alias is not defined"
 #endif
+
+BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 void io_led_init(void)
 {

--- a/boot/zephyr/io.c
+++ b/boot/zephyr/io.c
@@ -91,6 +91,11 @@ void io_led_init(void)
     gpio_pin_configure_dt(&led0, GPIO_OUTPUT);
     gpio_pin_set_dt(&led0, 0);
 }
+
+void io_led_set(int value)
+{
+    gpio_pin_set_dt(&led0, value);
+}
 #endif /* CONFIG_MCUBOOT_INDICATION_LED */
 
 #if defined(CONFIG_BOOT_SERIAL_ENTRANCE_GPIO) || defined(CONFIG_BOOT_USB_DFU_GPIO) || \

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -377,7 +377,7 @@ static void boot_serial_enter()
     int rc;
 
 #ifdef CONFIG_MCUBOOT_INDICATION_LED
-    gpio_pin_set_dt(&led0, 1);
+    io_led_set(1);
 #endif
 
     mcuboot_status_change(MCUBOOT_STATUS_SERIAL_DFU_ENTERED);
@@ -434,7 +434,7 @@ int main(void)
 #if defined(CONFIG_BOOT_USB_DFU_GPIO)
     if (io_detect_pin()) {
 #ifdef CONFIG_MCUBOOT_INDICATION_LED
-        gpio_pin_set_dt(&led0, 1);
+        io_led_set(1);
 #endif
 
         mcuboot_status_change(MCUBOOT_STATUS_USB_DFU_ENTERED);
@@ -475,7 +475,7 @@ int main(void)
     uint32_t start = k_uptime_get_32();
 
 #ifdef CONFIG_MCUBOOT_INDICATION_LED
-    gpio_pin_set_dt(&led0, 1);
+    io_led_set(1);
 #endif
 #endif
 
@@ -499,7 +499,7 @@ int main(void)
     boot_serial_check_start(&boot_funcs,timeout_in_ms);
 
 #ifdef CONFIG_MCUBOOT_INDICATION_LED
-    gpio_pin_set_dt(&led0, 0);
+    io_led_set(0);
 #endif
 #endif
 

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -407,7 +407,7 @@ int main(void)
 
 #ifdef CONFIG_MCUBOOT_INDICATION_LED
     /* LED init */
-    led_init();
+    io_led_init();
 #endif
 
     os_heap_init();


### PR DESCRIPTION
This short series includes 3 warning/error fixes found when building with `MCUBOOT_INDICATION_LED` and `LOG` enabled:

- `zephyr: rename 'led_init()' to 'io_led_init()'`
- `zephyr: io: include 'bootutil_log.h' and declare log module membership`
- `zephyr: io: add 'io_led_set()'`

All issues were introduced in 433b8480f760bdf40381e7543e358185a1006a2b.

The last fix (`zephyr: io: add 'io_led_set()'`) should be treated as more a proposal as there might be other solutions/approaches preferred.