### PR TITLE
boot: zephyr: use EXTRA_CONF_FILE instead of deprecated OVERLAY_CONFIG

### DIFF
--- a/boot/zephyr/sample.yaml
+++ b/boot/zephyr/sample.yaml
@@ -11,7 +11,7 @@ tests:
       - frdm_k64f
       - disco_l475_iot1
   sample.bootloader.mcuboot.serial_recovery:
-    extra_args: OVERLAY_CONFIG=serial_recovery.conf
+    extra_args: EXTRA_CONF_FILE=serial_recovery.conf
     platform_allow:  nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
@@ -23,14 +23,14 @@ tests:
     integration_platforms:
       - nrf52840dongle/nrf52840
   sample.bootloader.mcuboot.usb_cdc_acm_recovery_log:
-    extra_args: OVERLAY_CONFIG=./usb_cdc_acm_log_recovery.conf
+    extra_args: EXTRA_CONF_FILE=./usb_cdc_acm_log_recovery.conf
       DTC_OVERLAY_FILE="./boards/nrf52840_big.overlay;app.overlay"
     platform_allow:  nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
     tags: bootloader_mcuboot
   sample.bootloader.mcuboot.single_slot:
-    extra_args: OVERLAY_CONFIG=./single_slot.conf
+    extra_args: EXTRA_CONF_FILE=./single_slot.conf
       DTC_OVERLAY_FILE="./boards/nrf52840_single_slot.overlay;app.overlay"
     platform_allow:  nrf52840dk/nrf52840
     integration_platforms:
@@ -38,21 +38,21 @@ tests:
     tags: bootloader_mcuboot
   sample.bootloader.mcuboot.qspi_nor_slot:
     extra_args: DTC_OVERLAY_FILE="./boards/nrf52840dk_qspi_nor_secondary.overlay;app.overlay"
-      OVERLAY_CONFIG="./boards/nrf52840dk_qspi_nor.conf;./boards/nrf52840dk_qspi_secondary_boot.conf"
+      EXTRA_CONF_FILE="./boards/nrf52840dk_qspi_nor.conf;./boards/nrf52840dk_qspi_secondary_boot.conf"
     platform_allow: nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
     tags: bootloader_mcuboot
   sample.bootloader.mcuboot.hooks_multi:
     extra_args: DTC_OVERLAY_FILE="./boards/nrf52840dk_ram_multi.overlay;app.overlay"
-      OVERLAY_CONFIG=./boards/nrf52840dk_hooks_sample_overlay.conf
+      EXTRA_CONF_FILE=./boards/nrf52840dk_hooks_sample_overlay.conf
       TEST_BOOT_IMAGE_ACCESS_HOOKS=Y
     platform_allow: nrf52840dk/nrf52840
     integration_platforms:
       - nrf52840dk/nrf52840
     tags: bootloader_mcuboot
   sample.bootloader.mcuboot.ram_load:
-    extra_args: OVERLAY_CONFIG=./ram_load.conf
+    extra_args: EXTRA_CONF_FILE=./ram_load.conf
     tags: bootloader_mcuboot
     platform_allow: mimxrt1020_evk
     integration_platforms:

--- a/samples/zephyr/Makefile
+++ b/samples/zephyr/Makefile
@@ -50,7 +50,7 @@
 
 # Extra .conf fragments to merge into the MCUboot .config, as a
 # semicolon-separated list (i.e., a CMake list).
-BOOTLOADER_OVERLAY_CONFIG ?=
+BOOTLOADER_EXTRA_CONF_FILE ?=
 
 BOARD ?= frdm_k64f
 SLOT_SIZE ?= 0x60000
