### PR TITLE
RFC: bootutil: Add TLV for  Pure (over image) signature

### DIFF
--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -101,6 +101,9 @@ struct flash_area;
 #define IMAGE_TLV_ECDSA_SIG         0x22   /* ECDSA of hash output */
 #define IMAGE_TLV_RSA3072_PSS       0x23   /* RSA3072 of hash output */
 #define IMAGE_TLV_ED25519           0x24   /* ed25519 of hash output */
+#define IMAGE_TLV_SIG_PURE          0x25   /* Indicator that attached signature has been prepared
+                                            * over image rather than its digest.
+                                            */
 #define IMAGE_TLV_ENC_RSA2048       0x30   /* Key encrypted with RSA-OAEP-2048 */
 #define IMAGE_TLV_ENC_KW            0x31   /* Key encrypted with AES-KW 128 or 256*/
 #define IMAGE_TLV_ENC_EC256         0x32   /* Key encrypted with ECIES-EC256 */

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -69,6 +69,7 @@ TLV_VALUES = {
         'ECDSASIG': 0x22,
         'RSA3072': 0x23,
         'ED25519': 0x24,
+        'SIG_PURE': 0x25,
         'ENCRSA2048': 0x30,
         'ENCKW': 0x31,
         'ENCEC256': 0x32,


### PR DESCRIPTION
The commit reserves IMAGE_TLV_SIG_PURE == 0x25 as indicator that the signature attached to image is calculated over image rather than its digest (pure, by the name of PureEdDSA). The indicator/flag is provided so that no special TLV is designated to one signature type, because, in theory, any signature algorithm that can be used over image rather than digest can be marked as "Pure".

The PureEdDSA ED25519 signature should be done directly over message, so image in our case. The current implementation is not really PureEdDSA nor HashEdDSA, as we basically pass sha256 as a message to PureEdDSA. ~~Not perfect.~~

**Why is this added?**
This PR adds TLV that indicates that PureEdDSA has been run over image rather than sha has been calculated and passed to ed25519 for signature/verification.

**Problems**
This only works with devices that are mapping flash to RAM address space, so that image signature verification can directly access whole image as message.
This means that configuration with external devices may not work.

Note also that signatures PureEdDSA(image) != PureEdDSA(sha512(image)) != HashEdDSA(sha512(image)), so there is no realu way to use multi-part signature verification with PureEdDSA.

The https://github.com/mcu-tools/mcuboot/pull/2048 is implementation where sha512 is used with PureEdDSA ~~, not perfect.~~