### PR TITLE
cmake: zephyr: change ERROR into FATAL_ERROR

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -372,7 +372,7 @@ function(dt_get_parent node)
   string(FIND "${${node}}" "/" pos REVERSE)
 
   if(pos EQUAL -1)
-    message(ERROR "Unable to get parent of node: ${${node}}")
+    message(FATAL_ERROR "Unable to get parent of node: ${${node}}")
   endif()
 
   string(SUBSTRING "${${node}}" 0 ${pos} ${node})


### PR DESCRIPTION
CMake's message function was mistakenly called with ERROR but the correct correct argument to use is FATAL_ERROR.