### PR TITLE
boot: zephyr: Allow disabling NRFX_WDT on nRF devices

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -736,15 +736,20 @@ config BOOT_WATCHDOG_FEED
 	bool "Feed the watchdog while doing swap"
 	default y if WATCHDOG
 	default y if SOC_FAMILY_NORDIC_NRF
-	# for nRF nrfx based implementation is available
-	imply NRFX_WDT if SOC_FAMILY_NORDIC_NRF
-	imply NRFX_WDT0 if SOC_FAMILY_NORDIC_NRF
-	imply NRFX_WDT1 if SOC_FAMILY_NORDIC_NRF
-	imply NRFX_WDT30 if SOC_FAMILY_NORDIC_NRF
-	imply NRFX_WDT31 if SOC_FAMILY_NORDIC_NRF
+	imply BOOT_WATCHDOG_FEED_NRFX_WDT if SOC_FAMILY_NORDIC_NRF
 	help
 	  Enables implementation of MCUBOOT_WATCHDOG_FEED() macro which is
 	  used to feed watchdog while doing time consuming operations.
+
+config BOOT_WATCHDOG_FEED_NRFX_WDT
+	bool "Feed the watchdog using NRFX WDT directly"
+	depends on SOC_FAMILY_NORDIC_NRF
+	# for nRF nrfx based implementation is available
+	imply NRFX_WDT
+	imply NRFX_WDT0
+	imply NRFX_WDT1
+	imply NRFX_WDT30
+	imply NRFX_WDT31
 
 config BOOT_IMAGE_ACCESS_HOOKS
 	bool "Enable hooks for overriding MCUboot's native routines"

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -330,7 +330,7 @@
 #endif
 
 #if CONFIG_BOOT_WATCHDOG_FEED
-#if CONFIG_NRFX_WDT
+#if CONFIG_BOOT_WATCHDOG_FEED_NRFX_WDT
 #include <nrfx_wdt.h>
 
 #define FEED_WDT_INST(id)                                    \
@@ -367,7 +367,7 @@
 #error "No NRFX WDT instances enabled"
 #endif
 
-#elif DT_NODE_HAS_STATUS(DT_ALIAS(watchdog0), okay) /* CONFIG_NRFX_WDT */
+#elif DT_NODE_HAS_STATUS(DT_ALIAS(watchdog0), okay) /* CONFIG_BOOT_WATCHDOG_FEED_NRFX_WDT */
 #include <zephyr/device.h>
 #include <zephyr/drivers/watchdog.h>
 


### PR DESCRIPTION
Allow disabling feeding the watchdog on nrf devices directly using the nrfx_wdt functions.
The imply on NRFX_WDT cannot be disabled since NRFX_WDT is a promptless symbol and cannot be assigned in a config fragment. Not even deleting the wdt0 node in a devicetree overlay works since the configuration takes predence and ends in a #error without any nrfx_wdt instances.

To fix this create new Kconfig option with prompt and change the imply to this option. That way the option can be assigned to off by the user.

This is needed to support the use case of an external watchdog controlled using the zephyr watchdog API instead of the wdt peripheral.