### PR TITLE
boot: zephyr: add support for frdm-mcxn947

### DIFF
--- a/boot/zephyr/boards/frdm_mcxn947_mcxn947_cpu0.conf
+++ b/boot/zephyr/boards/frdm_mcxn947_mcxn947_cpu0.conf
@@ -1,0 +1,5 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+#MCXN94x does not support the MCUBoot swap mode.
+CONFIG_BOOT_UPGRADE_ONLY=y


### PR DESCRIPTION
Add default configuration for frdm-mcxn947.