### PR TITLE
boot: bootutil: Add TLV for size of compressed but decrypted image

### DIFF
--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -126,6 +126,7 @@ struct flash_area;
                                             * the format and size of the raw slot (compressed)
                                             * signature
                                             */
+#define IMAGE_TLV_COMP_DEC_SIZE     0x73   /* Compressed decrypted image size */
 					   /*
 					    * vendor reserved TLVs at xxA0-xxFF,
 					    * where xx denotes the upper byte


### PR DESCRIPTION
This TLV is needed in order to know what the data length provided to the decompression system is to remove the padding that is a resultant of the encryption block size