### PR TITLE
bootutil: Fix signed/unsigned comparison in boot_read_enc_key

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -268,7 +268,7 @@ boot_read_enc_key(const struct flash_area *fap, uint8_t slot, struct boot_status
 {
     uint32_t off;
 #if MCUBOOT_SWAP_SAVE_ENCTLV
-    int i;
+    uint32_t i;
 #endif
     int rc;
 


### PR DESCRIPTION
When `MCUBOOT_SWAP_SAVE_ENCTLV` is enabled, a comparison between a signed and an unsigned integer is made in `boot_read_enc_key`. This shouldn't cause any issue at runtime but might lead to a warning to be emitted at compile-time.

In particular, with GCC, if `-Wsign-compare` is enabled:
```
MCUboot/boot/bootutil/src/bootutil_misc.c:279:23: warning: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
         for (i = 0; i < BOOT_ENC_TLV_ALIGN_SIZE; i++) {
                       ^
```