### PR TITLE
codeowners: Fix format

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,10 @@
-boot/boot_serial @nordicjm @de-nordic
-boot/bootutil @davidvincze
-boot/cypress @romanjoe
-boot/espressif @almir-okato
-boot/mynewt @kasjer
-boot/nuttx @michallenc
-boot/zcbor @nordicjm @de-nordic
-boot/zephyr @nordicjm @de-nordic
+boot/boot_serial/ @nordicjm @de-nordic
+boot/bootutil/ @davidvincze
+boot/cypress/ @romanjoe
+boot/espressif/ @almir-okato
+boot/mynewt/ @kasjer
+boot/nuttx/ @michallenc
+boot/zcbor/ @nordicjm @de-nordic
+boot/zephyr/ @nordicjm @de-nordic
+zephyr/ @nordicjm @de-nordic
 * @d3zd3z


### PR DESCRIPTION
Fixes the format of the CODEOWNERS file by putting slashes on the end of directories. Also add the missed top level zephyr directory to the list