### PR TITLE
New OVERWRITE_ONLY_KEEP_BACKUP option

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1450,6 +1450,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
     }
 #endif /* MCUBOOT_HW_ROLLBACK_PROT */
 
+#ifndef MCUBOOT_OVERWRITE_ONLY_KEEP_BACKUP
     /*
      * Erases header and trailer. The trailer is erased because when a new
      * image is written without a trailer as is the case when using newt, the
@@ -1460,6 +1461,8 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
                            boot_img_sector_off(state, BOOT_SECONDARY_SLOT, 0),
                            boot_img_sector_size(state, BOOT_SECONDARY_SLOT, 0));
     assert(rc == 0);
+#endif
+
     last_sector = boot_img_num_sectors(state, BOOT_SECONDARY_SLOT) - 1;
     BOOT_LOG_DBG("erasing secondary trailer");
     rc = boot_erase_region(fap_secondary_slot,


### PR DESCRIPTION
I needed to create s solution based on OVERWRITE_ONLY mode that would keep a backup of the active image in the secondary slot. The main motivation was a use of MCU that doesn't support available swap modes due to its flash features. The code modification was very simple, however, I'm not 100% sure these changes don't clash with something else.

I needed to cover these scenarios:
- Both primary and secondary images are valid -> boot
- Primary image invalid -> do a recovery from the backup in the secondary slot -> boot
- Secondary image invalid -> do a backup recovery from the primary slot -> boot

The commit message explains further:

It builds on top of OVERWRITE_ONLY mode and uses secondary slot as a backup of the primary slot. The main difference is that after image copy to the primary slot the secondary slot is **NOT** erased. This is meant to be used together with BOOTSTRAP option that will recover the primary image from the backup in case it's not valid. The backup is checked on every boot. In case the backup is invalid the image from the primary slot is used to create a valid backup again.