### PR TITLE
espressif: increase esp32s2 dram_seg size

### DIFF
--- a/boot/espressif/port/esp32s2/ld/bootloader.ld
+++ b/boot/espressif/port/esp32s2/ld/bootloader.ld
@@ -14,7 +14,7 @@ MEMORY
 {
   iram_seg (RWX) :                  org = 0x40047000, len = 0x9000
   iram_loader_seg (RWX) :           org = 0x40050000, len = 0x6000
-  dram_seg (RW) :                   org = 0x3FFE6000, len = 0x9000
+  dram_seg (RW) :                   org = 0x3FFE6000, len = 0x9A00
 }
 
 /*  Default entry point:  */


### PR DESCRIPTION
Fixes ESP32-S2 CI build for PR https://github.com/mcu-tools/mcuboot/pull/2173 
