### PR TITLE
boot: zephyr: Fix disabling I/D caches

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -690,6 +690,16 @@ config MCUBOOT_ACTION_HOOKS
 	  'mcuboot_status_type_t' is listed in
 	  boot/bootutil/include/bootutil/mcuboot_status.h
 
+config BOOT_DISABLE_CACHES
+	bool "Disable I/D caches before chain-loading application"
+	depends on CPU_HAS_ICACHE || CPU_HAS_DCACHE
+	default y
+	help
+	  Will flush and disable the instruction and data caches on the CPU prior to
+	  booting an application, this is required on some ARM Cortex devices and
+	  increases protection against data leakage from MCUboot to applications via
+	  these caches.
+
 endmenu
 
 config MCUBOOT_DEVICE_SETTINGS

--- a/docs/release-notes.d/zephyr-cache.md
+++ b/docs/release-notes.d/zephyr-cache.md
@@ -1,0 +1,4 @@
+- Zephyr: Fixes support for disabling instruction/data caches prior
+  to chain-loading an application, this will be automatically
+  enabled if one or both of these caches are present. This feature
+  can be disabled by setting `CONFIG_BOOT_DISABLE_CACHES` to `n`.


### PR DESCRIPTION
    Fixes an issue whereby the instruction and data caches being
    disabled before booting code had bit-rotted and no longer worked,
    adds a new Kconfig that allows this option to be turned off if
    wanted.
