### PR TITLE
boot/bootutil: Remove direct accesses to flash_area::fa_xyz

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -173,7 +173,7 @@ boot_status_off(const struct flash_area *fap)
     elem_sz = flash_area_align(fap);
 
 #if MCUBOOT_SWAP_USING_SCRATCH
-    if (fap->fa_id == FLASH_AREA_IMAGE_SCRATCH) {
+    if (flash_area_get_id(fap) == FLASH_AREA_IMAGE_SCRATCH) {
         off_from_end = boot_scratch_trailer_sz(elem_sz);
     } else {
 #endif

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1056,7 +1056,7 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
             goto out;
         }
 
-        if (reset_value < pri_fa->fa_off || reset_value> (pri_fa->fa_off + pri_fa->fa_size)) {
+        if (reset_value < flash_area_get_off(pri_fa) || reset_value > (flash_area_get_off(pri_fa) + flash_area_get_size(pri_fa))) {
             BOOT_LOG_ERR("Reset address of image in secondary slot is not in the primary slot");
             BOOT_LOG_ERR("Erasing image from secondary slot");
 

--- a/docs/release-notes.d/bootutil-sector.md
+++ b/docs/release-notes.d/bootutil-sector.md
@@ -1,3 +1,5 @@
+- bootutil: Removed manual mentions to `flash_area::fa_xyz`,
+  allowing for an opaque `flash_area` definition.
 - bootutil: Fixed issue with comparing sector sizes for
   compatibility, this now also checks against the number of usable
   sectors (which is the slot size minus the swap status and moved


### PR DESCRIPTION
I plan on working towards building a Rust API for bootutil, and I would like to pass an opaque `struct flash_area` to bootutil, so that this struct can be fully managed from the rust side, with only a few `extern "C"` functions that will need to be defined on the rust side before linking.

This PR removes the few direct accesses to `flash_area::fa_id`, `flash_area::fa_off` and `flash_area::fa_size` that are present in bootutil, and replaces them with the corresponding `flash_area_get_XYZ` functions.

Currently, however, one can only use an opaque `struct flash_area` if they enable the new flash sector API (`MCUBOOT_USE_FLASH_AREA_GET_SECTORS`), since otherwise `loader.c` will attempt to create an array of `struct flash_area`. I thus do not know how we could ensure that no additional mentions of `flash_area::fa_XYZ` will sneak back into the code.

One option would be to create a `bootutil_shared.h` file, which would contain the minimal expected subset of `flash_map_backend.h`, and progressively have files include it, until the `flash_map_backend.h` only needs to provide the `struct flash_area` for when `MCUBOOT_USE_FLASH_AREA_GET_SECTORS` isn't toggled on.