### PR TITLE
Add BOOT_SERIAL_WAIT_FOR_DFU_ALWAYS Zephyr Kconfig option.

### DIFF
--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -150,12 +150,20 @@ config BOOT_SERIAL_DETECT_DELAY
 	  the one used to place the device in bootloader mode.
 
 menuconfig BOOT_SERIAL_WAIT_FOR_DFU
-	bool "Wait a prescribed duration to see if DFU is invoked by receiving a MCUmgr comand"
+	bool "Wait a prescribed duration to see if DFU is invoked by receiving a MCUmgr command"
 	depends on BOOT_SERIAL_UART || BOOT_SERIAL_CDC_ACM
 	help
 	  If y, MCUboot waits for a prescribed duration of time to allow
 	  for DFU to be invoked. The serial recovery can be entered by receiving any
 	  mcumgr command.
+
+config BOOT_SERIAL_WAIT_FOR_DFU_ALWAYS
+	bool "Always enter serial recovery mode upon startup"
+	depends on BOOT_SERIAL_WAIT_FOR_DFU
+	help
+	  If y, MCUboot always enters serial recovery mode upon startup for the
+	  duration of BOOT_SERIAL_WAIT_FOR_DFU_TIMEOUT. Otherwise, MCUboot only
+	  enters serial recovery mode if the board was physically reset.
 
 config BOOT_SERIAL_WAIT_FOR_DFU_TIMEOUT
 	int "Duration to wait for the serial DFU timeout in ms"

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -385,8 +385,12 @@ static void boot_serial_enter()
     BOOT_LOG_INF("Enter the serial recovery mode");
     rc = boot_console_init();
     __ASSERT(rc == 0, "Error initializing boot console.\n");
+#ifdef CONFIG_BOOT_SERIAL_WAIT_FOR_DFU
+    boot_serial_check_start(&boot_funcs, CONFIG_BOOT_SERIAL_WAIT_FOR_DFU_TIMEOUT);
+#else
     boot_serial_start(&boot_funcs);
     __ASSERT(0, "Bootloader serial process was terminated unexpectedly.\n");
+#endif 
 }
 #endif
 
@@ -464,7 +468,7 @@ int main(void)
     }
 #endif
 
-#ifdef CONFIG_BOOT_SERIAL_WAIT_FOR_DFU
+#ifdef CONFIG_BOOT_SERIAL_WAIT_FOR_DFU_ALWAYS
     /* Initialize the boot console, so we can already fill up our buffers while
      * waiting for the boot image check to finish. This image check, can take
      * some time, so it's better to reuse thistime to already receive the
@@ -490,7 +494,7 @@ int main(void)
     }
 #endif
 
-#ifdef CONFIG_BOOT_SERIAL_WAIT_FOR_DFU
+#ifdef CONFIG_BOOT_SERIAL_WAIT_FOR_DFU_ALWAYS
     timeout_in_ms -= (k_uptime_get_32() - start);
     if( timeout_in_ms <= 0 ) {
         /* at least one check if time was expired */


### PR DESCRIPTION
This PR adds the `BOOT_SERIAL_WAIT_FOR_DFU_ALWAYS` Kconfig option. When set to `n`, under normal circumstances, the bootloader doesn't enter serial recovery mode, allowing the firmware to start up as quickly as possible. However, when physically resetting the device, the bootloader enters serial recovery mode, which comes in very handy when the firmware is broken.

This patch was actually created by Vidar Berg at https://devzone.nordicsemi.com/f/nordic-q-a/108213/mcuboot-should-only-timeout-after-hardware-reset/469112 who allowed me to submit it here as a PR.