### PR TITLE
zephyr: convert platform_allow to a list

### DIFF
--- a/boot/zephyr/sample.yaml
+++ b/boot/zephyr/sample.yaml
@@ -5,7 +5,10 @@ sample:
 tests:
   sample.bootloader.mcuboot:
     tags: bootloader_mcuboot
-    platform_allow:  nrf52840dk/nrf52840 frdm_k64f disco_l475_iot1
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - frdm_k64f
+      - disco_l475_iot1
     integration_platforms:
       - nrf52840dk/nrf52840
       - frdm_k64f


### PR DESCRIPTION
Twister now expects a yaml list of plaforms.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
