### PR TITLE
boot: zephyr: Add a custom boot banner

### DIFF
--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -35,3 +35,6 @@ CONFIG_MCUBOOT_LOG_LEVEL_INF=y
 CONFIG_CBPRINTF_NANO=y
 ### Use the minimal C library to reduce flash usage
 CONFIG_MINIMAL_LIBC=y
+
+### Custom boot banner
+CONFIG_BOOT_BANNER_STRING="Booting MCUBoot build"


### PR DESCRIPTION
Cutomize MCUBoot boot banner to ease identifiation of boot steps in console.