### PR TITLE
boot: zephyr: add ram_load overlays for nrf52840dk and mimxrt1050_evk boards

### DIFF
--- a/boot/zephyr/boards/mimxrt1050_evk_mimxrt1052_hyperflash_ram_load.overlay
+++ b/boot/zephyr/boards/mimxrt1050_evk_mimxrt1052_hyperflash_ram_load.overlay
@@ -1,0 +1,26 @@
+/ {
+	sram@80007F00 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x80007F00 0x100>;
+		zephyr,memory-region = "RetainedMem";
+		status = "okay";
+
+		retainedmem {
+			compatible = "zephyr,retained-ram";
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			boot_info0: boot_info@0 {
+				compatible = "zephyr,retention";
+				status = "okay";
+				reg = <0x0 0x100>;
+			};
+		};
+	};
+
+	chosen {
+		zephyr,bootloader-info = &boot_info0;
+		zephyr,code-partition = &boot_partition;
+	};
+};

--- a/boot/zephyr/boards/nrf52840dk_nrf52840_ram_load.overlay
+++ b/boot/zephyr/boards/nrf52840dk_nrf52840_ram_load.overlay
@@ -1,0 +1,26 @@
+/ {
+	sram@2003FF00 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		reg = <0x2003FF00 0x100>;
+		zephyr,memory-region = "RetainedMem";
+		status = "okay";
+
+		retainedmem {
+			compatible = "zephyr,retained-ram";
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			boot_info0: boot_info@0 {
+				compatible = "zephyr,retention";
+				status = "okay";
+				reg = <0x0 0x100>;
+			};
+		};
+	};
+
+	chosen {
+		zephyr,bootloader-info = &boot_info0;
+		zephyr,code-partition = &boot_partition;
+	};
+};


### PR DESCRIPTION
Add ram load overlays for nrf52840dk and mimxrt1050_evk boards. These ram load overlays are moved from the Zephyr in tree smp_svr sample, to enable ram load support for multiple platforms.