### PR TITLE
Byte Alignment to support STM32U5

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil_public.h
+++ b/boot/bootutil/include/bootutil/bootutil_public.h
@@ -93,7 +93,11 @@ _Static_assert(MCUBOOT_BOOT_MAX_ALIGN >= 8 && MCUBOOT_BOOT_MAX_ALIGN <= 32,
 #define BOOT_MAX_ALIGN          MCUBOOT_BOOT_MAX_ALIGN
 #define BOOT_MAGIC_ALIGN_SIZE   ALIGN_UP(BOOT_MAGIC_SZ, BOOT_MAX_ALIGN)
 #else
+
+#if !defined( BOOT_MAX_ALIGN )
 #define BOOT_MAX_ALIGN          8
+#endif
+
 #define BOOT_MAGIC_ALIGN_SIZE   BOOT_MAGIC_SZ
 #endif
 

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -57,7 +57,7 @@ BOOT_LOG_MODULE_DECLARE(mcuboot);
 BOOT_LOG_MODULE_REGISTER(mcuboot_util);
 #endif
 
-#if BOOT_MAX_ALIGN == 8
+#if (BOOT_MAX_ALIGN == 8) || (BOOT_MAX_ALIGN == 16)
 const union boot_img_magic_t boot_img_magic = {
     .val = {
         0x77, 0xc2, 0x95, 0xf3,


### PR DESCRIPTION
- Modified **#if BOOT_MAX_ALIGN == 8** to **#if (BOOT_MAX_ALIGN == 8) || (BOOT_MAX_ALIGN == 16)** for boot_img_magic in boot/bootutil/src/bootutil_public.c, because STM32U5 supports 16 Byte alignment.

- Provided **#if !defined( BOOT_MAX_ALIGN )** preprocessor directive for **#define BOOT_MAX_ALIGN          8** in boot/bootutil/include/bootutil/bootutil_public.h, because STM32U5 supports 16 Byte alignment which can  be provided with preprocessor options as **#define BOOT_MAX_ALIGN          16**.












Signed-off-by: Chanakya Macharla <macharla.chanakya@gmail.com>