### PR TITLE
Fix macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["sim"]
 exclude = ["ptest"]
+resolver = "2"
 
 # The simulator runs very slowly without optimization.  A value of 1
 # compiles in about half the time, but runs about 5-6 times slower.  2

--- a/boot/bootutil/include/bootutil/fault_injection_hardening.h
+++ b/boot/bootutil/include/bootutil/fault_injection_hardening.h
@@ -278,6 +278,8 @@ void fih_cfi_decrement(void);
  */
 #if defined(__ICCARM__)
 #define FIH_LABEL(str, lin, cnt) __asm volatile ("FIH_LABEL_" str "_" #lin "_" #cnt "::" ::);
+#elif defined(__APPLE__)
+#define FIH_LABEL(str) do {} while (0)
 #else
 #define FIH_LABEL(str) __asm volatile ("FIH_LABEL_" str "_%=:" ::);
 #endif

--- a/sim/mcuboot-sys/src/api.rs
+++ b/sim/mcuboot-sys/src/api.rs
@@ -90,7 +90,7 @@ impl Default for FlashContext {
 }
 
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct CSimContext {
     pub flash_counter: libc::c_int,
     pub jumped: libc::c_int,
@@ -99,7 +99,19 @@ pub struct CSimContext {
     // NOTE: Always leave boot_jmpbuf declaration at the end; this should
     // store a "jmp_buf" which is arch specific and not defined by libc crate.
     // The size below is enough to store data on a x86_64 machine.
-    pub boot_jmpbuf: [u64; 16],
+    pub boot_jmpbuf: [u64; 48],
+}
+
+impl Default for CSimContext {
+    fn default() -> Self {
+        CSimContext {
+            flash_counter: 0,
+            jumped: 0,
+            c_asserts: 0,
+            c_catch_asserts: 0,
+            boot_jmpbuf: [0; 48],
+        }
+    }
 }
 
 pub struct CSimContextPtr {

--- a/sim/mcuboot-sys/src/api.rs
+++ b/sim/mcuboot-sys/src/api.rs
@@ -189,42 +189,42 @@ pub fn clear_flash(dev_id: u8) {
 // This isn't meant to call directly, but by a wrapper.
 
 #[no_mangle]
-pub extern fn sim_get_flash_areas() -> *const CAreaDesc {
+pub extern "C" fn sim_get_flash_areas() -> *const CAreaDesc {
     THREAD_CTX.with(|ctx| {
         ctx.borrow().flash_areas.ptr
     })
 }
 
 #[no_mangle]
-pub extern fn sim_set_flash_areas(areas: *const CAreaDesc) {
+pub extern "C" fn sim_set_flash_areas(areas: *const CAreaDesc) {
     THREAD_CTX.with(|ctx| {
         ctx.borrow_mut().flash_areas.ptr = areas;
     });
 }
 
 #[no_mangle]
-pub extern fn sim_reset_flash_areas() {
+pub extern "C" fn sim_reset_flash_areas() {
     THREAD_CTX.with(|ctx| {
         ctx.borrow_mut().flash_areas.ptr = ptr::null();
     });
 }
 
 #[no_mangle]
-pub extern fn sim_get_context() -> *const CSimContext {
+pub extern "C" fn sim_get_context() -> *const CSimContext {
     SIM_CTX.with(|ctx| {
         ctx.borrow().ptr
     })
 }
 
 #[no_mangle]
-pub extern fn sim_set_context(ptr: *const CSimContext) {
+pub extern "C" fn sim_set_context(ptr: *const CSimContext) {
     SIM_CTX.with(|ctx| {
         ctx.borrow_mut().ptr = ptr;
     });
 }
 
 #[no_mangle]
-pub extern fn sim_reset_context() {
+pub extern "C" fn sim_reset_context() {
     SIM_CTX.with(|ctx| {
         ctx.borrow_mut().ptr = ptr::null();
     });
@@ -257,7 +257,7 @@ pub fn clear_ram_info() {
 }
 
 #[no_mangle]
-pub extern fn sim_flash_erase(dev_id: u8, offset: u32, size: u32) -> libc::c_int {
+pub extern "C" fn sim_flash_erase(dev_id: u8, offset: u32, size: u32) -> libc::c_int {
     let mut rc: libc::c_int = -19;
     THREAD_CTX.with(|ctx| {
         if let Some(flash) = ctx.borrow().flash_map.get(&dev_id) {
@@ -269,7 +269,7 @@ pub extern fn sim_flash_erase(dev_id: u8, offset: u32, size: u32) -> libc::c_int
 }
 
 #[no_mangle]
-pub extern fn sim_flash_read(dev_id: u8, offset: u32, dest: *mut u8, size: u32) -> libc::c_int {
+pub extern "C" fn sim_flash_read(dev_id: u8, offset: u32, dest: *mut u8, size: u32) -> libc::c_int {
     let mut rc: libc::c_int = -19;
     THREAD_CTX.with(|ctx| {
         if let Some(flash) = ctx.borrow().flash_map.get(&dev_id) {
@@ -282,7 +282,7 @@ pub extern fn sim_flash_read(dev_id: u8, offset: u32, dest: *mut u8, size: u32) 
 }
 
 #[no_mangle]
-pub extern fn sim_flash_write(dev_id: u8, offset: u32, src: *const u8, size: u32) -> libc::c_int {
+pub extern "C" fn sim_flash_write(dev_id: u8, offset: u32, src: *const u8, size: u32) -> libc::c_int {
     let mut rc: libc::c_int = -19;
     THREAD_CTX.with(|ctx| {
         if let Some(flash) = ctx.borrow().flash_map.get(&dev_id) {
@@ -295,14 +295,14 @@ pub extern fn sim_flash_write(dev_id: u8, offset: u32, src: *const u8, size: u32
 }
 
 #[no_mangle]
-pub extern fn sim_flash_align(id: u8) -> u32 {
+pub extern "C" fn sim_flash_align(id: u8) -> u32 {
     THREAD_CTX.with(|ctx| {
         ctx.borrow().flash_params.get(&id).unwrap().align
     })
 }
 
 #[no_mangle]
-pub extern fn sim_flash_erased_val(id: u8) -> u8 {
+pub extern "C" fn sim_flash_erased_val(id: u8) -> u8 {
     THREAD_CTX.with(|ctx| {
         ctx.borrow().flash_params.get(&id).unwrap().erased_val
     })
@@ -325,7 +325,7 @@ fn map_err(err: Result<()>) -> libc::c_int {
 /// or
 ///     RUST_LOG=bootsim=info cargo run --release runall
 #[no_mangle]
-pub extern fn sim_log_enabled(level: libc::c_int) -> libc::c_int {
+pub extern "C" fn sim_log_enabled(level: libc::c_int) -> libc::c_int {
     let res = match level {
         1 => log_enabled!(Level::Error),
         2 => log_enabled!(Level::Warn),

--- a/sim/mcuboot-sys/src/area.rs
+++ b/sim/mcuboot-sys/src/area.rs
@@ -9,6 +9,7 @@
 use simflash::{Flash, SimFlash, Sector};
 use std::ptr;
 use std::collections::HashMap;
+use std::borrow::BorrowMut;
 
 /// Structure to build up the boot area table.
 #[derive(Debug, Default, Clone)]
@@ -124,8 +125,9 @@ impl AreaDesc {
         None
     }
 
-    pub fn get_c(&self) -> CAreaDesc {
-        let mut areas: CAreaDesc = Default::default();
+    pub fn get_c(&self) -> Box<CAreaDesc> {
+        let mut areas_box: Box<CAreaDesc> = Box::new(Default::default());
+        let areas: &mut CAreaDesc = areas_box.borrow_mut();
 
         assert_eq!(self.areas.len(), self.whole.len());
 
@@ -140,7 +142,7 @@ impl AreaDesc {
 
         areas.num_slots = self.areas.len() as u32;
 
-        areas
+        areas_box
     }
 
     /// Return an iterator over all `FlashArea`s present.

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -81,10 +81,8 @@ pub fn boot_go(multiflash: &mut SimMultiFlash, areadesc: &AreaDesc,
             None => 0,
             Some(ref c) => **c as libc::c_int
         },
-        jumped: 0,
-        c_asserts: 0,
         c_catch_asserts: if catch_asserts { 1 } else { 0 },
-        boot_jmpbuf: [0; 16],
+        .. Default::default()
     };
     let mut rsp = api::BootRsp {
         br_hdr: std::ptr::null(),

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -13,6 +13,8 @@ use crate::api;
 #[allow(unused)]
 use std::sync::Once;
 
+use std::borrow::Borrow;
+
 /// The result of an invocation of `boot_go`.  This is intentionally opaque so that we can provide
 /// accessors for everything we need from this.
 #[derive(Debug)]
@@ -90,12 +92,13 @@ pub fn boot_go(multiflash: &mut SimMultiFlash, areadesc: &AreaDesc,
         image_off: 0,
     };
     let result: i32 = unsafe {
+        let adesc = areadesc.get_c();
         match image_index {
             None => raw::invoke_boot_go(&mut sim_ctx as *mut _,
-                                        &areadesc.get_c() as *const _,
+                                        adesc.borrow() as *const _,
                                         &mut rsp as *mut _, -1) as i32,
             Some(i) => raw::invoke_boot_go(&mut sim_ctx as *mut _,
-                                           &areadesc.get_c() as *const _,
+                                           adesc.borrow() as *const _,
                                            &mut rsp as *mut _,
                                            i as i32) as i32
         }

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -19,10 +19,7 @@ use rand::{
     rngs::SmallRng,
 };
 use std::{
-    collections::{BTreeMap, HashSet},
-    io::{Cursor, Write},
-    mem,
-    slice,
+    collections::{BTreeMap, HashSet}, io::{Cursor, Write}, mem, rc::Rc, slice
 };
 use aes::{
     Aes128,
@@ -67,7 +64,7 @@ const RAM_LOAD_ADDR: u32 = 1024;
 #[derive(Clone)]
 pub struct ImagesBuilder {
     flash: SimMultiFlash,
-    areadesc: AreaDesc,
+    areadesc: Rc<AreaDesc>,
     slots: Vec<[SlotInfo; 2]>,
     ram: RamData,
 }
@@ -77,7 +74,7 @@ pub struct ImagesBuilder {
 /// and upgrades hold the expected contents of these images.
 pub struct Images {
     flash: SimMultiFlash,
-    areadesc: AreaDesc,
+    areadesc: Rc<AreaDesc>,
     images: Vec<OneImage>,
     total_count: Option<i32>,
     ram: RamData,
@@ -433,7 +430,7 @@ impl ImagesBuilder {
     }
 
     /// Build the Flash and area descriptor for a given device.
-    pub fn make_device(device: DeviceName, align: usize, erased_val: u8) -> (SimMultiFlash, AreaDesc, &'static [Caps]) {
+    pub fn make_device(device: DeviceName, align: usize, erased_val: u8) -> (SimMultiFlash, Rc<AreaDesc>, &'static [Caps]) {
         match device {
             DeviceName::Stm32f4 => {
                 // STM style flash.  Large sectors, with a large scratch area.
@@ -454,7 +451,7 @@ impl ImagesBuilder {
 
                 let mut flash = SimMultiFlash::new();
                 flash.insert(dev_id, dev);
-                (flash, areadesc, &[Caps::SwapUsingMove])
+                (flash, Rc::new(areadesc), &[Caps::SwapUsingMove])
             }
             DeviceName::K64f => {
                 // NXP style flash.  Small sectors, one small sector for scratch.
@@ -469,7 +466,7 @@ impl ImagesBuilder {
 
                 let mut flash = SimMultiFlash::new();
                 flash.insert(dev_id, dev);
-                (flash, areadesc, &[])
+                (flash, Rc::new(areadesc), &[])
             }
             DeviceName::K64fBig => {
                 // Simulating an STM style flash on top of an NXP style flash.  Underlying flash device
@@ -485,7 +482,7 @@ impl ImagesBuilder {
 
                 let mut flash = SimMultiFlash::new();
                 flash.insert(dev_id, dev);
-                (flash, areadesc, &[Caps::SwapUsingMove])
+                (flash, Rc::new(areadesc), &[Caps::SwapUsingMove])
             }
             DeviceName::Nrf52840 => {
                 // Simulating the flash on the nrf52840 with partitions set up so that the scratch size
@@ -501,7 +498,7 @@ impl ImagesBuilder {
 
                 let mut flash = SimMultiFlash::new();
                 flash.insert(dev_id, dev);
-                (flash, areadesc, &[])
+                (flash, Rc::new(areadesc), &[])
             }
             DeviceName::Nrf52840UnequalSlots => {
                 let dev = SimFlash::new(vec![4096; 128], align as usize, erased_val);
@@ -514,7 +511,7 @@ impl ImagesBuilder {
 
                 let mut flash = SimMultiFlash::new();
                 flash.insert(dev_id, dev);
-                (flash, areadesc, &[Caps::SwapUsingScratch, Caps::OverwriteUpgrade])
+                (flash, Rc::new(areadesc), &[Caps::SwapUsingScratch, Caps::OverwriteUpgrade])
             }
             DeviceName::Nrf52840SpiFlash => {
                 // Simulate nrf52840 with external SPI flash. The external SPI flash
@@ -533,7 +530,7 @@ impl ImagesBuilder {
                 let mut flash = SimMultiFlash::new();
                 flash.insert(0, dev0);
                 flash.insert(1, dev1);
-                (flash, areadesc, &[Caps::SwapUsingMove])
+                (flash, Rc::new(areadesc), &[Caps::SwapUsingMove])
             }
             DeviceName::K64fMulti => {
                 // NXP style flash, but larger, to support multiple images.
@@ -550,7 +547,7 @@ impl ImagesBuilder {
 
                 let mut flash = SimMultiFlash::new();
                 flash.insert(dev_id, dev);
-                (flash, areadesc, &[])
+                (flash, Rc::new(areadesc), &[])
             }
         }
     }


### PR DESCRIPTION
Several fixes to allow the simulator to run on MacOS (aarch64). Several of these are actual problems with taking addresses of stack variables, or values that are later moved.

There is also a problem with the LLVM linker and the way the FIH_LABEL labels are added, which results in large blocks of code being discarded, and resulting in nonsensical code flow. For now, disable these labels on Apple targets, but as Rust is moving to the LLVM linker on other targets, this is likely to be more important.

Fixes #1979.