### PR TITLE
bootutil: Add support for Ed25519 using SHA-512 with mbedTLS

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/sha.h
+++ b/boot/bootutil/include/bootutil/crypto/sha.h
@@ -55,7 +55,12 @@
 
 #elif defined(MCUBOOT_USE_MBED_TLS)
 
+#ifdef MCUBOOT_SHA512
+#include <mbedtls/sha512.h>
+#else
 #include <mbedtls/sha256.h>
+#endif
+
 #include <mbedtls/version.h>
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000
 #include <mbedtls/compat-2.x.h>
@@ -123,17 +128,35 @@ static inline int bootutil_sha_finish(bootutil_sha_context *ctx,
 
 #elif defined(MCUBOOT_USE_MBED_TLS)
 
+#ifdef MCUBOOT_SHA512
+typedef mbedtls_sha512_context bootutil_sha_context;
+#else
 typedef mbedtls_sha256_context bootutil_sha_context;
+#endif
 
 static inline int bootutil_sha_init(bootutil_sha_context *ctx)
 {
+    int ret;
+
+#ifdef MCUBOOT_SHA512
+    mbedtls_sha512_init(ctx);
+    ret = mbedtls_sha512_starts_ret(ctx, 0);
+#else
     mbedtls_sha256_init(ctx);
-    return mbedtls_sha256_starts_ret(ctx, 0);
+    ret = mbedtls_sha256_starts_ret(ctx, 0);
+#endif
+
+    return ret;
 }
 
 static inline int bootutil_sha_drop(bootutil_sha_context *ctx)
 {
+#ifdef MCUBOOT_SHA512
+    mbedtls_sha512_free(ctx);
+#else
     mbedtls_sha256_free(ctx);
+#endif
+
     return 0;
 }
 
@@ -141,13 +164,29 @@ static inline int bootutil_sha_update(bootutil_sha_context *ctx,
                                       const void *data,
                                       uint32_t data_len)
 {
-    return mbedtls_sha256_update_ret(ctx, data, data_len);
+    int ret;
+
+#ifdef MCUBOOT_SHA512
+    ret = mbedtls_sha512_update_ret(ctx, data, data_len);
+#else
+    ret = mbedtls_sha256_update_ret(ctx, data, data_len);
+#endif
+
+    return ret;
 }
 
 static inline int bootutil_sha_finish(bootutil_sha_context *ctx,
                                       uint8_t *output)
 {
-    return mbedtls_sha256_finish_ret(ctx, output);
+    int ret;
+
+#ifdef MCUBOOT_SHA512
+    ret = mbedtls_sha512_finish_ret(ctx, output);
+#else
+    ret = mbedtls_sha256_finish_ret(ctx, output);
+#endif
+
+    return ret;
 }
 
 #endif /* MCUBOOT_USE_MBED_TLS */

--- a/boot/bootutil/src/image_ed25519.c
+++ b/boot/bootutil/src/image_ed25519.c
@@ -17,6 +17,7 @@
 
 #include "bootutil_priv.h"
 #include "bootutil/crypto/common.h"
+#include "bootutil/crypto/sha.h"
 
 static const uint8_t ed25519_pubkey_oid[] = MBEDTLS_OID_ISO_IDENTIFIED_ORG "\x65\x70";
 #define NUM_ED25519_BYTES 32
@@ -73,7 +74,7 @@ bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
     uint8_t *pubkey;
     uint8_t *end;
 
-    if (hlen != 32 || slen != 64) {
+    if (hlen != IMAGE_HASH_SIZE || slen != 64) {
         FIH_SET(fih_rc, FIH_FAILURE);
         goto out;
     }
@@ -87,7 +88,7 @@ bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, size_t slen,
         goto out;
     }
 
-    rc = ED25519_verify(hash, 32, sig, pubkey);
+    rc = ED25519_verify(hash, IMAGE_HASH_SIZE, sig, pubkey);
 
     if (rc == 0) {
         /* if verify returns 0, there was an error. */


### PR DESCRIPTION
This MR adds in the bootloader support for Ed25519 using SHA-512 with mbedTLS. To do so, this MR:
* Adds support for SHA-512 with mbedTLS.
* Adds support for images hashed with SHA-512 in the Ed25519 verification routine.

The changes were tested on an STM32F4 MCU, with both SHA-256 and SHA-512 configuration.

Relates to https://github.com/mcu-tools/mcuboot/pull/2048.