### PR TITLE
boot: Make boot_enc_valid take slot instead of image index

### DIFF
--- a/boot/bootutil/include/bootutil/enc_key.h
+++ b/boot/bootutil/include/bootutil/enc_key.h
@@ -69,8 +69,7 @@ int boot_enc_set_key(struct enc_key_data *enc_state, uint8_t slot,
 int boot_enc_load(struct enc_key_data *enc_state, int slot,
         const struct image_header *hdr, const struct flash_area *fap,
         struct boot_status *bs);
-bool boot_enc_valid(struct enc_key_data *enc_state, int image_index,
-        const struct flash_area *fap);
+bool boot_enc_valid(struct enc_key_data *enc_state, int slot);
 void boot_encrypt(struct enc_key_data *enc_state, int slot,
         uint32_t off, uint32_t sz, uint32_t blk_off, uint8_t *buf);
 void boot_enc_zeroize(struct enc_key_data *enc_state);

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -682,19 +682,9 @@ boot_enc_load(struct enc_key_data *enc_state, int slot,
 }
 
 bool
-boot_enc_valid(struct enc_key_data *enc_state, int image_index,
-        const struct flash_area *fap)
+boot_enc_valid(struct enc_key_data *enc_state, int slot)
 {
-    int rc;
-
-    rc = flash_area_id_to_multi_image_slot(image_index, flash_area_get_id(fap));
-    if (rc < 0) {
-        /* can't get proper slot number - skip encryption, */
-        /* postpone the error for a upper layer */
-        return false;
-    }
-
-    return enc_state[rc].valid;
+    return enc_state[slot].valid;
 }
 
 void

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -96,7 +96,7 @@ bootutil_img_hash(struct enc_key_data *enc_state, int image_index,
 #ifdef MCUBOOT_ENC_IMAGES
     /* Encrypted images only exist in the secondary slot */
     if (MUST_DECRYPT(fap, image_index, hdr) &&
-            !boot_enc_valid(enc_state, image_index, fap)) {
+            !boot_enc_valid(enc_state, 1)) {
         return -1;
     }
 #endif


### PR DESCRIPTION
There is no point for boot_enc_valid to take image index and flash area and use these to figure out slot number.