### PR TITLE
bootutil: Fix AES and SHA-256 contexts not zeroized (mbedTLS)

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/aes_ctr.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_ctr.h
@@ -53,9 +53,7 @@ static inline void bootutil_aes_ctr_init(bootutil_aes_ctr_context *ctx)
 
 static inline void bootutil_aes_ctr_drop(bootutil_aes_ctr_context *ctx)
 {
-    /* XXX: config defines MBEDTLS_PLATFORM_NO_STD_FUNCTIONS so no need to free */
-    /* (void)mbedtls_aes_free(ctx); */
-    (void)ctx;
+    mbedtls_aes_free(ctx);
 }
 
 static inline int bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx, const uint8_t *k)

--- a/boot/bootutil/include/bootutil/crypto/aes_kw.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_kw.h
@@ -45,9 +45,7 @@ static inline void bootutil_aes_kw_init(bootutil_aes_kw_context *ctx)
 
 static inline void bootutil_aes_kw_drop(bootutil_aes_kw_context *ctx)
 {
-    /* XXX: config defines MBEDTLS_PLATFORM_NO_STD_FUNCTIONS so no need to free */
-    /* (void)mbedtls_aes_free(ctx); */
-    (void)ctx;
+    mbedtls_nist_kw_free(ctx);
 }
 
 static inline int bootutil_aes_kw_set_unwrap_key(bootutil_aes_kw_context *ctx, const uint8_t *k, uint32_t klen)

--- a/boot/bootutil/include/bootutil/crypto/sha.h
+++ b/boot/bootutil/include/bootutil/crypto/sha.h
@@ -126,9 +126,7 @@ static inline int bootutil_sha_init(bootutil_sha_context *ctx)
 
 static inline int bootutil_sha_drop(bootutil_sha_context *ctx)
 {
-    /* XXX: config defines MBEDTLS_PLATFORM_NO_STD_FUNCTIONS so no need to free */
-    /* (void)mbedtls_sha256_free(ctx); */
-    (void)ctx;
+    mbedtls_sha256_free(ctx);
     return 0;
 }
 


### PR DESCRIPTION
For some reason, the calls to `mbedtls_aes_free`, `mbedtls_nist_kw_free` and `mbedtls_sha256_free_drop` were commented out which means the AES and SHA-256 contexts were not properly de-initialized after usage when mbedTLS is used. In the case of AES-KW it seems that might lead to a memory leak depending on the mbedTLS configuration, but in any case and independently of the mbedTLS configuration, this leads to the contexts not be zeroized after usage.

Not zeroizing a context means it stays in RAM an undefined amount of time, which might enable an attacker to access it and to dump the sensitive data it contains. For example, for SHA-256, knowing the value of the context might make possible to obtain part of sensitive data that was hashed. For AES, it might make possible to infer the AES master key (or at least part of it).

The commit adding the commented out code is [here](https://github.com/mcu-tools/mcuboot/commit/4f4833d4655fdafe5301c74624a68325137646e6). My understanding of the commit message is that the de-initialization functions weren't called because this was not needed on Zephyr which defines `MBEDTLS_PLATFORM_NO_STD_FUNCTIONS`:

> - No need to free contexts because Zephyr sets MBEDTLS_PLATFORM_NO_STD_FUNCTIONS.
>
> I don't quite like this because it's implicit and will leak memory on other ports.

To me, this seems to be an incorrect statement even on Zephyr when `MBEDTLS_PLATFORM_NO_STD_FUNCTIONS` is defined as zeroization is always needed (or at least highly recommended) for security purposes.