### PR TITLE
bootutil: Fix device bricked after power failure during swap-move revert

### DIFF
--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -118,7 +118,7 @@ static const struct boot_swap_table boot_swap_tables[] = {
     },
     {
         .magic_primary_slot =       BOOT_MAGIC_GOOD,
-        .magic_secondary_slot =     BOOT_MAGIC_UNSET,
+        .magic_secondary_slot =     BOOT_MAGIC_ANY,
         .image_ok_primary_slot =    BOOT_FLAG_UNSET,
         .image_ok_secondary_slot =  BOOT_FLAG_ANY,
         .copy_done_primary_slot =   BOOT_FLAG_SET,

--- a/docs/design.md
+++ b/docs/design.md
@@ -656,7 +656,7 @@ types described above via a set of tables.  These tables are reproduced below.
     State III
                      | primary slot | secondary slot |
     -----------------+--------------+----------------|
-               magic | Good         | Unset          |
+               magic | Good         | Any            |
             image-ok | 0xff         | Any            |
            copy-done | 0x01         | Any            |
     -----------------+--------------+----------------'


### PR DESCRIPTION
This PR proposes a fix to https://github.com/mcu-tools/mcuboot/issues/1966, which describes a scenario where a device can be bricked if a revert process is interrupted when using swap-move.

As suggested in [this message](https://github.com/mcu-tools/mcuboot/issues/1966#issuecomment-2200541322), a very straightforward fix might be enough. The latter is implemented in this PR.

The idea is to perform a revert no matter the state of the magic number in the secondary slot's trailer, provided the `copy-done`
flag is set in the primary slot but the `image-ok` flag is not. The `copy-done` flag is set only after having completed an upgrade or
revert process so if the `copy-done` flag is set but the `image-ok` is unset, it is guaranteed an upgrade has been performed but the new image has not been confirmed, which implies a revert is needed.

That looks good to me but perhaps I missed some corner cases that would justify that `BOOT_MAGIC_UNSET` was used instead of `BOOT_MAGIC_ANY`. @utzig @d3zd3z do you have any input on that point?

Fixes #1966