### PR TITLE
samples: zephyr: add sysbuild to the hello-world sample

### DIFF
--- a/samples/zephyr/hello-world/sample.yaml
+++ b/samples/zephyr/hello-world/sample.yaml
@@ -2,6 +2,8 @@ sample:
   name: Application Skeleton
   description: Basic "hello world" application, but loadable by mcuboot
   platforms: all
+common:
+  sysbuild: true
 tests:
     - test:
         build_only: true

--- a/samples/zephyr/hello-world/sysbuild.conf
+++ b/samples/zephyr/hello-world/sysbuild.conf
@@ -1,0 +1,2 @@
+# Enable the bootloader when building with sysbuild.
+SB_CONFIG_BOOTLOADER_MCUBOOT=y


### PR DESCRIPTION
Enable the MCUBoot when building with sysbuild.