### PR TITLE
Add allowed hash for ECDSA256P1Public key

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -183,6 +183,7 @@ ALLOWED_KEY_SHA = {
     keys.ECDSA384P1         : ['384'],
     keys.ECDSA384P1Public   : ['384'],
     keys.ECDSA256P1         : ['256'],
+    keys.ECDSA256P1Public   : ['256'],
     keys.RSA                : ['256'],
     keys.RSAPublic          : ['256'],
     # This two are set to 256 for compatibility, the right would be 512


### PR DESCRIPTION
Hello,

I've found a problem with IMGTOOL when I was trying to inject externally generated signature. (using --fix-sig and --fix-sig-pubkey options)

IMGTOOL was returning an error "Error: Colud not find allowed hash algorithms for <class 'imgtool.keys.ecdsa.ECDSA256P1Public'>"

This PR adds allowed hash (SHA256) for ECC256 Public key.
