### PR TITLE
bootutil: Fix missing include

### DIFF
--- a/boot/bootutil/include/bootutil/boot_record.h
+++ b/boot/bootutil/include/bootutil/boot_record.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include "bootutil/image.h"
+#include "bootutil/bootutil.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes a missing include in the header