### PR TITLE
docs: Replace Slack channel links with Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ Developers are welcome!
 Use the following links to join or see more about the project:
 
 * [Our developer mailing list](https://groups.io/g/MCUBoot)
-* [Our Slack channel](https://mcuboot.slack.com/) <br />
-  Get [your invite](https://join.slack.com/t/mcuboot/shared_invite/MjE2NDcwMTQ2MTYyLTE1MDA4MTIzNTAtYzgyZTU0NjFkMg)
+* [Our Discord channel](https://discord.com/channels/1106321706588577904/1106322802308550716) <br />
+  Get [your invite](https://discord.com/invite/5PpXhvda5p)

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,7 @@ Developers are welcome!
 Use the following links to join or see more about the project:
 
 * [Our developer mailing list](https://groups.io/g/MCUBoot)
-* [Our Slack channel](https://mcuboot.slack.com/) <br />
-  Get [your invite](https://join.slack.com/t/mcuboot/shared_invite/MjE2NDcwMTQ2MTYyLTE1MDA4MTIzNTAtYzgyZTU0NjFkMg)
+* [Our Discord channel](https://discord.com/channels/1106321706588577904/1106322802308550716) <br />
+  Get [your invite](https://discord.com/invite/5PpXhvda5p)
 * [Current members](https://github.com/mcu-tools/mcuboot/wiki/Members)
 * [Project charter](https://github.com/mcu-tools/mcuboot/wiki/MCUboot-Project-Charter)


### PR DESCRIPTION
Replace Slack channel links with MCUboot Discord channel as the discussions have moved there.