### PR TITLE
imgtool: fix signing for fix-sig-pubkey public rsa

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -184,6 +184,7 @@ ALLOWED_KEY_SHA = {
     keys.ECDSA384P1Public   : ['384'],
     keys.ECDSA256P1         : ['256'],
     keys.RSA                : ['256'],
+    keys.RSAPublic          : ['256'],
     # This two are set to 256 for compatibility, the right would be 512
     keys.Ed25519            : ['256', '512'],
     keys.X25519             : ['256', '512']


### PR DESCRIPTION
After #2048 the signing with `--fix-sig <sig> --fix-sig-pubkey <key>` for RSA 256 fails with error:

`Error: Colud not find allowed hash algorithms for <class 'imgtool.keys.rsa.RSAPublic'>`

Addition of `keys.RSAPublic` to allowed SHA dictionary fixes the problem.