### PR TITLE
boot: Support bootstrapping for multiple images

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1960,8 +1960,7 @@ boot_prepare_image_for_update(struct boot_loader_state *state,
         rc = boot_read_image_headers(state, !boot_status_is_reset(bs), bs);
 #ifdef MCUBOOT_BOOTSTRAP
         /* When bootstrapping it's OK to not have image magic in the primary slot */
-        if (rc != 0 && (BOOT_CURR_IMG(state) != BOOT_PRIMARY_SLOT ||
-                boot_check_header_erased(state, BOOT_PRIMARY_SLOT) != 0)) {
+        if (rc != 0 && boot_check_header_erased(state, BOOT_PRIMARY_SLOT) != 0) {
 #else
         if (rc != 0) {
 #endif


### PR DESCRIPTION
Bootstrapping is currently not allowed for more than one image. But that seems to be unintentional according to https://github.com/mcu-tools/mcuboot/pull/826#issuecomment-707939624

I ran into the same issue trying to boot two images (for M7 and M4) on a i.MX RT1170 using zephyr. We solved this using the suggested change and hope it could be added to main.

With this it's possible to enable MCUmgr SMP within MCUBoot and update a device that only has the bootloader in flash.