### PR TITLE
boot: zephyr: add `BOOT_MAX_IMG_SECTORS_OVERRIDE`

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -365,9 +365,12 @@ config BOOT_ENCRYPTION_KEY_FILE
 	  with the public key information will be written in a format expected by
 	  MCUboot.
 
+config BOOT_MAX_IMG_SECTORS_OVERRIDE
+	bool "Use external default for BOOT_MAX_IMG_SECTORS"
+
 config BOOT_MAX_IMG_SECTORS
 	int "Maximum number of sectors per image slot"
-	default 128
+	default 128 if !BOOT_MAX_IMG_SECTORS_OVERRIDE
 	help
 	  This option controls the maximum number of sectors that each of
 	  the two image areas can contain. Smaller values reduce MCUboot's


### PR DESCRIPTION
Add a symbol to allow the default value of `BOOT_MAX_IMG_SECTORS` to be updated by external kconfig files.

${BOARD_ROOT}/board/kconfig.default
```
// This board requires at least 206 sectors
config BOOT_MAX_IMG_SECTORS_OVERRIDE
	bool "Override default value"
	default y if MCUBOOT

config BOOT_MAX_IMG_SECTORS
	int "Override default value"
	depends on MCUBOOT
	default 256
```

Resolves #1919