### PR TITLE
bootutil: Add better mode selection checks

### DIFF
--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -58,8 +58,14 @@ struct flash_area;
      defined(MCUBOOT_SWAP_USING_MOVE) + \
      defined(MCUBOOT_DIRECT_XIP) + \
      defined(MCUBOOT_RAM_LOAD) + \
-     defined(MCUBOOT_FIRMWARE_LOADER)) > 1
+     defined(MCUBOOT_FIRMWARE_LOADER) + \
+     defined(MCUBOOT_SWAP_USING_SCRATCH)) > 1
 #error "Please enable only one of MCUBOOT_OVERWRITE_ONLY, MCUBOOT_SWAP_USING_MOVE, MCUBOOT_DIRECT_XIP, MCUBOOT_RAM_LOAD or MCUBOOT_FIRMWARE_LOADER"
+#endif
+
+#if !defined(MCUBOOT_DIRECT_XIP) && \
+     defined(MCUBOOT_DIRECT_XIP_REVERT)
+#error "MCUBOOT_DIRECT_XIP_REVERT cannot be enabled unless MCUBOOT_DIRECT_XIP is used"
 #endif
 
 #if !defined(MCUBOOT_OVERWRITE_ONLY) && \

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -493,6 +493,35 @@ find_last_sector_idx(const struct boot_loader_state *state, uint32_t copy_size)
 }
 
 /**
+ * Finds the number of swap operations that have to be performed to swap the two images.
+ *
+ * @param state     Current bootloader's state.
+ * @param copy_size Total number of bytes to swap.
+ *
+ * @return          The number of swap operations that have to be performed.
+*/
+static uint32_t
+find_swap_count(const struct boot_loader_state *state, uint32_t copy_size)
+{
+    int first_sector_idx;
+    int last_sector_idx;
+    uint32_t swap_count;
+
+    last_sector_idx = find_last_sector_idx(state, copy_size);
+
+    swap_count = 0;
+
+    while (last_sector_idx >= 0) {
+        boot_copy_sz(state, last_sector_idx, &first_sector_idx);
+
+        last_sector_idx = first_sector_idx - 1;
+        swap_count++;
+    }
+
+    return swap_count;
+}
+
+/**
  * Swaps the contents of two flash regions within the two image slots.
  *
  * @param idx                   The index of the first sector in the range of
@@ -731,37 +760,6 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
 
 }
 #endif /* !MCUBOOT_OVERWRITE_ONLY */
-
-#ifdef MCUBOOT_SWAP_USING_SCRATCH
-/**
- * Finds the number of swap operations that have to be performed to swap the two images.
- *
- * @param state     Current bootloader's state.
- * @param copy_size Total number of bytes to swap.
- *
- * @return          The number of swap operations that have to be performed.
-*/
-static uint32_t
-find_swap_count(const struct boot_loader_state *state, uint32_t copy_size)
-{
-    int first_sector_idx;
-    int last_sector_idx;
-    uint32_t swap_count;
-
-    last_sector_idx = find_last_sector_idx(state, copy_size);
-
-    swap_count = 0;
-
-    while (last_sector_idx >= 0) {
-        boot_copy_sz(state, last_sector_idx, &first_sector_idx);
-
-        last_sector_idx = first_sector_idx - 1;
-        swap_count++;
-    }
-
-    return swap_count;
-}
-#endif /* MCUBOOT_SWAP_USING_SCRATCH */
 
 int app_max_size(struct boot_loader_state *state)
 {


### PR DESCRIPTION
    Improves the mode selection checks to prevent selecting multiple
    conflicting modes as has been seen in TFM


Also reverts a change that was not needed