### PR TITLE
codeowners: Move wildcard entry to top

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
+* @d3zd3z
 boot/boot_serial/ @nordicjm @de-nordic
 boot/bootutil/ @davidvincze
 boot/cypress/ @romanjoe
@@ -7,4 +8,3 @@ boot/nuttx/ @michallenc
 boot/zcbor/ @nordicjm @de-nordic
 boot/zephyr/ @nordicjm @de-nordic
 zephyr/ @nordicjm @de-nordic
-* @d3zd3z


### PR DESCRIPTION
The wildcard entry needs moving to the top so other entries override it


@utzig Now that this seems to sort of work (the action fails, I have no idea why but I've given up trying to work that out), should any folders/files be added to you?