### PR TITLE
espressif: Update the references for using the new Espressif HAL

### DIFF
--- a/boot/espressif/hal/include/esp32c6/esp32c6.cmake
+++ b/boot/espressif/hal/include/esp32c6/esp32c6.cmake
@@ -10,7 +10,8 @@ list(APPEND hal_srcs
     ${esp_hal_dir}/components/hal/cache_hal.c
     ${esp_hal_dir}/components/hal/lp_timer_hal.c
     ${esp_hal_dir}/components/efuse/src/efuse_controller/keys/with_key_purposes/esp_efuse_api_key.c
-    ${esp_hal_dir}/components/esp_rom/patches/esp_rom_regi2c_${MCUBOOT_TARGET}.c
+    ${esp_hal_dir}/components/esp_rom/patches/esp_rom_hp_regi2c_${MCUBOOT_TARGET}.c
+    ${esp_hal_dir}/components/esp_hw_support/port/${MCUBOOT_TARGET}/pmu_param.c
 )
 
 if (DEFINED CONFIG_ESP_CONSOLE_UART_CUSTOM)

--- a/boot/espressif/hal/include/esp32h2/esp32h2.cmake
+++ b/boot/espressif/hal/include/esp32h2/esp32h2.cmake
@@ -11,6 +11,7 @@ list(APPEND hal_srcs
     ${esp_hal_dir}/components/hal/lp_timer_hal.c
     ${esp_hal_dir}/components/efuse/src/efuse_controller/keys/with_key_purposes/esp_efuse_api_key.c
     ${esp_hal_dir}/components/esp_rom/patches/esp_rom_regi2c_${MCUBOOT_TARGET}.c
+    ${esp_hal_dir}/components/esp_hw_support/port/${MCUBOOT_TARGET}/pmu_param.c
 )
 
 if (DEFINED CONFIG_ESP_CONSOLE_UART_CUSTOM)


### PR DESCRIPTION
The new Espressif HAL is based on ESP-IDF v5.1.4 and this PR updates the required files to compile MCUboot using this HAL version.