### PR TITLE
mynewt: Change main to mynewt_main

### DIFF
--- a/boot/mynewt/src/main.c
+++ b/boot/mynewt/src/main.c
@@ -214,7 +214,7 @@ int flash_device_base(uint8_t fd_id, uintptr_t *ret)
 }
 
 int
-main(void)
+mynewt_main(void)
 {
     struct boot_rsp rsp;
     uintptr_t flash_base;
@@ -264,4 +264,15 @@ main(void)
 #endif
 
     return 0;
+}
+
+/*
+ * Mynewt startup code jump to mynewt_main()
+ * This function is here for compatibility with
+ * pre 1.12. mynewt-core that still wanted main()
+ */
+int
+main(void)
+{
+    mynewt_main();
 }


### PR DESCRIPTION
mynewt system for some time now uses mynewt_main() as starting point called from startup code.
This changes function name main to mynewt_main but provides backup main function that will be linked if pre 1.12 mynewt-core is used with mcuboot