### PR TITLE
boards: mcxn947_qspi: fix mcuboot partition allocation

### DIFF
--- a/boot/zephyr/boards/frdm_mcxn947_mcxn947_cpu0_qspi.overlay
+++ b/boot/zephyr/boards/frdm_mcxn947_mcxn947_cpu0_qspi.overlay
@@ -7,6 +7,7 @@
 / {
         chosen {
                 zephyr,flash = &flash;
+                zephyr,code-partition = &boot_partition;
         };
 };
 


### PR DESCRIPTION
- Fixes MCUBoot partition allocation for frdm_mcxn947_mcxn947_cpu0_qspi
- Assign "zephyr,code-partition" in the frdm_mcxn947_mcxn947_cpu0_qspi overlay, as app.overlay is ignored if a board overlay is present.