### PR TITLE
zephyr: boards: Remove CONFIG_FPROTECT from nrf54l15

### DIFF
--- a/boot/zephyr/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
+++ b/boot/zephyr/boards/nrf54l15pdk_nrf54l15_cpuapp.conf
@@ -7,6 +7,4 @@ CONFIG_BOOT_MAX_IMG_SECTORS=256
 # Ensure that the qspi driver is disabled by default
 CONFIG_NORDIC_QSPI_NOR=n
 
-# TODO: below are not yet supported and need fixing
-CONFIG_FPROTECT=n
 CONFIG_BOOT_WATCHDOG_FEED=n


### PR DESCRIPTION
CONFIG_FPROTECT is defined only in NRF repository, it should not be added here.