### PR TITLE
imgtool: Add --non-bootable flag

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -142,7 +142,8 @@ class Image():
                  slot_size=0, max_sectors=DEFAULT_MAX_SECTORS,
                  overwrite_only=False, endian="little", load_addr=0,
                  rom_fixed=None, erased_val=None, save_enctlv=False,
-                 security_counter=None, max_align=None):
+                 security_counter=None, max_align=None,
+                 non_bootable=False):
 
         if load_addr and rom_fixed:
             raise click.UsageError("Can not set rom_fixed and load_addr at the same time")
@@ -166,6 +167,7 @@ class Image():
         self.save_enctlv = save_enctlv
         self.enctlv_len = 0
         self.max_align = max(DEFAULT_MAX_ALIGN, align) if max_align is None else int(max_align)
+        self.non_bootable = non_bootable
 
         if self.max_align == DEFAULT_MAX_ALIGN:
             self.boot_magic = bytes([
@@ -551,6 +553,8 @@ class Image():
             flags |= IMAGE_F['RAM_LOAD']
         if self.rom_fixed:
             flags |= IMAGE_F['ROM_FIXED']
+        if self.non_bootable:
+            flags |= IMAGE_F['NON_BOOTABLE']
 
         e = STRUCT_ENDIAN_DICT[self.endian]
         fmt = (e +

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -312,6 +312,8 @@ class BasedIntParamType(click.ParamType):
 
 @click.argument('outfile')
 @click.argument('infile')
+@click.option('--non-bootable', default=False, is_flag=True,
+              help='Mark the image as non-bootable.')
 @click.option('--custom-tlv', required=False, nargs=2, default=[],
               multiple=True, metavar='[tag] [value]',
               help='Custom TLV that will be placed into protected area. '
@@ -409,7 +411,7 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
          endian, encrypt_keylen, encrypt, infile, outfile, dependencies,
          load_addr, hex_addr, erased_val, save_enctlv, security_counter,
          boot_record, custom_tlv, rom_fixed, max_align, clear, fix_sig,
-         fix_sig_pubkey, sig_out, vector_to_sign):
+         fix_sig_pubkey, sig_out, vector_to_sign, non_bootable):
 
     if confirm:
         # Confirmed but non-padded images don't make much sense, because
@@ -421,7 +423,8 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
                       max_sectors=max_sectors, overwrite_only=overwrite_only,
                       endian=endian, load_addr=load_addr, rom_fixed=rom_fixed,
                       erased_val=erased_val, save_enctlv=save_enctlv,
-                      security_counter=security_counter, max_align=max_align)
+                      security_counter=security_counter, max_align=max_align,
+                      non_bootable=non_bootable)
     img.load(infile)
     key = load_key(key) if key else None
     enckey = load_key(encrypt) if encrypt else None


### PR DESCRIPTION
One of the allowed flags in the image header is `IMAGE_F_NON_BOOTABLE`. This adds the ability to set this flag via the CLI tool.