### PR TITLE
mbedtls config: fix too early check_config.h includes

### DIFF
--- a/boot/bootutil/src/fault_injection_hardening_delay_rng_mbedtls.c
+++ b/boot/bootutil/src/fault_injection_hardening_delay_rng_mbedtls.c
@@ -8,7 +8,6 @@
 
 #ifdef FIH_ENABLE_DELAY
 
-#include "mcuboot-mbedtls-cfg.h"
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/entropy.h"
 

--- a/boot/cypress/MCUBootApp/config/mcuboot_crypto_config.h
+++ b/boot/cypress/MCUBootApp/config/mcuboot_crypto_config.h
@@ -3596,8 +3596,6 @@
 #include MBEDTLS_USER_CONFIG_FILE
 #endif
 
-#include "mbedtls/check_config.h"
-
 #ifdef MCUBOOT_ENC_IMAGES
 #define MBEDTLS_SHA256_DIGEST_SIZE (32)
 #define MBEDTLS_AES_KEY_SIZE 16

--- a/boot/zephyr/include/config-asn1.h
+++ b/boot/zephyr/include/config-asn1.h
@@ -41,6 +41,4 @@
 // #define MBEDTLS_OID_C
 // #define MBEDTLS_SHA256_C
 
-#include "mbedtls/check_config.h"
-
 #endif /* MBEDTLS_CONFIG_ASN1_H */

--- a/boot/zephyr/include/config-ec.h
+++ b/boot/zephyr/include/config-ec.h
@@ -91,6 +91,4 @@
 #define MBEDTLS_NIST_KW_C
 #endif /* MCUBOOT_ENC_IMAGES */
 
-#include "mbedtls/check_config.h"
-
 #endif /* MCUBOOT_MBEDTLS_CONFIG_ECDSA */

--- a/boot/zephyr/include/config-ed25519.h
+++ b/boot/zephyr/include/config-ed25519.h
@@ -73,6 +73,4 @@
 /* Save ROM and a few bytes of RAM by specifying our own ciphersuite list */
 #define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
 
-#include "mbedtls/check_config.h"
-
 #endif /* MCUBOOT_MBEDTLS_CONFIG_RSA */

--- a/boot/zephyr/include/config-kw.h
+++ b/boot/zephyr/include/config-kw.h
@@ -63,6 +63,4 @@
 #define MBEDTLS_CIPHER_C
 #define MBEDTLS_NIST_KW_C
 
-#include "mbedtls/check_config.h"
-
 #endif /* MCUBOOT_MBEDTLS_CONFIG_KW */

--- a/boot/zephyr/include/config-rsa-kw.h
+++ b/boot/zephyr/include/config-rsa-kw.h
@@ -77,6 +77,4 @@
 /* Save ROM and a few bytes of RAM by specifying our own ciphersuite list */
 #define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
 
-#include "mbedtls/check_config.h"
-
 #endif /* MCUBOOT_MBEDTLS_CONFIG_RSA_KW */

--- a/boot/zephyr/include/config-rsa.h
+++ b/boot/zephyr/include/config-rsa.h
@@ -80,6 +80,4 @@
 /* Save ROM and a few bytes of RAM by specifying our own ciphersuite list */
 #define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
 
-#include "mbedtls/check_config.h"
-
 #endif /* MCUBOOT_MBEDTLS_CONFIG_RSA */

--- a/sim/mcuboot-sys/csupport/config-asn1.h
+++ b/sim/mcuboot-sys/csupport/config-asn1.h
@@ -41,6 +41,4 @@
 // #define MBEDTLS_OID_C
 // #define MBEDTLS_SHA256_C
 
-#include "mbedtls/check_config.h"
-
 #endif /* MBEDTLS_CONFIG_ASN1_H */

--- a/sim/mcuboot-sys/csupport/config-ec-psa.h
+++ b/sim/mcuboot-sys/csupport/config-ec-psa.h
@@ -32,6 +32,4 @@
 #define MBEDTLS_ECP_DP_SECP256R1_ENABLED
 #endif /* MCUBOOT_SIGN_EC384 */
 
-#include "mbedtls/check_config.h"
-
 #endif /* MCUBOOT_PSA_CRYPTO_CONFIG_ECDSA */

--- a/sim/mcuboot-sys/csupport/config-ec.h
+++ b/sim/mcuboot-sys/csupport/config-ec.h
@@ -92,6 +92,4 @@
 #define MBEDTLS_NIST_KW_C
 #endif /* MCUBOOT_ENC_IMAGES */
 
-#include "mbedtls/check_config.h"
-
 #endif /* MCUBOOT_MBEDTLS_CONFIG_ECDSA */

--- a/sim/mcuboot-sys/csupport/config-ed25519.h
+++ b/sim/mcuboot-sys/csupport/config-ed25519.h
@@ -74,6 +74,4 @@
 /* Save ROM and a few bytes of RAM by specifying our own ciphersuite list */
 #define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
 
-#include "mbedtls/check_config.h"
-
 #endif /* MCUBOOT_MBEDTLS_CONFIG_RSA */

--- a/sim/mcuboot-sys/csupport/config-kw.h
+++ b/sim/mcuboot-sys/csupport/config-kw.h
@@ -62,6 +62,4 @@
 #define MBEDTLS_CIPHER_C
 #define MBEDTLS_NIST_KW_C
 
-#include "mbedtls/check_config.h"
-
 #endif /* MCUBOOT_MBEDTLS_CONFIG_KW */

--- a/sim/mcuboot-sys/csupport/config-rsa-kw.h
+++ b/sim/mcuboot-sys/csupport/config-rsa-kw.h
@@ -81,6 +81,4 @@
 /* Save ROM and a few bytes of RAM by specifying our own ciphersuite list */
 #define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
 
-#include "mbedtls/check_config.h"
-
 #endif /* MCUBOOT_MBEDTLS_CONFIG_RSA_KW */

--- a/sim/mcuboot-sys/csupport/config-rsa.h
+++ b/sim/mcuboot-sys/csupport/config-rsa.h
@@ -82,6 +82,4 @@
 /* Save ROM and a few bytes of RAM by specifying our own ciphersuite list */
 #define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
 
-#include "mbedtls/check_config.h"
-
 #endif /* MCUBOOT_MBEDTLS_CONFIG_RSA */


### PR DESCRIPTION
check_config.h was included manually by custom configuration files. This caused compilation errors when updating MbedTLS to 3.6.0 because check_config.h was processed too early, before the whole configuration is defined, effectively causing configuration check errors.

MbedTLS already takes care of including check_config.h at the right time. Remove those erroneous manual check_config.h includes.