### PR TITLE
imgtool: Support for SHA512 for ED25519 usage

### DIFF
--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -72,6 +72,7 @@ keygens = {
     'x25519':     gen_x25519,
 }
 valid_formats = ['openssl', 'pkcs8']
+valid_sha = [ 'auto', '256', '384', '512' ]
 
 
 def load_signature(sigfile):
@@ -401,6 +402,9 @@ class BasedIntParamType(click.ParamType):
 @click.option('--sig-out', metavar='filename',
               help='Path to the file to which signature will be written. '
               'The image signature will be encoded as base64 formatted string')
+@click.option('--sha', 'user_sha', type=click.Choice(valid_sha), default='auto',
+              help='selected sha algorithm to use; defaults to "auto" which is 256 if '
+              'no cryptographic signature is used, or default for signature type')
 @click.option('--vector-to-sign', type=click.Choice(['payload', 'digest']),
               help='send to OUTFILE the payload or payload''s digest instead '
               'of complied image. These data can be used for external image '
@@ -413,7 +417,7 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
          endian, encrypt_keylen, encrypt, infile, outfile, dependencies,
          load_addr, hex_addr, erased_val, save_enctlv, security_counter,
          boot_record, custom_tlv, rom_fixed, max_align, clear, fix_sig,
-         fix_sig_pubkey, sig_out, vector_to_sign, non_bootable):
+         fix_sig_pubkey, sig_out, user_sha, vector_to_sign, non_bootable):
 
     if confirm:
         # Confirmed but non-padded images don't make much sense, because
@@ -481,7 +485,7 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
 
     img.create(key, public_key_format, enckey, dependencies, boot_record,
                custom_tlvs, int(encrypt_keylen), clear, baked_signature,
-               pub_key, vector_to_sign)
+               pub_key, vector_to_sign, user_sha)
     img.save(outfile, hex_addr)
 
     if sig_out is not None:


### PR DESCRIPTION
imgtool changes to support the SHA512 and proper ED25519 signare.

This PR is alternative to https://github.com/mcu-tools/mcuboot/pull/2029 where new TLV is introduced.
While working on image changes I have decided that it is not needed to provide new TLV  for signature, because:
 - the SHA512 is newly support hash and there is no logic for it yet so no possible mismatch of SHA and key
 - it is enough to decide by key and hash TLV whether the ED25519 is double or single hashing.

Depends on https://github.com/mcu-tools/mcuboot/pull/1967