### PR TITLE
boot: zephyr: Add optional MCUboot boot banner

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -358,6 +358,11 @@ zephyr_library_sources(
 )
 endif()
 
+if(CONFIG_MCUBOOT_BOOT_BANNER)
+  # Replace Zephyr's boot banner with the MCUboot one
+  zephyr_sources(kernel/banner.c)
+endif()
+
 if(SYSBUILD)
   function(align_up num align result)
     math(EXPR out "(((${num}) + ((${align}) - 1)) & ~((${align}) - 1))")

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -700,6 +700,23 @@ config BOOT_DISABLE_CACHES
 	  increases protection against data leakage from MCUboot to applications via
 	  these caches.
 
+config MCUBOOT_BOOT_BANNER
+	bool "Use MCUboot boot banner"
+	depends on BOOT_BANNER
+	depends on "$(APP_VERSION_EXTENDED_STRING)" != ""
+	default y
+	help
+	  Uses a MCUboot boot banner instead of the default zephyr one, which will output the
+	  MCUboot name and version, followed by the zephyr name and version.
+
+	  For example:
+
+	    *** Booting MCUboot v2.0.0-72-g8c0e36c88663 ***
+	    *** Using Zephyr OS build v3.6.0-2607-gd0be2010c31f ***
+
+config BOOT_BANNER_STRING
+        default "Using Zephyr OS build" if MCUBOOT_BOOT_BANNER
+
 endmenu
 
 config MCUBOOT_DEVICE_SETTINGS

--- a/boot/zephyr/kernel/banner.c
+++ b/boot/zephyr/kernel/banner.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/device.h>
+#include <version.h>
+#include <app_version.h>
+
+#if defined(CONFIG_BOOT_DELAY) && (CONFIG_BOOT_DELAY > 0)
+#define DELAY_STR STRINGIFY(CONFIG_BOOT_DELAY)
+#define BANNER_POSTFIX " (delayed boot " DELAY_STR "ms)"
+#else
+#define BANNER_POSTFIX ""
+#endif /* defined(CONFIG_BOOT_DELAY) && (CONFIG_BOOT_DELAY > 0) */
+
+#ifndef BANNER_VERSION
+#if defined(BUILD_VERSION) && !IS_EMPTY(BUILD_VERSION)
+#define BANNER_VERSION STRINGIFY(BUILD_VERSION)
+#else
+#define BANNER_VERSION KERNEL_VERSION_STRING
+#endif /* BUILD_VERSION */
+#endif /* !BANNER_VERSION */
+
+#if defined(APP_BUILD_VERSION)
+#define APPLICATION_BANNER_VERSION STRINGIFY(APP_BUILD_VERSION)
+#elif defined(APP_VERSION_EXTENDED_STRING)
+#define APPLICATION_BANNER_VERSION APP_VERSION_EXTENDED_STRING
+#endif
+
+#if defined(APPLICATION_BANNER_VERSION)
+void boot_banner(void)
+{
+#if defined(CONFIG_BOOT_DELAY) && (CONFIG_BOOT_DELAY > 0)
+	printk("***** delaying boot " DELAY_STR "ms (per build configuration) *****\n");
+	k_busy_wait(CONFIG_BOOT_DELAY * USEC_PER_MSEC);
+#endif /* defined(CONFIG_BOOT_DELAY) && (CONFIG_BOOT_DELAY > 0) */
+
+	printk("*** Booting MCUboot " APPLICATION_BANNER_VERSION " ***\n");
+	printk("*** " CONFIG_BOOT_BANNER_STRING " " BANNER_VERSION BANNER_POSTFIX " ***\n");
+}
+#endif /* APP_BUILD_VERSION */

--- a/docs/release-notes.d/zephyr-boot-banner.md
+++ b/docs/release-notes.d/zephyr-boot-banner.md
@@ -1,0 +1,4 @@
+- Zephyr: Added a MCUboot banner which displays the version of
+  MCUboot being used and the version of zephyr. This can be
+  disabled by setting ``CONFIG_MCUBOOT_BOOT_BANNER=n`` which
+  will revert back to the default zephyr boot banner.


### PR DESCRIPTION
Adds an optional MCUboot boot banner which displays the MCUboot version and zephyr version