### PR TITLE
bootutil: Add missing MBEDTLS_ASN1_PARSE_C

### DIFF
--- a/boot/bootutil/src/image_ed25519.c
+++ b/boot/bootutil/src/image_ed25519.c
@@ -12,6 +12,8 @@
 #ifdef MCUBOOT_SIGN_ED25519
 #include "bootutil/sign_key.h"
 
+/* We are not really using the MBEDTLS but need the ASN.1 parsing functions */
+#define MBEDTLS_ASN1_PARSE_C
 #include "mbedtls/oid.h"
 #include "mbedtls/asn1.h"
 


### PR DESCRIPTION
Need to define MBEDTLS_ASN1_PARSE_C to be able to see ASN1 functions declarations from mbedTLS.