### PR TITLE
boot/zephyr: Define SOC_FLASH_0_ID and SPI_FLASH_0_ID

### DIFF
--- a/boot/zephyr/include/sysflash/sysflash.h
+++ b/boot/zephyr/include/sysflash/sysflash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Nordic Semiconductor ASA
+ * Copyright (c) 2023-2024 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,6 +11,14 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/sys/util_macro.h>
+
+#ifndef SOC_FLASH_0_ID
+#define SOC_FLASH_0_ID 0
+#endif
+
+#ifndef SPI_FLASH_0_ID
+#define SPI_FLASH_0_ID 1
+#endif
 
 #if !defined(CONFIG_SINGLE_APPLICATION_SLOT) && !defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_SINGLE_APP)
 


### PR DESCRIPTION
The defines have been taken from the Zephyr flash_map.h but as they are provided there for MCUboot only, they can be just defined here.