### PR TITLE
bootutil: Fix memory leak in HKDF implementation

### DIFF
--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -276,6 +276,8 @@ hkdf(uint8_t *ikm, uint16_t ikm_len, uint8_t *info, uint16_t info_len,
         goto error;
     }
 
+    bootutil_hmac_sha256_drop(&hmac);
+
     /*
      * Expand
      */
@@ -315,6 +317,8 @@ hkdf(uint8_t *ikm, uint16_t ikm_len, uint8_t *info, uint16_t info_len,
             goto error;
         }
 
+        bootutil_hmac_sha256_drop(&hmac);
+
         if (len > BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE) {
             memcpy(&okm[off], T, BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
             len -= BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE;
@@ -324,7 +328,6 @@ hkdf(uint8_t *ikm, uint16_t ikm_len, uint8_t *info, uint16_t info_len,
         }
     }
 
-    bootutil_hmac_sha256_drop(&hmac);
     return 0;
 
 error:


### PR DESCRIPTION
The `bootutil_hmac_sha256_set_key` routine performs some dynamic memory allocations when mbedTLS is used. To properly free the allocated memory, `bootutil_hmac_sha256_drop` must be called before re-initializing the HMAC context using `bootutil_hmac_sha256_init`. However, in the `hkdf` routine, the HMAC context was freed only once even though it was initialized multiple times.

This PR fixes the issue.