### PR TITLE
zephyr: Fix sysflash and undefined function warning

### DIFF
--- a/boot/zephyr/firmware_loader.c
+++ b/boot/zephyr/firmware_loader.c
@@ -62,6 +62,7 @@ boot_image_validate(const struct flash_area *fa_p,
 }
 #endif /* MCUBOOT_VALIDATE_PRIMARY_SLOT || MCUBOOT_VALIDATE_PRIMARY_SLOT_ONCE*/
 
+#if defined(MCUBOOT_VALIDATE_PRIMARY_SLOT_ONCE)
 inline static fih_ret
 boot_image_validate_once(const struct flash_area *fa_p,
                     struct image_header *hdr)
@@ -92,6 +93,7 @@ boot_image_validate_once(const struct flash_area *fa_p,
     }
     FIH_RET(FIH_SUCCESS);
 }
+#endif
 
 /**
  * Validates that an image in a slot is OK to boot.

--- a/boot/zephyr/include/sysflash/sysflash.h
+++ b/boot/zephyr/include/sysflash/sysflash.h
@@ -12,7 +12,7 @@
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/sys/util_macro.h>
 
-#ifndef CONFIG_SINGLE_APPLICATION_SLOT
+#if !defined(CONFIG_SINGLE_APPLICATION_SLOT) && !defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_SINGLE_APP)
 
 /* Each pair of slots is separated by , and there is no terminating character */
 #define FLASH_AREA_IMAGE_0_SLOTS    slot0_partition, slot1_partition
@@ -50,7 +50,7 @@ static inline uint32_t __flash_area_ids_for_slot(int img, int slot)
 #define FLASH_AREA_IMAGE_SCRATCH    FIXED_PARTITION_ID(scratch_partition)
 #endif
 
-#else /* CONFIG_SINGLE_APPLICATION_SLOT */
+#else /* !CONFIG_SINGLE_APPLICATION_SLOT && !CONFIG_MCUBOOT_BOOTLOADER_MODE_SINGLE_APP */
 
 #define FLASH_AREA_IMAGE_PRIMARY(x)	FIXED_PARTITION_ID(slot0_partition)
 #define FLASH_AREA_IMAGE_SECONDARY(x)	FIXED_PARTITION_ID(slot0_partition)

--- a/boot/zephyr/single_loader.c
+++ b/boot/zephyr/single_loader.c
@@ -58,6 +58,7 @@ boot_image_validate(const struct flash_area *fa_p,
 }
 #endif /* MCUBOOT_VALIDATE_PRIMARY_SLOT || MCUBOOT_VALIDATE_PRIMARY_SLOT_ONCE*/
 
+#if defined(MCUBOOT_VALIDATE_PRIMARY_SLOT_ONCE)
 inline static fih_ret
 boot_image_validate_once(const struct flash_area *fa_p,
                     struct image_header *hdr)
@@ -88,6 +89,7 @@ boot_image_validate_once(const struct flash_area *fa_p,
     }
     FIH_RET(FIH_SUCCESS);
 }
+#endif
 
 /**
  * Gather information on image and prepare for booting.


### PR DESCRIPTION
    zephyr: sysflash: Fix if condition for zephyr applications
    
    Fixes an issue when sysflash is included by zephyr (non-mcuboot)
    applications


    zephyr: firmware/single_loader: Fix compile warning
    
    Fixes an issue of an unused function calling an undefined function
