### PR TITLE
RFC: boot: bootutil: Swap offset: Do not fail on header in wrong sector

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1069,9 +1069,7 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
         }
 
         if (first_sector_hdr.ih_magic == IMAGE_MAGIC) {
-            BOOT_LOG_ERR("Secondary header magic detected in first sector, wrong upload address?");
-            fih_rc = FIH_NO_BOOTABLE_IMAGE;
-            goto check_validity;
+            BOOT_LOG_WRN("Secondary header magic detected in first sector, wrong upload address?");
         }
     }
 #endif


### PR DESCRIPTION
Swap offset does not expect header in first sector/page of secondary slot, rather in secondary, and only attempts to swap an image that starts at second sector.
This commit demotes condition when header is found in first page to just a warning and allows boot to proceed, as long as there is a header is second slot.