### PR TITLE
imgtool: Bump cryptography library version

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,4 @@
-cryptography>=2.6
+cryptography>=40.0.0
 intelhex
 click
 cbor2

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import setuptools
+
 from imgtool import imgtool_version
 
 setuptools.setup(
@@ -14,7 +15,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     python_requires='>=3.6',
     install_requires=[
-        'cryptography>=2.4.2',
+        'cryptography>=40.0.0',
         'intelhex>=2.2.1',
         'click',
         'cbor2',


### PR DESCRIPTION
Update requirements.txt to support PrivateKeyType and PublicKeyType which are available in cryptography library since version 40.0.0 and prevent failing CI jobs in upcoming changes.
