### PR TITLE
 boot: Replace boot_encrypt by boot_enc_encrypt and boot_enc_decrypt

### DIFF
--- a/boot/boot_serial/src/boot_serial_encryption.c
+++ b/boot/boot_serial/src/boot_serial_encryption.c
@@ -171,7 +171,7 @@ decrypt_region_inplace(struct boot_loader_state *state,
                     blk_sz = tlv_off - (off + bytes_copied);
                 }
             }
-            boot_encrypt(BOOT_CURR_ENC(state), slot,
+            boot_enc_decrypt(BOOT_CURR_ENC(state), slot,
                     (off + bytes_copied + idx) - hdr->ih_hdr_size, blk_sz,
                     blk_off, &buf[idx]);
         }

--- a/boot/bootutil/include/bootutil/enc_key.h
+++ b/boot/bootutil/include/bootutil/enc_key.h
@@ -70,7 +70,9 @@ int boot_enc_load(struct enc_key_data *enc_state, int slot,
         const struct image_header *hdr, const struct flash_area *fap,
         struct boot_status *bs);
 bool boot_enc_valid(struct enc_key_data *enc_state, int slot);
-void boot_encrypt(struct enc_key_data *enc_state, int slot,
+void boot_enc_encrypt(struct enc_key_data *enc_state, int slot,
+        uint32_t off, uint32_t sz, uint32_t blk_off, uint8_t *buf);
+void boot_enc_decrypt(struct enc_key_data *enc_state, int slot,
         uint32_t off, uint32_t sz, uint32_t blk_off, uint8_t *buf);
 void boot_enc_zeroize(struct enc_key_data *enc_state);
 

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -153,8 +153,8 @@ bootutil_img_hash(struct enc_key_data *enc_state, int image_index,
 
             if (off >= hdr_size && off < tlv_off) {
                 blk_off = (off - hdr_size) & 0xf;
-                boot_encrypt(enc_state, slot, off - hdr_size,
-                             blk_sz, blk_off, tmp_buf);
+                boot_enc_decrypt(enc_state, slot, off - hdr_size,
+                                 blk_sz, blk_off, tmp_buf);
             }
         }
 #endif

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1359,9 +1359,15 @@ boot_copy_region(struct boot_loader_state *state,
                         blk_sz = tlv_off - abs_off;
                     }
                 }
-                boot_encrypt(BOOT_CURR_ENC(state), source_slot,
-                        (abs_off + idx) - hdr->ih_hdr_size, blk_sz,
-                        blk_off, &buf[idx]);
+                if (source_slot == 0) {
+                    boot_enc_encrypt(BOOT_CURR_ENC(state), source_slot,
+                            (abs_off + idx) - hdr->ih_hdr_size, blk_sz,
+                            blk_off, &buf[idx]);
+                } else {
+                    boot_enc_decrypt(BOOT_CURR_ENC(state), source_slot,
+                            (abs_off + idx) - hdr->ih_hdr_size, blk_sz,
+                            blk_off, &buf[idx]);
+                }
             }
         }
 #endif
@@ -2894,10 +2900,9 @@ boot_decrypt_and_copy_image_to_sram(struct boot_loader_state *state,
              * Part of the chunk is encrypted payload */
             blk_sz = tlv_off - (bytes_copied);
         }
-        boot_encrypt(BOOT_CURR_ENC(state), slot,
-            (bytes_copied + idx) - hdr->ih_hdr_size, blk_sz,
-            blk_off, cur_dst);
-
+        boot_enc_decrypt(BOOT_CURR_ENC(state), slot,
+                (bytes_copied + idx) - hdr->ih_hdr_size, blk_sz,
+                blk_off, cur_dst);
         bytes_copied += chunk_sz;
     }
     rc = 0;


### PR DESCRIPTION
To be able to implement encryption with API that requires different
calls for encryption and encryption, the boot_encrypt
needs to be replaced with encryption/decryption specific functions.

Depends on:
- [x] https://github.com/mcu-tools/mcuboot/pull/2003
- [x] https://github.com/mcu-tools/mcuboot/pull/2004
- [x] https://github.com/mcu-tools/mcuboot/pull/2013
