### PR TITLE
Revert "boot: Add MCUBOOT_HW_KEY support for image encryption"

### DIFF
--- a/boot/bootutil/include/bootutil/enc_key.h
+++ b/boot/bootutil/include/bootutil/enc_key.h
@@ -32,7 +32,6 @@
 #include <flash_map_backend/flash_map_backend.h>
 #include "bootutil/crypto/aes_ctr.h"
 #include "bootutil/image.h"
-#include "bootutil/sign_key.h"
 #include "bootutil/enc_key_public.h"
 
 #ifdef __cplusplus
@@ -46,17 +45,7 @@ struct enc_key_data {
     bootutil_aes_ctr_context aes_ctr;
 };
 
-/**
- * Retrieve the private key for image encryption.
- *
- * @param[out]  private_key  structure to store the private key and
- *                           its length.
- *
- * @return                   0 on success; nonzero on failure.
- *
- */
-int boot_enc_retrieve_private_key(struct bootutil_key **private_key);
-
+extern const struct bootutil_key bootutil_enc_key;
 struct boot_status;
 
 int boot_enc_init(struct enc_key_data *enc_state, uint8_t slot);

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -67,13 +67,13 @@ static int bootutil_constant_time_compare(const uint8_t *a, const uint8_t *b, si
 
 #if defined(MCUBOOT_ENCRYPT_KW)
 static int
-key_unwrap(const uint8_t *wrapped, uint8_t *enckey, struct bootutil_key *bootutil_enc_key)
+key_unwrap(const uint8_t *wrapped, uint8_t *enckey)
 {
     bootutil_aes_kw_context aes_kw;
     int rc;
 
     bootutil_aes_kw_init(&aes_kw);
-    rc = bootutil_aes_kw_set_unwrap_key(&aes_kw, bootutil_enc_key->key, *bootutil_enc_key->len);
+    rc = bootutil_aes_kw_set_unwrap_key(&aes_kw, bootutil_enc_key.key, *bootutil_enc_key.len);
     if (rc != 0) {
         goto done;
     }
@@ -441,23 +441,13 @@ boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey)
     uint8_t counter[BOOTUTIL_CRYPTO_AES_CTR_BLOCK_SIZE];
     uint16_t len;
 #endif
-    struct bootutil_key *bootutil_enc_key = NULL;
     int rc = -1;
-
-    rc = boot_enc_retrieve_private_key(&bootutil_enc_key);
-    if (rc) {
-        return rc;
-    }
-
-    if (bootutil_enc_key == NULL) {
-        return rc;
-    }
 
 #if defined(MCUBOOT_ENCRYPT_RSA)
 
     bootutil_rsa_init(&rsa);
-    cp = (uint8_t *)bootutil_enc_key->key;
-    cpend = cp + *bootutil_enc_key->len;
+    cp = (uint8_t *)bootutil_enc_key.key;
+    cpend = cp + *bootutil_enc_key.len;
 
     /* The enckey is encrypted through RSA so for decryption we need the private key */
     rc = bootutil_rsa_parse_private_key(&rsa, &cp, cpend);
@@ -476,15 +466,15 @@ boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey)
 
 #if defined(MCUBOOT_ENCRYPT_KW)
 
-    assert(*bootutil_enc_key->len == BOOT_ENC_KEY_SIZE);
-    rc = key_unwrap(buf, enckey, bootutil_enc_key);
+    assert(*bootutil_enc_key.len == BOOT_ENC_KEY_SIZE);
+    rc = key_unwrap(buf, enckey);
 
 #endif /* defined(MCUBOOT_ENCRYPT_KW) */
 
 #if defined(MCUBOOT_ENCRYPT_EC256)
 
-    cp = (uint8_t *)bootutil_enc_key->key;
-    cpend = cp + *bootutil_enc_key->len;
+    cp = (uint8_t *)bootutil_enc_key.key;
+    cpend = cp + *bootutil_enc_key.len;
 
     /*
      * Load the stored EC256 decryption private key
@@ -510,8 +500,8 @@ boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey)
 
 #if defined(MCUBOOT_ENCRYPT_X25519)
 
-    cp = (uint8_t *)bootutil_enc_key->key;
-    cpend = cp + *bootutil_enc_key->len;
+    cp = (uint8_t *)bootutil_enc_key.key;
+    cpend = cp + *bootutil_enc_key.len;
 
     /*
      * Load the stored X25519 decryption private key

--- a/boot/cypress/MCUBootApp/keys.c
+++ b/boot/cypress/MCUBootApp/keys.c
@@ -167,12 +167,3 @@ const struct bootutil_key bootutil_enc_key = {
     .key = enc_priv_key,
     .len = &enc_priv_key_len,
 };
-
-#if !defined(MCUBOOT_HW_KEY) && defined(MCUBOOT_ENC_IMAGES)
-int boot_enc_retrieve_private_key(struct bootutil_key **private_key)
-{
-    *private_key = (struct bootutil_key *)&bootutil_enc_key;
-
-    return 0;
-}
-#endif /* !MCUBOOT_HW_KEY && MCUBOOT_ENC_IMAGES */

