### PR TITLE
ci: mynewt: Use newt for downloading dependencies

### DIFF
--- a/.github/workflows/mynewt.yaml
+++ b/.github/workflows/mynewt.yaml
@@ -18,6 +18,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - uses: actions/setup-go@v3
+      with:
+        go-version: 'stable'
     - name: Print the environment
       run: |
         uname -a

--- a/ci/mynewt_install.sh
+++ b/ci/mynewt_install.sh
@@ -30,22 +30,19 @@ install_newt() {
     popd
 }
 
-shallow_clone_mynewt() {
-    mkdir -p repos/apache-mynewt-core
-    git clone --depth=1 https://github.com/apache/mynewt-core repos/apache-mynewt-core
+install_mynewt() {
+    build="$PWD/build"
+    newt new "$build"
     [[ $? -ne 0 ]] && exit 1
 
-    # nrfx is now taken from original repository
-    git clone --depth=1 --branch v3.3.0 https://github.com/NordicSemiconductor/nrfx.git repos/nordic-nrfx
+    cp -f ci/mynewt_project.yml "$build"/project.yml
+
+    pushd "$build"
+    newt upgrade --shallow=1
     [[ $? -ne 0 ]] && exit 1
 
-    # Mbed-TLS is now taken from original repository
-    git clone --depth=1 --branch v2.28.4 https://github.com/Mbed-TLS/mbedtls.git repos/mbedtls
-    [[ $? -ne 0 ]] && exit 1
-
-    # CMSIS is now taken from original repository
-    git clone --depth=1 --branch 5.4.0 https://github.com/ARM-software/CMSIS_5.git repos/arm-CMSIS_5
-    [[ $? -ne 0 ]] && exit 1
+    popd
+    mv "$build"/repos .
 }
 
 arm_toolchain_install() {
@@ -78,6 +75,6 @@ mkdir -p $HOME/bin
 export PATH=$HOME/bin:$PATH
 
 install_newt
-shallow_clone_mynewt
+install_mynewt
 arm_toolchain_install
 native_test_setup

--- a/ci/mynewt_project.yml
+++ b/ci/mynewt_project.yml
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+project.name: "my_project"
+
+# Use github's distribution mechanism for core ASF libraries.
+# This provides mirroring automatically for us.
+#
+repository.apache-mynewt-core:
+    type: github
+    vers: 0.0.0
+    user: apache
+    repo: mynewt-core
+
+project.repositories.allowed:
+       - apache-mynewt-core
+       - apache-mynewt-nimble
+       - apache-mynewt-mcumgr
+       - mbedtls
+       - nordic-nrfx
+       - arm-CMSIS_5


### PR DESCRIPTION
This makes sure that Mynewt targets have all required dependencies downloaded.

newt can now do shallow clones as well as download only specified repositories, so no unnecessary downloading happens on CI.