### PR TITLE
zephyr: boards: set BOOT_MAX_IMG_SECTORS value for rd_rw612_bga

### DIFF
--- a/boot/zephyr/boards/rd_rw612_bga.conf
+++ b/boot/zephyr/boards/rd_rw612_bga.conf
@@ -1,0 +1,4 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BOOT_MAX_IMG_SECTORS=1024


### PR DESCRIPTION
MX25UM flash on rd_rw612_bga is very large (8MB), so we must increase the number of max sectors when targeting this board with MCUboot

Note- this support depends on https://github.com/zephyrproject-rtos/zephyr/pull/70186