### PR TITLE
boot: Rename boot_enc_decrypt to boot_decrypt_key

### DIFF
--- a/boot/bootutil/include/bootutil/enc_key.h
+++ b/boot/bootutil/include/bootutil/enc_key.h
@@ -48,6 +48,9 @@ struct enc_key_data {
 extern const struct bootutil_key bootutil_enc_key;
 struct boot_status;
 
+/* Decrypt random, symmetric encryption key */
+int boot_decrypt_key(const uint8_t *buf, uint8_t *enckey);
+
 int boot_enc_init(struct enc_key_data *enc_state, uint8_t slot);
 int boot_enc_drop(struct enc_key_data *enc_state, uint8_t slot);
 int boot_enc_set_key(struct enc_key_data *enc_state, uint8_t slot,
@@ -55,7 +58,6 @@ int boot_enc_set_key(struct enc_key_data *enc_state, uint8_t slot,
 int boot_enc_load(struct enc_key_data *enc_state, int image_index,
         const struct image_header *hdr, const struct flash_area *fap,
         struct boot_status *bs);
-int boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey);
 bool boot_enc_valid(struct enc_key_data *enc_state, int image_index,
         const struct flash_area *fap);
 void boot_encrypt(struct enc_key_data *enc_state, int image_index,

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -283,7 +283,7 @@ boot_read_enc_key(const struct flash_area *fap, uint8_t slot, struct boot_status
         }
         /* Only try to decrypt non-erased TLV metadata */
         if (i != BOOT_ENC_TLV_ALIGN_SIZE) {
-            rc = boot_enc_decrypt(bs->enctlv[slot], bs->enckey[slot]);
+            rc = boot_decrypt_key(bs->enctlv[slot], bs->enckey[slot]);
         }
     }
 #else

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -415,7 +415,7 @@ static int fake_rng(void *p_rng, unsigned char *output, size_t len)
  * @param enckey An AES-128 or AES-256 key sized buffer to store to plain key.
  */
 int
-boot_enc_decrypt(const uint8_t *buf, uint8_t *enckey)
+boot_decrypt_key(const uint8_t *buf, uint8_t *enckey)
 {
 #if defined(MCUBOOT_ENCRYPT_RSA)
     bootutil_rsa_context rsa;
@@ -660,7 +660,7 @@ boot_enc_load(struct enc_key_data *enc_state, int image_index,
         return -1;
     }
 
-    return boot_enc_decrypt(buf, bs->enckey[slot]);
+    return boot_decrypt_key(buf, bs->enckey[slot]);
 }
 
 bool


### PR DESCRIPTION
All of boot_enc_ function follow the same pattern where they take encryption context as the first parameter, and the boot_enc_decrypt stands out here as it does not work around the encryption context, but is rather single-part decryption function only used for decrypting of the image encryption key.