### PR TITLE
ci: actions/cache v1 has been deprecated, use v4

### DIFF
--- a/.github/workflows/imgtool.yaml
+++ b/.github/workflows/imgtool.yaml
@@ -51,7 +51,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Cache pip
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip


### PR DESCRIPTION
GitHub recently announced that [actions/cache](https://github.com/actions/cache) v1 and v2 are deprecated. Jobs using them will start failing in February. In this repo, only the imgtool action uses actions/cache.

This PR updates the imgtool.yaml workflow to use actions/cache@v4.

- Announcement: https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/
- Discussion: https://github.com/actions/cache/discussions/1510