### PR TITLE
Allow bypassing ASN.1 processing of public key for ED25519

### DIFF
--- a/boot/bootutil/src/image_ed25519.c
+++ b/boot/bootutil/src/image_ed25519.c
@@ -12,27 +12,30 @@
 #ifdef MCUBOOT_SIGN_ED25519
 #include "bootutil/sign_key.h"
 
+#if !defined(MCUBOOT_KEY_IMPORT_BYPASS_ASN)
 /* We are not really using the MBEDTLS but need the ASN.1 parsing functions */
 #define MBEDTLS_ASN1_PARSE_C
 #include "mbedtls/oid.h"
 #include "mbedtls/asn1.h"
+#endif
 
 #include "bootutil_priv.h"
 #include "bootutil/crypto/common.h"
 #include "bootutil/crypto/sha.h"
 
 #define EDDSA_SIGNATURE_LENGTH 64
-
-static const uint8_t ed25519_pubkey_oid[] = MBEDTLS_OID_ISO_IDENTIFIED_ORG "\x65\x70";
 #define NUM_ED25519_BYTES 32
 
 extern int ED25519_verify(const uint8_t *message, size_t message_len,
                           const uint8_t signature[EDDSA_SIGNATURE_LENGTH],
                           const uint8_t public_key[NUM_ED25519_BYTES]);
 
+#if !defined(MCUBOOT_KEY_IMPORT_BYPASS_ASN)
 /*
  * Parse the public key used for signing.
  */
+static const uint8_t ed25519_pubkey_oid[] = MBEDTLS_OID_ISO_IDENTIFIED_ORG "\x65\x70";
+
 static int
 bootutil_import_key(uint8_t **cp, uint8_t *end)
 {
@@ -68,6 +71,7 @@ bootutil_import_key(uint8_t **cp, uint8_t *end)
 
     return 0;
 }
+#endif /* !defined(MCUBOOT_KEY_IMPORT_BYPASS_ASN) */
 
 /* Signature verification base function.
  * The function takes buffer of specified length and tries to verify
@@ -93,11 +97,25 @@ bootutil_verify(uint8_t *buf, uint32_t blen,
     pubkey = (uint8_t *)bootutil_keys[key_id].key;
     end = pubkey + *bootutil_keys[key_id].len;
 
+#if !defined(MCUBOOT_KEY_IMPORT_BYPASS_ASN)
     rc = bootutil_import_key(&pubkey, end);
     if (rc) {
         FIH_SET(fih_rc, FIH_FAILURE);
         goto out;
     }
+#else
+    /* Directly use the key contents from the ASN stream,
+     * these are the last NUM_ED25519_BYTES.
+     * There is no check whether this is the correct key,
+     * here, by the algorithm selected.
+     */
+    if (*bootutil_keys[key_id].len < NUM_ED25519_BYTES) {
+        FIH_SET(fih_rc, FIH_FAILURE);
+        goto out;
+    }
+
+    pubkey = end - NUM_ED25519_BYTES;
+#endif
 
     rc = ED25519_verify(buf, blen, sig, pubkey);
 

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -240,6 +240,15 @@ config BOOT_ED25519_MBEDTLS
 	select BOOT_AES_MBEDTLS_DEPENDENCIES if MBEDTLS_BUILTIN && BOOT_ENCRYPT_IMAGE
 
 endchoice
+
+config BOOT_KEY_IMPORT_BYPASS_ASN
+	bool "Directly access key value without ASN.1 parsing"
+	help
+	  Originally, public keys compiled into MCUboot were
+	  stored in ASN.1 encoded format. Enabling this option
+	  bypasses the ASN.1 decoding and directly accesses the key
+	  in ASN.1 bitstream; this reduces MCUboot code by removing
+	  the ASN.1 processing.
 endif
 
 endchoice

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -34,6 +34,10 @@
 #     error "One crypto library implementation allowed at a time."
 #endif
 
+#if defined(CONFIG_BOOT_KEY_IMPORT_BYPASS_ASN)
+#define MCUBOOT_KEY_IMPORT_BYPASS_ASN
+#endif
+
 #ifdef CONFIG_BOOT_USE_MBEDTLS
 #define MCUBOOT_USE_MBED_TLS
 #elif defined(CONFIG_BOOT_USE_TINYCRYPT)


### PR DESCRIPTION
Add conditional compilation of ASN.1 decoding of ED25519 key.

This allows to cut out the ASN.1 encoding, which results in reduced flash size.

Comparison on nrf52840dk/nrf52840 build of MCUboot with the ED25519 enabled 
```
west build -p -d builds/nrf52_mcuboot_ed25519_no_asn -b nrf52840dk/nrf52840 bootloader/mcuboot/boot/zephyr/ -DCONFIG_BOOT_SIGNATURE_TYPE_ED25519=y
```

Reduces code from 40422 bytes to 39918 bytes, when  `-DCONFIG_BOOT_KEY_IMPORT_BYPASS_ASN=y` is added.

Another benefit of the option is that it is no longer needed to have portion of the mbedTLS, that does the ASN.1 support, enabled when compiling MCUboot with ED25519 for TinyCrypt.