### PR TITLE
zephyr: boards: Add files needed for NXP FRDM MCXN947 QSPI variant

### DIFF
--- a/boot/zephyr/boards/frdm_mcxn947_mcxn947_cpu0_qspi.conf
+++ b/boot/zephyr/boards/frdm_mcxn947_mcxn947_cpu0_qspi.conf
@@ -1,0 +1,4 @@
+# Copyright 2023 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BOOT_MAX_IMG_SECTORS=1024

--- a/boot/zephyr/boards/frdm_mcxn947_mcxn947_cpu0_qspi.overlay
+++ b/boot/zephyr/boards/frdm_mcxn947_mcxn947_cpu0_qspi.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2023 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+        chosen {
+                zephyr,flash = &flash;
+        };
+};
+


### PR DESCRIPTION
1. set BOOT_MAX_IMG_SECTORS value for frmd_mcxn947_qspi. W25Q64 flash on the board is very large (8MB), so we must increase the number of max sectors when targeting this board with MCUboot.
2. Set the zephyr,flash chosen node to point to internal flash as this board supports booting from internal flash only.