### PR TITLE
zephyr: kconfig: make MBEDTLS_PROMPTLESS depend on MBEDTLS

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -30,7 +30,7 @@ config BOOT_USE_TINYCRYPT
 	# When building for ECDSA, we use our own copy of mbedTLS, so the
 	# Zephyr one must not be enabled or the MBEDTLS_CONFIG_FILE macros
 	# will collide.
-	select MBEDTLS_PROMPTLESS
+	select MBEDTLS_PROMPTLESS if ZEPHYR_MBEDTLS_MODULE
 	help
 	  Use TinyCrypt for crypto primitives.
 


### PR DESCRIPTION
This addresses compilation error when MBEDTLS module is not present.