### PR TITLE
espressif: extend loader data

### DIFF
--- a/boot/espressif/hal/include/esp_mcuboot_image.h
+++ b/boot/espressif/hal/include/esp_mcuboot_image.h
@@ -15,12 +15,25 @@
  * for MCUboot-Espressif port booting.
  */
 typedef struct esp_image_load_header {
-    uint32_t header_magic;          /* Magic for load header */
-    uint32_t entry_addr;            /* Application entry address */
-    uint32_t iram_dest_addr;        /* Destination address(VMA) for IRAM region */
-    uint32_t iram_flash_offset;     /* Flash offset(LMA) for start of IRAM region */
-    uint32_t iram_size;             /* Size of IRAM region */
-    uint32_t dram_dest_addr;        /* Destination address(VMA) for DRAM region */
-    uint32_t dram_flash_offset;     /* Flash offset(LMA) for start of DRAM region */
-    uint32_t dram_size;             /* Size of DRAM region */
+    uint32_t header_magic;             /* Magic for load header */
+    uint32_t entry_addr;               /* Application entry address */
+    uint32_t iram_dest_addr;           /* Destination address(VMA) for IRAM region */
+    uint32_t iram_flash_offset;        /* Flash offset(LMA) for start of IRAM region */
+    uint32_t iram_size;                /* Size of IRAM region */
+    uint32_t dram_dest_addr;           /* Destination address(VMA) for DRAM region */
+    uint32_t dram_flash_offset;        /* Flash offset(LMA) for start of DRAM region */
+    uint32_t dram_size;                /* Size of DRAM region */
+    uint32_t lp_rtc_iram_dest_addr;    /* Destination address (VMA) for LP_IRAM region */
+    uint32_t lp_rtc_iram_flash_offset; /* Flash offset (LMA) for LP_IRAM region */
+    uint32_t lp_rtc_iram_size;         /* Size of LP_IRAM region */
+    uint32_t lp_rtc_dram_dest_addr;    /* Destination address (VMA) for LP_DRAM region */
+    uint32_t lp_rtc_dram_flash_offset; /* Flash offset (LMA) for LP_DRAM region */
+    uint32_t lp_rtc_dram_size;         /* Size of LP_DRAM region */
+    uint32_t irom_map_addr;            /* Mapped address (VMA) for IROM region */
+    uint32_t irom_flash_offset;        /* Flash offset (LMA) for IROM region */
+    uint32_t irom_size;                /* Size of IROM region */
+    uint32_t drom_map_addr;            /* Mapped address (VMA) for DROM region */
+    uint32_t drom_flash_offset;        /* Flash offset (LMA) for DROM region */
+    uint32_t drom_size;                /* Size of DROM region */
+    uint32_t _reserved[4];             /* Up to 24 words reserved for the header */
 } esp_image_load_header_t;

--- a/boot/espressif/port/esp32s2/ld/bootloader.ld
+++ b/boot/espressif/port/esp32s2/ld/bootloader.ld
@@ -14,7 +14,7 @@ MEMORY
 {
   iram_seg (RWX) :                  org = 0x40047000, len = 0x9000
   iram_loader_seg (RWX) :           org = 0x40050000, len = 0x6000
-  dram_seg (RW) :                   org = 0x3FFE6000, len = 0x9000
+  dram_seg (RW) :                   org = 0x3FFE6000, len = 0x9A00
 }
 
 /*  Default entry point:  */

--- a/docs/release-notes.d/espressif-idf-version-checking.md
+++ b/docs/release-notes.d/espressif-idf-version-checking.md
@@ -1,2 +1,3 @@
 - Added verification for supported IDF-based HAL version.
 - Fixed missing macro for XMC flash devices on ESP32-S3
+- Extended image loader header to include RTC/LP RAM, DROM and IROM segments.


### PR DESCRIPTION
Add additional regions in loader to include
RTC, LP, IROM and DROM information.