### PR TITLE
zephyr: print version number before boot

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -553,6 +553,10 @@ int main(void)
                  rsp.br_image_off);
 #endif
 
+    BOOT_LOG_INF("Image version: v%d.%d.%d", rsp.br_hdr->ih_ver.iv_major,
+                                                    rsp.br_hdr->ih_ver.iv_minor,
+                                                    rsp.br_hdr->ih_ver.iv_revision);
+
 #if defined(MCUBOOT_DIRECT_XIP)
     BOOT_LOG_INF("Jumping to the image slot");
 #else


### PR DESCRIPTION
Before booting, It might be handy to see the version of the image we boot into.