### PR TITLE
boot: zephyr: Fix RAM load chain load address

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -534,8 +534,13 @@ int main(void)
         FIH_PANIC;
     }
 
+#ifdef CONFIG_BOOT_RAM_LOAD
+    BOOT_LOG_INF("Bootloader chainload address offset: 0x%x",
+                 rsp.br_hdr->ih_load_addr);
+#else
     BOOT_LOG_INF("Bootloader chainload address offset: 0x%x",
                  rsp.br_image_off);
+#endif
 
 #if defined(MCUBOOT_DIRECT_XIP)
     BOOT_LOG_INF("Jumping to the image slot");

--- a/docs/release-notes.d/fix-ram-load-zephyr-address.md
+++ b/docs/release-notes.d/fix-ram-load-zephyr-address.md
@@ -1,0 +1,2 @@
+- Fixed chain load address output log message for RAM load
+  mode in Zephyr


### PR DESCRIPTION
Fixes showing the wrong address when booting a RAM load image