@@ -110,7 +110,7 @@ boot: check
 	@rm -f mcuboot.bin
 	(mkdir -p $(BUILD_DIR_BOOT) && \
 		cd $(BUILD_DIR_BOOT) && \
-		cmake -DOVERLAY_CONFIG=$(BOOTLOADER_OVERLAY_CONFIG) \
+		cmake -DEXTRA_CONF_FILE=$(BOOTLOADER_EXTRA_CONF_FILE) \
 			-G"Ninja" \
 			-DBOARD=$(BOARD) \
 			$(SOURCE_DIRECTORY)/../../boot/zephyr && \
@@ -193,7 +193,7 @@ flash_full:
 # reset: hello1 runs
 test-good-rsa: clean
 	$(MAKE) \
-		BOOTLOADER_OVERLAY_CONFIG=$(PWD)/overlay-rsa.conf \
+		BOOTLOADER_EXTRA_CONF_FILE=$(PWD)/overlay-rsa.conf \
 		all
 
 # Test a good image, with a good upgrade, using ECDSA signatures.
@@ -203,7 +203,7 @@ test-good-rsa: clean
 # reset: hello1 runs
 test-good-ecdsa: clean
 	$(MAKE) \
-		BOOTLOADER_OVERLAY_CONFIG=$(PWD)/overlay-ecdsa-p256.conf \
+		BOOTLOADER_EXTRA_CONF_FILE=$(PWD)/overlay-ecdsa-p256.conf \
 		SIGNING_KEY=../../root-ec-p256.pem \
 		all
 
@@ -215,7 +215,7 @@ test-good-ecdsa: clean
 # reset: hello2 runs
 test-overwrite: clean
 	$(MAKE) \
-		BOOTLOADER_OVERLAY_CONFIG=$(PWD)/overlay-upgrade-only.conf \
+		BOOTLOADER_EXTRA_CONF_FILE=$(PWD)/overlay-upgrade-only.conf \
 		all
 
 # Test that when configured for RSA, a wrong signature in the upgrade
@@ -226,10 +226,10 @@ test-overwrite: clean
 # reset: hello1 runs
 test-bad-rsa-upgrade: clean
 	$(MAKE) \
-		BOOTLOADER_OVERLAY_CONFIG=$(PWD)/overlay-rsa.conf \
+		BOOTLOADER_EXTRA_CONF_FILE=$(PWD)/overlay-rsa.conf \
 		boot hello1
 	$(MAKE) \
-		BOOTLOADER_OVERLAY_CONFIG=$(PWD)/overlay-rsa.conf \
+		BOOTLOADER_EXTRA_CONF_FILE=$(PWD)/overlay-rsa.conf \
 		SIGNING_KEY=../../root-ec-p256.pem \
 		hello2
 
@@ -241,11 +241,11 @@ test-bad-rsa-upgrade: clean
 # reset: hello1 runs
 test-bad-ecdsa-upgrade: clean
 	$(MAKE) \
-		BOOTLOADER_OVERLAY_CONFIG=$(PWD)/overlay-ecdsa-p256.conf \
+		BOOTLOADER_EXTRA_CONF_FILE=$(PWD)/overlay-ecdsa-p256.conf \
 		SIGNING_KEY=../../root-ec-p256.pem \
 		boot hello1
 	$(MAKE) \
-		BOOTLOADER_OVERLAY_CONFIG=$(PWD)/overlay-ecdsa-p256.conf \
+		BOOTLOADER_EXTRA_CONF_FILE=$(PWD)/overlay-ecdsa-p256.conf \
 		SIGNING_KEY=../../root-rsa-2048.pem \
 		hello2
 
@@ -257,7 +257,7 @@ test-bad-ecdsa-upgrade: clean
 # reset: hello1 runs
 test-no-bootcheck: clean
 	$(MAKE) \
-		BOOTLOADER_OVERLAY_CONFIG=$(PWD)/overlay-skip-primary-slot-validate.conf \
+		BOOTLOADER_EXTRA_CONF_FILE=$(PWD)/overlay-skip-primary-slot-validate.conf \
 		SIGNING_KEY=../../root-ec-p256.pem \
 		all
 
@@ -268,10 +268,10 @@ test-no-bootcheck: clean
 # reset: hello1 runs
 test-wrong-rsa: clean
 	$(MAKE) \
-		BOOTLOADER_OVERLAY_CONFIG=$(PWD)/overlay-rsa.conf \
+		BOOTLOADER_EXTRA_CONF_FILE=$(PWD)/overlay-rsa.conf \
 		boot hello1
 	$(MAKE) \
-		BOOTLOADER_OVERLAY_CONFIG=$(PWD)/overlay-rsa.conf \
+		BOOTLOADER_EXTRA_CONF_FILE=$(PWD)/overlay-rsa.conf \
 		SIGNING_KEY=bad-keys/bad-rsa-2048.pem \
 		hello2
 
@@ -282,11 +282,11 @@ test-wrong-rsa: clean
 # reset: hello1 runs
 test-wrong-ecdsa: clean
 	$(MAKE) \
-		BOOTLOADER_OVERLAY_CONFIG=$(PWD)/overlay-ecdsa-p256.conf \
+		BOOTLOADER_EXTRA_CONF_FILE=$(PWD)/overlay-ecdsa-p256.conf \
 		SIGNING_KEY=../../root-ec-p256.pem \
 		boot hello1
 	$(MAKE) \
-		BOOTLOADER_OVERLAY_CONFIG=$(PWD)/overlay-ecdsa-p256.conf \
+		BOOTLOADER_EXTRA_CONF_FILE=$(PWD)/overlay-ecdsa-p256.conf \
 		SIGNING_KEY=bad-keys/bad-ec-p256.pem \
 		hello2
 


### PR DESCRIPTION
Use EXTRA_CONF_FILE that replaced OVERLAY_CONFIG since the Zephyr v3.4 release.