### PR TITLE
bootutil: Fix compatible sector check

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -470,6 +470,10 @@ boot_write_status(const struct boot_loader_state *state, struct boot_status *bs)
     memset(buf, erased_val, BOOT_MAX_ALIGN);
     buf[0] = bs->state;
 
+    BOOT_LOG_DBG("writing swap status; fa_id=%d off=0x%lx (0x%lx)",
+                 flash_area_get_id(fap), (unsigned long)off,
+                 (unsigned long)flash_area_get_off(fap) + off);
+
     rc = flash_area_write(fap, off, buf, align);
     if (rc != 0) {
         rc = BOOT_EFLASH;

--- a/docs/release-notes.d/bootutil-sector.md
+++ b/docs/release-notes.d/bootutil-sector.md
@@ -1,0 +1,7 @@
+- bootutil: Fixed issue with comparing sector sizes for
+  compatibility, this now also checks against the number of usable
+  sectors (which is the slot size minus the swap status and moved
+  up by one sector).
+- bootutil: Added debug logging to show write location of swap status
+  and details on sectors including if slot sizes are not optimal for
+  a given board.


### PR DESCRIPTION
    bootutil: Add debug logging for boot status write
    
    Adds debug level logging which shows the offset of where a
    sector swap status write is occurring at


    bootutil: Fix compatible sector checking
    
    Fixes an issue whereby slot sizes were checked but the check was
    not done properly. This also adds debug log messages to show the
    sector configuration including if slot sizes are not optimal


    docs: release: Add release notes on changes
    
    Adds release notes on bootutil changes
