### PR TITLE
zephyr: prefix generated header path with `zephyr/`

### DIFF
--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -287,7 +287,7 @@
 #endif
 
 #if defined(MCUBOOT_DATA_SHARING) && defined(ZEPHYR_VER_INCLUDE)
-#include <app_version.h>
+#include <zephyr/app_version.h>
 
 #define MCUBOOT_VERSION_AVAILABLE
 #define MCUBOOT_VERSION_MAJOR APP_VERSION_MAJOR

--- a/boot/zephyr/kernel/banner.c
+++ b/boot/zephyr/kernel/banner.c
@@ -8,8 +8,8 @@
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/device.h>
-#include <version.h>
-#include <app_version.h>
+#include <zephyr/version.h>
+#include <zephyr/app_version.h>
 
 #if defined(CONFIG_BOOT_DELAY) && (CONFIG_BOOT_DELAY > 0)
 #define DELAY_STR STRINGIFY(CONFIG_BOOT_DELAY)


### PR DESCRIPTION
Update the include path of generated headers.

See:
- https://github.com/zephyrproject-rtos/zephyr/pull/63973