### PR TITLE
imgtool: image.py: fix tlv type packing

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -123,7 +123,7 @@ class TLV():
                 raise click.UsageError(msg)
             buf = struct.pack(e + 'HH', kind, len(payload))
         else:
-            buf = struct.pack(e + 'BBH', TLV_VALUES[kind], 0, len(payload))
+            buf = struct.pack(e + 'HH', TLV_VALUES[kind], len(payload))
         self.buf += buf
         self.buf += payload
 


### PR DESCRIPTION
TLV type is a 16-bit. Even though the standard tlv types are all limited to 8-bit, custom / vendor specific tlv types can be 16-bit. This change allows to correctly set a vendor specific 16-bit tlv type.