### PR TITLE
boot: Remove pointless slot identification

### DIFF
--- a/boot/boot_serial/src/boot_serial_encryption.c
+++ b/boot/boot_serial/src/boot_serial_encryption.c
@@ -40,10 +40,6 @@ boot_image_validate_encrypted(const struct flash_area *fa_p,
         if (rc < 0) {
             FIH_RET(fih_rc);
         }
-        rc = flash_area_id_to_multi_image_slot(image_index, flash_area_get_id(fa_p));
-        if (rc < 0) {
-            FIH_RET(fih_rc);
-        }
         rc = boot_enc_set_key(BOOT_CURR_ENC(state), 1, bs);
         if (rc < 0) {
             FIH_RET(fih_rc);


### PR DESCRIPTION
In the boot_image_validate_encrypted there was call to flash_area_id_to_multi_image_slot, which tries to figure out slot index from flash area and image index, and the result of the call was not used for anything as slot index is hardcoded in the next call to be 1 (secondary).