### PR TITLE
boot: main: avoid unused build warning

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -277,7 +277,9 @@ done:
  */
 static void do_boot(struct boot_rsp *rsp)
 {
+#ifndef CONFIG_SOC_FAMILY_ESPRESSIF_ESP32
     void *start;
+#endif /* CONFIG_SOC_FAMILY_ESPRESSIF_ESP32 */
 
     BOOT_LOG_INF("br_image_off = 0x%x\n", rsp->br_image_off);
     BOOT_LOG_INF("ih_hdr_size = 0x%x\n", rsp->br_hdr->ih_hdr_size);


### PR DESCRIPTION
In case ESP32 SoC is used, *start will get
build warning as it is not used.