### PR TITLE
boot: zephyr: Add fallback to USB DFU

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -573,6 +573,12 @@ config BOOT_USB_DFU_DETECT_DELAY
 
 endif # BOOT_USB_DFU_GPIO
 
+config BOOT_USB_DFU_NO_APPLICATION
+	bool "Stay in bootloader if no application"
+	help
+	  Allows for entering USB DFU recovery mode if there is no bootable
+	  application that the bootloader can jump to.
+
 config BOOT_USE_BENCH
         bool "Enable benchmark code"
         default n

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -531,6 +531,14 @@ int main(void)
          * recovery mode
          */
         boot_serial_enter();
+#elif defined(CONFIG_BOOT_USB_DFU_NO_APPLICATION)
+        rc = usb_enable(NULL);
+        if (rc && rc != -EALREADY) {
+            BOOT_LOG_ERR("Cannot enable USB");
+        } else {
+            BOOT_LOG_INF("Waiting for USB DFU");
+            wait_for_usb_dfu(K_FOREVER);
+        }
 #endif
 
         FIH_PANIC;


### PR DESCRIPTION
Allow bootloader to fallback to USB DFU if no application is present, that can be booted from. Similar to config BOOT_SERIAL_NO_APPLICATION.