### PR TITLE
zephyr: Add estimated size of update trailer to sysbuild

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -492,15 +492,24 @@ if(SYSBUILD)
     endif()
 
     math(EXPR required_size "${key_size} + ${boot_magic_size} + ${boot_swap_data_size} + ${boot_status_data_size} + ${boot_tlv_estimate}")
-
     align_up(${required_size} ${erase_size} required_size)
+
+    if(CONFIG_SINGLE_APPLICATION_SLOT OR CONFIG_BOOT_FIRMWARE_LOADER)
+      set(required_upgrade_size "0")
+    else()
+      math(EXPR required_upgrade_size "${boot_magic_size} + ${boot_swap_data_size} + ${boot_status_data_size}")
+      align_up(${required_upgrade_size} ${erase_size} required_upgrade_size)
+    endif()
 
     if(CONFIG_BOOT_SWAP_USING_MOVE)
       math(EXPR required_size "${required_size} + ${erase_size}")
+      math(EXPR required_upgrade_size "${required_upgrade_size} + ${erase_size}")
     endif()
   else()
     set(required_size 0)
+    set(required_upgrade_size 0)
   endif()
 
   set(mcuboot_image_footer_size ${required_size} CACHE INTERNAL "Estimated MCUboot image trailer size" FORCE)
+  set(mcuboot_image_upgrade_footer_size ${required_upgrade_size} CACHE INTERNAL "Estimated MCUboot update image trailer size" FORCE)
 endif()

--- a/boot/zephyr/sysbuild/CMakeLists.txt
+++ b/boot/zephyr/sysbuild/CMakeLists.txt
@@ -31,9 +31,12 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_post_image_cmake)
 
     if("${app_type}" STREQUAL "MAIN")
       sysbuild_get(mcuboot_image_footer_size IMAGE mcuboot CACHE)
+      sysbuild_get(mcuboot_image_upgrade_footer_size IMAGE mcuboot CACHE)
       math(EXPR mcuboot_image_footer_size "${mcuboot_image_footer_size}" OUTPUT_FORMAT HEXADECIMAL)
+      math(EXPR mcuboot_image_upgrade_footer_size "${mcuboot_image_upgrade_footer_size}" OUTPUT_FORMAT HEXADECIMAL)
 
       set_property(TARGET ${image} APPEND_STRING PROPERTY CONFIG "CONFIG_ROM_END_OFFSET=${mcuboot_image_footer_size}\n")
+      set_property(TARGET ${image} APPEND_STRING PROPERTY CONFIG "CONFIG_MCUBOOT_UPDATE_FOOTER_SIZE=${mcuboot_image_upgrade_footer_size}\n")
       return()
     endif()
   endforeach()


### PR DESCRIPTION
Adds a new field which is set to the estimated size of the upgrade slot data, this is used to know how much space should be reserved in an update image to determine if an update will fit or not