### PR TITLE
boot: bootutil: swap_scratch: Fix compressed image sector size check

### DIFF
--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -191,7 +191,17 @@ boot_slots_compatible(struct boot_loader_state *state)
             smaller = 1;
             i++;
         } else {
-            sz1 += boot_img_sector_size(state, BOOT_SECONDARY_SLOT, j);
+            size_t sector_size = boot_img_sector_size(state, BOOT_SECONDARY_SLOT, j);
+
+#ifdef MCUBOOT_DECOMPRESS_IMAGES
+            if (sector_size == 0) {
+                /* Since this supports decompressed images, we can safely exit if slot1 is
+                 * smaller than slot0.
+                 */
+                break;
+            }
+#endif
+            sz1 += sector_size;
             /* Guarantee that multiple sectors of the primary slot
              * fit into the secondary slot.
              */


### PR DESCRIPTION
Fixes an issue with compressed update support whereby it would wrong continue to check all sector sizes and error due to the sector sizes of the secondary slot being 0 until overflow