### PR TITLE
bootutil: Fix image verification and add state to is header valid function

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -863,9 +863,12 @@ out:
  * within the flash area we are in.
  */
 static bool
-boot_is_header_valid(const struct image_header *hdr, const struct flash_area *fap)
+boot_is_header_valid(const struct image_header *hdr, const struct flash_area *fap,
+                     struct boot_loader_state *state)
 {
     uint32_t size;
+
+    (void)state;
 
     if (hdr->ih_magic != IMAGE_MAGIC) {
         return false;
@@ -1033,7 +1036,7 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
     {
         FIH_CALL(boot_image_check, fih_rc, state, hdr, fap, bs);
     }
-    if (!boot_is_header_valid(hdr, fap) || FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
+    if (!boot_is_header_valid(hdr, fap, state) || FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
         if ((slot != BOOT_PRIMARY_SLOT) || ARE_SLOTS_EQUIVALENT()) {
             flash_area_erase(fap, 0, flash_area_get_size(fap));
             /* Image is invalid, erase it to prevent further unnecessary
@@ -2556,7 +2559,7 @@ boot_get_slot_usage(struct boot_loader_state *state)
         for (slot = 0; slot < BOOT_NUM_SLOTS; slot++) {
             hdr = boot_img_hdr(state, slot);
 
-            if (boot_is_header_valid(hdr, BOOT_IMG_AREA(state, slot))) {
+            if (boot_is_header_valid(hdr, BOOT_IMG_AREA(state, slot), state)) {
                 state->slot_usage[BOOT_CURR_IMG(state)].slot_available[slot] = true;
                 BOOT_LOG_IMAGE_INFO(slot, hdr);
             } else {

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1030,13 +1030,16 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
         }
     }
 #endif
-    BOOT_HOOK_CALL_FIH(boot_image_check_hook, FIH_BOOT_HOOK_REGULAR,
-                       fih_rc, BOOT_CURR_IMG(state), slot);
-    if (FIH_EQ(fih_rc, FIH_BOOT_HOOK_REGULAR))
-    {
-        FIH_CALL(boot_image_check, fih_rc, state, hdr, fap, bs);
+    if (!boot_is_header_valid(hdr, fap, state)) {
+        fih_rc = FIH_FAILURE;
+    } else {
+        BOOT_HOOK_CALL_FIH(boot_image_check_hook, FIH_BOOT_HOOK_REGULAR,
+                           fih_rc, BOOT_CURR_IMG(state), slot);
+        if (FIH_EQ(fih_rc, FIH_BOOT_HOOK_REGULAR)) {
+            FIH_CALL(boot_image_check, fih_rc, state, hdr, fap, bs);
+        }
     }
-    if (!boot_is_header_valid(hdr, fap, state) || FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
+    if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
         if ((slot != BOOT_PRIMARY_SLOT) || ARE_SLOTS_EQUIVALENT()) {
             flash_area_erase(fap, 0, flash_area_get_size(fap));
             /* Image is invalid, erase it to prevent further unnecessary

--- a/docs/release-notes.d/bootutil-image-verification.md
+++ b/docs/release-notes.d/bootutil-image-verification.md
@@ -1,0 +1,4 @@
+- Changed bootutil's order of events to verify the image header
+  before checking the image.
+- Added the bootloader state object to the bootutil
+  boot_is_header_valid() function


### PR DESCRIPTION
    bootutil: loader: Add state to boot_is_header_valid() function
    
    Adds the state object to this function so it can be referenced

    bootutil: loader: Verify image header before checking image
    
    Changes the order of operations to validate the image header
    before checking the image, it does not make sense to check the
    image if the header itself is invalid
