### PR TITLE
zephyr: Add NRF54L configuration

### DIFF
--- a/boot/zephyr/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/boot/zephyr/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_BOOT_MAX_IMG_SECTORS=256
+
+# Ensure that the qspi driver is disabled by default
+CONFIG_NORDIC_QSPI_NOR=n
+
+# TODO: below are not yet supported and need fixing
+CONFIG_FPROTECT=n
+CONFIG_BOOT_WATCHDOG_FEED=n


### PR DESCRIPTION
Adds default Kconfig configuration that allows to build MCUboot for NRF54L.
Currently this configuration turns off WDT and FPROTECT, which is TODO to fix.