### PR TITLE
boot: Allow watchdog timeout to be configured

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -750,6 +750,14 @@ config BOOT_WATCHDOG_FEED_NRFX_WDT
 	imply NRFX_WDT30
 	imply NRFX_WDT31
 
+config MCUBOOT_WATCHDOG_TIMEOUT
+	int "Watchdog timeout in milliseconds"
+	default 0
+	depends on BOOT_WATCHDOG_FEED
+	help
+	  Specify the watchdog timeout for devices that require a timeout 
+	  installed to setup the watchdog.
+
 config BOOT_IMAGE_ACCESS_HOOKS
 	bool "Enable hooks for overriding MCUboot's native routines"
 	help

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -371,6 +371,22 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/watchdog.h>
 
+#if CONFIG_MCUBOOT_WATCHDOG_TIMEOUT
+#define MCUBOOT_WATCHDOG_INSTALL_TIMEOUT()                    \
+    do {                                                      \
+        struct wdt_timeout_cfg wdtConfig = {                  \
+            .flags = WDT_FLAG_RESET_SOC,                      \
+            .window.min = 0,                                  \
+            .window.max = CONFIG_MCUBOOT_WATCHDOG_TIMEOUT     \
+        };                                                    \
+        wdt_install_timeout(wdt, &wdtConfig);                 \
+    } while (0)
+#else
+#define MCUBOOT_WATCHDOG_INSTALL_TIMEOUT()                    \
+    do {                                                      \
+    } while (0)
+#endif /* CONFIG_MCUBOOT_WATCHDOG_TIMEOUT */
+
 #define MCUBOOT_WATCHDOG_SETUP()                              \
     do {                                                      \
         const struct device* wdt =                            \
@@ -385,6 +401,7 @@
         const struct device* wdt =                            \
             DEVICE_DT_GET(DT_ALIAS(watchdog0));               \
         if (device_is_ready(wdt)) {                           \
+            MCUBOOT_WATCHDOG_INSTALL_TIMEOUT();               \
             wdt_feed(wdt, 0);                                 \
         }                                                     \
     } while (0)


### PR DESCRIPTION
This change adds a new Kconfig option MCUBOOT_WATCHDOG_TIMEOUT to specify the watchdog timeout value. Several devices (NXP among others) require a timeout to be installed in order to enable the watchdog. On e.g. imxrt1170 enabling the watchdog without a timeout will print the error "No valid timeouts installed" and fail to setup the watchdog.

Fixes: https://github.com/mcu-tools/mcuboot/issues/2093