### PR TITLE
zephyr: hello_world: Fix the main() return type warning

### DIFF
--- a/samples/zephyr/hello-world/src/main.c
+++ b/samples/zephyr/hello-world/src/main.c
@@ -7,8 +7,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 
-void main(void)
+int main(void)
 {
 	printk("Hello World from %s on %s!\n",
 	       MCUBOOT_HELLO_WORLD_FROM, CONFIG_BOARD);
+	return 0;
 }


### PR DESCRIPTION
Fixes the "return type of 'main' is not 'int'" warning.