### PR TITLE
boot: zephyr: boards: Add frdm-mcxa156 configuration

### DIFF
--- a/boot/zephyr/boards/frdm_mcxa156.conf
+++ b/boot/zephyr/boards/frdm_mcxa156.conf
@@ -1,0 +1,5 @@
+# Copyright 2024 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+#MCXA156 does not support the MCUBoot swap mode.
+CONFIG_BOOT_UPGRADE_ONLY=y


### PR DESCRIPTION
Adds default configuration for the frdm-mcxa156 board.