### PR TITLE
imgtool: bugfix #2096

### DIFF
--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -510,7 +510,7 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
         }
 
     img.create(key, public_key_format, enckey, dependencies, boot_record,
-               custom_tlvs, compression_tlvs, int(encrypt_keylen), clear,
+               custom_tlvs, compression_tlvs, None, int(encrypt_keylen), clear,
                baked_signature, pub_key, vector_to_sign, user_sha)
 
     if compression == "lzma2":


### PR DESCRIPTION
fixing broken encryption caused by shift in function parameters.

Fixes #2096