### PR TITLE
bootutil: Fix signature length passed to ED25519_verify

### DIFF
--- a/boot/bootutil/src/image_ed25519.c
+++ b/boot/bootutil/src/image_ed25519.c
@@ -87,7 +87,7 @@ bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
         goto out;
     }
 
-    rc = ED25519_verify(hash, 32, sig, pubkey);
+    rc = ED25519_verify(hash, slen, sig, pubkey);
 
     if (rc == 0) {
         /* if verify returns 0, there was an error. */


### PR DESCRIPTION
The signature length passed to ED25519_verify, from bootutil_verify_sig, has been accidentally hardcoded, which prevented vertification of signatures different than 32 byte in length.