### PR TITLE
ext: fiat: Use user-defined assert macro

### DIFF
--- a/ext/fiat/src/curve25519.c
+++ b/ext/fiat/src/curve25519.c
@@ -27,11 +27,10 @@
 //
 // The field functions are shared by Ed25519 and X25519 where possible.
 
-#include <assert.h>
 #include <string.h>
 #include <stdint.h>
 
-#include <mcuboot_config/mcuboot_config.h>
+#include <bootutil/bootutil_public.h>
 
 #if defined(MCUBOOT_USE_MBED_TLS)
 #include <mbedtls/platform_util.h>


### PR DESCRIPTION
By defining `MCUBOOT_HAVE_ASSERT_H`, a user can configure MCUboot to use a custom definition of the `assert` macro, defined in `mcuboot_config/mcuboot_assert.h` instead of the one coming from the C standard library.

However, the libc's `assert` macro was used in `curve25519.c` even if `MCUBOOT_HAVE_ASSERT_H` is defined. This PR fixes this issue by removing `#include <assert.h>` from `curve25519.c` to rely instead of the `assert` definition from `bootutil/bootutil_public.h`.