### PR TITLE
boot: zephyr: boards: add support for M5stack CoreS3/CoreS3SE

### DIFF
--- a/boot/zephyr/boards/m5stack_cores3_esp32s3_procpu.overlay
+++ b/boot/zephyr/boards/m5stack_cores3_esp32s3_procpu.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 TOKITA Hiroshi <tokita.hiroshi@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&aw9523b {
+	status = "disabled";
+};
+
+&aw9523b_gpio {
+	status = "disabled";
+};
+
+&ft6336_touch {
+	status = "disabled";
+};

--- a/boot/zephyr/boards/m5stack_cores3_esp32s3_procpu_se.overlay
+++ b/boot/zephyr/boards/m5stack_cores3_esp32s3_procpu_se.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 TOKITA Hiroshi <tokita.hiroshi@gmail.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&aw9523b {
+	status = "disabled";
+};
+
+&aw9523b_gpio {
+	status = "disabled";
+};
+
+&ft6336_touch {
+	status = "disabled";
+};


### PR DESCRIPTION
Add m5stack_cores3/esp32s3/procpu and m5stack_cores3/esp32s3/procpu/se board targets.
Adds an overlay to disable devices that cause dependency conflicts.