### PR TITLE
mynewt: Igore swap_scratch.c for single application slot

### DIFF
--- a/boot/bootutil/pkg.yml
+++ b/boot/bootutil/pkg.yml
@@ -43,6 +43,7 @@ pkg.deps:
 
 pkg.ign_files.BOOTUTIL_SINGLE_APPLICATION_SLOT:
     - "loader.c"
+    - "swap_scratch.c"
 
 pkg.deps.BOOTUTIL_USE_MBED_TLS:
     - "@apache-mynewt-core/crypto/mbedtls"

--- a/boot/mynewt/pkg.yml
+++ b/boot/mynewt/pkg.yml
@@ -37,6 +37,8 @@ pkg.deps:
 
 pkg.ign_files.!BOOTUTIL_SINGLE_APPLICATION_SLOT:
     - "single_loader.c"
+pkg.ign_files.BOOTUTIL_SINGLE_APPLICATION_SLOT:
+    - "swap_scratch.c"
 
 pkg.deps.BOOTUTIL_NO_LOGGING:
     - "@apache-mynewt-core/sys/console/stub"


### PR DESCRIPTION
swap_scratch.c requires definition of SLOT1, in single application slot build it's not needed and file would not be used anyway so now it is removed from mynewt build