--- a/boot/mbed/app_enc_keys.c
+++ b/boot/mbed/app_enc_keys.c
@@ -69,12 +69,3 @@ const struct bootutil_key bootutil_enc_key = {
 #endif
 
 #endif
-
-#if !defined(MCUBOOT_HW_KEY) && defined(MCUBOOT_ENC_IMAGES)
-int boot_enc_retrieve_private_key(struct bootutil_key **private_key)
-{
-    *private_key = (struct bootutil_key *)&bootutil_enc_key;
-
-    return 0;
-}
-#endif /* !MCUBOOT_HW_KEY && MCUBOOT_ENC_IMAGES */

--- a/boot/zephyr/keys.c
+++ b/boot/zephyr/keys.c
@@ -86,12 +86,3 @@ const struct bootutil_key bootutil_enc_key = {
 #elif defined(MCUBOOT_ENCRYPT_KW)
 #error "Encrypted images with AES-KW is not implemented yet."
 #endif
-
-#if !defined(MCUBOOT_HW_KEY) && defined(MCUBOOT_ENC_IMAGES)
-int boot_enc_retrieve_private_key(struct bootutil_key **private_key)
-{
-    *private_key = (struct bootutil_key *)&bootutil_enc_key;
-
-    return 0;
-}
-#endif /* !MCUBOOT_HW_KEY && MCUBOOT_ENC_IMAGES */

--- a/ci/mynewt_keys/enc_kw/src/keys.c
+++ b/ci/mynewt_keys/enc_kw/src/keys.c
@@ -28,12 +28,3 @@ const struct bootutil_key bootutil_enc_key = {
     .key = enc_key,
     .len = &enc_key_len,
 };
-
-#if !defined(MCUBOOT_HW_KEY) && defined(MCUBOOT_ENC_IMAGES)
-int boot_enc_retrieve_private_key(struct bootutil_key **private_key)
-{
-    *private_key = (struct bootutil_key *)&bootutil_enc_key;
-
-    return 0;
-}
-#endif /* !MCUBOOT_HW_KEY && MCUBOOT_ENC_IMAGES */

--- a/ci/mynewt_keys/enc_rsa/src/keys.c
+++ b/ci/mynewt_keys/enc_rsa/src/keys.c
@@ -126,12 +126,3 @@ const struct bootutil_key bootutil_enc_key = {
     .key = enc_key,
     .len = &enc_key_len,
 };
-
-#if !defined(MCUBOOT_HW_KEY) && defined(MCUBOOT_ENC_IMAGES)
-int boot_enc_retrieve_private_key(struct bootutil_key **private_key)
-{
-    *private_key = (struct bootutil_key *)&bootutil_enc_key;
-
-    return 0;
-}
-#endif /* !MCUBOOT_HW_KEY && MCUBOOT_ENC_IMAGES */

--- a/sim/mcuboot-sys/csupport/keys.c
+++ b/sim/mcuboot-sys/csupport/keys.c
@@ -328,12 +328,3 @@ const struct bootutil_key bootutil_enc_key = {
     .len = &enc_key_len,
 };
 #endif
-
-#if !defined(MCUBOOT_HW_KEY) && defined(MCUBOOT_ENC_IMAGES)
-int boot_enc_retrieve_private_key(struct bootutil_key **private_key)
-{
-    *private_key = (struct bootutil_key *)&bootutil_enc_key;
-
-    return 0;
-}
-#endif /* !MCUBOOT_HW_KEY && MCUBOOT_ENC_IMAGES */


### PR DESCRIPTION
This reverts commit 0fa46270c0b52b371a094042731c69e100478cbb.

This breaks:

    samples/synchronization/sample.kernel.synchronization on
    b_u585i_iot02a/stm32u585xx/ns error

as this TF-M configuration uses its own keys.  This change is an API change that needs to be coordinated with TF-M changes.

Before this revert, compiling this test results in:

    .../encrypted.c:447: undefined reference to
    `boot_enc_retrieve_private_key`