### PR TITLE
ci: Upgrade artifact actions

### DIFF
--- a/.github/workflows/imgtool.yaml
+++ b/.github/workflows/imgtool.yaml
@@ -35,13 +35,14 @@ jobs:
         pipenv run pip install pytest -e .
         pipenv run pytest --junitxml=../junit/pytest-results-${{ matrix.python-version }}.xml
     - name: Upload test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: pytest-results-${{ matrix.python-version }}
         path: |
           junit/pytest-results-${{ matrix.python-version }}*.xml
         if-no-files-found: ignore
+        overwrite: true
   environment:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
v3 of actions/upload-artifact and
actions/download-artifact becomes obsolete.