### PR TITLE
boot: zephyr: boot_record: Save boot data with single image

### DIFF
--- a/boot/bootutil/src/boot_record.c
+++ b/boot/bootutil/src/boot_record.c
@@ -237,7 +237,9 @@ int boot_save_shared_data(const struct image_header *hdr, const struct flash_are
                           const uint8_t slot, const struct image_max_size *max_app_sizes)
 {
     int rc;
+#if !defined(MCUBOOT_SINGLE_APPLICATION_SLOT)
     uint8_t image = 0;
+#endif
 
 #if defined(MCUBOOT_SINGLE_APPLICATION_SLOT)
     uint8_t mode = MCUBOOT_MODE_SINGLE_SLOT;
@@ -322,11 +324,13 @@ int boot_save_shared_data(const struct image_header *hdr, const struct flash_are
                                           sizeof(recovery), &recovery);
     }
 
+#if !defined(MCUBOOT_SINGLE_APPLICATION_SLOT)
     if (!rc) {
         rc = boot_add_data_to_shared_area(TLV_MAJOR_BLINFO,
                                           BLINFO_RUNNING_SLOT,
                                           sizeof(slot), (void *)&slot);
     }
+#endif
 
 #if defined(MCUBOOT_VERSION_AVAILABLE)
     if (!rc) {
@@ -337,6 +341,7 @@ int boot_save_shared_data(const struct image_header *hdr, const struct flash_are
     }
 #endif
 
+#if !defined(MCUBOOT_SINGLE_APPLICATION_SLOT)
     while (image < BOOT_IMAGE_NUMBER && !rc) {
         if (max_app_sizes[image].calculated == true) {
             rc = boot_add_data_to_shared_area(TLV_MAJOR_BLINFO,
@@ -348,6 +353,7 @@ int boot_save_shared_data(const struct image_header *hdr, const struct flash_are
 
         ++image;
     }
+#endif
 
     if (!rc) {
         saved_bootinfo = true;

--- a/boot/zephyr/single_loader.c
+++ b/boot/zephyr/single_loader.c
@@ -8,6 +8,8 @@
 #include <assert.h>
 #include "bootutil/image.h"
 #include "bootutil_priv.h"
+#include "bootutil/boot_record.h"
+#include "bootutil/bootutil.h"
 #include "bootutil/bootutil_log.h"
 #include "bootutil/bootutil_public.h"
 #include "bootutil/fault_injection_hardening.h"
@@ -139,6 +141,22 @@ boot_go(struct boot_rsp *rsp)
 #else
     fih_rc = FIH_SUCCESS;
 #endif /* MCUBOOT_VALIDATE_PRIMARY_SLOT */
+
+#ifdef MCUBOOT_MEASURED_BOOT
+    rc = boot_save_boot_status(0, &_hdr, _fa_p);
+    if (rc != 0) {
+        BOOT_LOG_ERR("Failed to add image data to shared area");
+        return rc;
+    }
+#endif /* MCUBOOT_MEASURED_BOOT */
+
+#ifdef MCUBOOT_DATA_SHARING
+    rc = boot_save_shared_data(&_hdr, _fa_p, 0, NULL);
+    if (rc != 0) {
+        BOOT_LOG_ERR("Failed to add data to shared memory area.");
+        return rc;
+    }
+#endif /* MCUBOOT_DATA_SHARING */
 
     rsp->br_flash_dev_id = flash_area_get_device_id(_fa_p);
     rsp->br_image_off = flash_area_get_off(_fa_p);


### PR DESCRIPTION
Ensure that bootloader info and measurements are saved to retained memory when using mcuboot in single-image mode.