### PR TITLE
boot: Move encryption context invalidation to boot_enc_drop.

### DIFF
--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -347,6 +347,7 @@ int
 boot_enc_drop(struct enc_key_data *enc_state, uint8_t slot)
 {
     bootutil_aes_ctr_drop(&enc_state[slot].aes_ctr);
+    enc_state[slot].valid = 0;
     return 0;
 }
 
@@ -359,7 +360,6 @@ boot_enc_set_key(struct enc_key_data *enc_state, uint8_t slot,
     rc = bootutil_aes_ctr_set_key(&enc_state[slot].aes_ctr, bs->enckey[slot]);
     if (rc != 0) {
         boot_enc_drop(enc_state, slot);
-        enc_state[slot].valid = 0;
         return -1;
     }
 


### PR DESCRIPTION
The enc_key_data.valid had been set to true when key has been added to the encryption context, but in case when boot_enc_drop was called, on the same context, the flag remained true, even though the context may no longer hold any valid context nor key.
The commit moves the enc_key_data invalidation to enc_key_drop.