### PR TITLE
zephyr: Fixing Kconfig dependency for SHA512

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -85,7 +85,6 @@ config BOOT_IMG_HASH_ALG_SHA384_ALLOW
 
 config BOOT_IMG_HASH_ALG_SHA512_ALLOW
 	bool
-	depends on BOOT_USE_PSA_CRYPTO
 	help
 	  Hidden option set by configurations that allow SHA512
 


### PR DESCRIPTION
The SHA512_ALLOW Kconfig has been added to allow signature algorithms to select which SHA they support. Unfortunately it has been given dependency on PSA crypto, which now is problematic because if signature algorithm wants to indicate that it allows SHA512 it immediately becomes dependent on PSA crypto.

The commit removes the dependency.