### PR TITLE
boot: SHA512 verification

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/sha.h
+++ b/boot/bootutil/include/bootutil/crypto/sha.h
@@ -34,13 +34,16 @@
     #error "One crypto backend must be defined: either CC310/MBED_TLS/TINYCRYPT/PSA_CRYPTO"
 #endif
 
-#if defined(MCUBOOT_SIGN_EC384)
+#if defined(MCUBOOT_SHA512)
+    #define IMAGE_HASH_SIZE (64)
+    #define EXPECTED_HASH_TLV IMAGE_TLV_SHA512
+#elif defined(MCUBOOT_SIGN_EC384)
     #define IMAGE_HASH_SIZE (48)
     #define EXPECTED_HASH_TLV IMAGE_TLV_SHA384
 #else
     #define IMAGE_HASH_SIZE (32)
     #define EXPECTED_HASH_TLV IMAGE_TLV_SHA256
-#endif /* MCUBOOT_SIGN_EC384 */
+#endif /* MCUBOOT_SIGN */
 
 /* Universal defines for SHA-256 */
 #define BOOTUTIL_CRYPTO_SHA256_BLOCK_SIZE  (64)
@@ -82,7 +85,9 @@ typedef psa_hash_operation_t bootutil_sha_context;
 static inline int bootutil_sha_init(bootutil_sha_context *ctx)
 {
     *ctx = psa_hash_operation_init();
-#if defined(MCUBOOT_SIGN_EC384)
+#if defined(MCUBOOT_SHA512)
+    psa_status_t status = psa_hash_setup(ctx, PSA_ALG_SHA_512);
+#elif defined(MCUBOOT_SIGN_EC384)
     psa_status_t status = psa_hash_setup(ctx, PSA_ALG_SHA_384);
 #else
     psa_status_t status = psa_hash_setup(ctx, PSA_ALG_SHA_256);
@@ -107,7 +112,9 @@ static inline int bootutil_sha_finish(bootutil_sha_context *ctx,
 {
     size_t hash_length = 0;
     /* Assumes the output buffer is at least the expected size of the hash */
-#if defined(MCUBOOT_SIGN_EC384)
+#if defined(MCUBOOT_SHA512)
+    return (int)psa_hash_finish(ctx, output, PSA_HASH_LENGTH(PSA_ALG_SHA_512), &hash_length);
+#elif defined(MCUBOOT_SIGN_EC384)
     return (int)psa_hash_finish(ctx, output, PSA_HASH_LENGTH(PSA_ALG_SHA_384), &hash_length);
 #else
     return (int)psa_hash_finish(ctx, output, PSA_HASH_LENGTH(PSA_ALG_SHA_256), &hash_length);

--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -96,6 +96,7 @@ struct flash_area;
 #define IMAGE_TLV_PUBKEY            0x02   /* public key */
 #define IMAGE_TLV_SHA256            0x10   /* SHA256 of image hdr and body */
 #define IMAGE_TLV_SHA384            0x11   /* SHA384 of image hdr and body */
+#define IMAGE_TLV_SHA512            0x12   /* SHA512 of image hdr and body */
 #define IMAGE_TLV_RSA2048_PSS       0x20   /* RSA2048 of hash output */
 #define IMAGE_TLV_ECDSA224          0x21   /* ECDSA of hash output - Not supported anymore */
 #define IMAGE_TLV_ECDSA_SIG         0x22   /* ECDSA of hash output */

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -362,6 +362,7 @@ static const uint16_t allowed_unprot_tlvs[] = {
      IMAGE_TLV_PUBKEY,
      IMAGE_TLV_SHA256,
      IMAGE_TLV_SHA384,
+     IMAGE_TLV_SHA512,
      IMAGE_TLV_RSA2048_PSS,
      IMAGE_TLV_ECDSA224,
      IMAGE_TLV_ECDSA_SIG,

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -24,6 +24,12 @@ config BOOT_USE_MBEDTLS
 	help
 	  Use mbedTLS for crypto primitives.
 
+config BOOT_USE_PSA_CRYPTO
+	bool
+	# Hidden option
+	help
+	  Hidden option set if using PSA crypt for cryptography functionality
+
 config BOOT_USE_TINYCRYPT
 	bool
 	# Hidden option
@@ -67,6 +73,52 @@ config SINGLE_APPLICATION_SLOT
 	  uploading a new application overwrites the one that previously
 	  occupied the area.
 
+config BOOT_IMG_HASH_ALG_SHA256_ALLOW
+	bool
+	help
+	  Hidden option set by configurations that allow SHA256
+
+config BOOT_IMG_HASH_ALG_SHA384_ALLOW
+	bool
+	help
+	  Hidden option set by configurations that allow SHA384
+
+config BOOT_IMG_HASH_ALG_SHA512_ALLOW
+	bool
+	depends on BOOT_USE_PSA_CRYPTO
+	help
+	  Hidden option set by configurations that allow SHA512
+
+choice BOOT_IMG_HASH_ALG
+	prompt "Selected image hash algorithm"
+	default BOOT_IMG_HASH_ALG_SHA256 if BOOT_IMG_HASH_ALG_SHA256_ALLOW
+	default BOOT_IMG_HASH_ALG_SHA384 if BOOT_IMG_HASH_ALG_SHA384_ALLOW
+	default BOOT_IMG_HASH_ALG_SHA512 if BOOT_IMG_HASH_ALG_SHA512_ALLOW
+	help
+	  Hash algorithm used for image verification. Selection
+	  here may be limited by other configurations, like for
+	  example selected cryptographic signature.
+
+config BOOT_IMG_HASH_ALG_SHA256
+	bool "SHA256"
+	depends on BOOT_IMG_HASH_ALG_SHA256_ALLOW
+	help
+	  SHA256 algorithm
+
+config BOOT_IMG_HASH_ALG_SHA384
+	bool "SHA384"
+	depends on BOOT_IMG_HASH_ALG_SHA384_ALLOW
+	help
+	  SHA384 algorithm
+
+config BOOT_IMG_HASH_ALG_SHA512
+	bool "SHA512"
+	depends on BOOT_IMG_HASH_ALG_SHA512_ALLOW
+	help
+	  SHA512 algorithm
+
+endchoice # BOOT_IMG_HASH_ALG
+
 choice BOOT_SIGNATURE_TYPE
 	prompt "Signature type"
 	default BOOT_SIGNATURE_TYPE_RSA
@@ -74,12 +126,14 @@ choice BOOT_SIGNATURE_TYPE
 config BOOT_SIGNATURE_TYPE_NONE
 	bool "No signature; use only hash check"
 	select BOOT_USE_TINYCRYPT
+	select BOOT_IMG_HASH_ALG_SHA256_ALLOW
 
 config BOOT_SIGNATURE_TYPE_RSA
 	bool "RSA signatures"
 	select BOOT_USE_MBEDTLS
 	select MBEDTLS
 	select BOOT_ENCRYPTION_SUPPORT
+	select BOOT_IMG_HASH_ALG_SHA256_ALLOW
 
 if BOOT_SIGNATURE_TYPE_RSA
 config BOOT_SIGNATURE_TYPE_RSA_LEN
@@ -91,6 +145,7 @@ endif
 config BOOT_SIGNATURE_TYPE_ECDSA_P256
 	bool "Elliptic curve digital signatures with curve P-256"
 	select BOOT_ENCRYPTION_SUPPORT
+	select BOOT_IMG_HASH_ALG_SHA256_ALLOW
 
 if BOOT_SIGNATURE_TYPE_ECDSA_P256
 choice BOOT_ECDSA_IMPLEMENTATION
@@ -114,6 +169,7 @@ endif
 config BOOT_SIGNATURE_TYPE_ED25519
 	bool "Edwards curve digital signatures using ed25519"
 	select BOOT_ENCRYPTION_SUPPORT
+	select BOOT_IMG_HASH_ALG_SHA256_ALLOW
 
 if BOOT_SIGNATURE_TYPE_ED25519
 choice BOOT_ED25519_IMPLEMENTATION

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -43,6 +43,16 @@
 #ifdef CONFIG_BOOT_USE_NRF_CC310_BL
 #define MCUBOOT_USE_NRF_CC310_BL
 #endif
+#elif defined(CONFIG_MBEDTLS_PSA_CRYPTO_CLIENT)
+#define MCUBOOT_USE_PSA_CRYPTO
+#endif
+
+#ifdef CONFIG_BOOT_IMG_HASH_ALG_SHA512
+#define MCUBOOT_SHA512
+#endif
+
+#ifdef CONFIG_BOOT_IMG_HASH_ALG_SHA256
+#define MCUBOOT_SHA256
 #endif
 
 /* Zephyr, regardless of C library used, provides snprintf */


### PR DESCRIPTION
adds TLV and Kconfig to decouple verification from other options.