### PR TITLE
boot: bootutil: loader: Fix issue with stuck revert

### DIFF
--- a/docs/release-notes.d/fix-stuck-revert.md
+++ b/docs/release-notes.d/fix-stuck-revert.md
@@ -1,0 +1,3 @@
+- Fixed issue for swap using move whereby a device could get
+  stuck in a revert loop despite there being no image in the
+  secondary slot


### PR DESCRIPTION
    Fixes an issue (only for swap using move, unsure if it affects
    other modes) whereby a device can get into a state that there is
    a valid primary image, no secondary image but the primary image
    flag is still set to revert, which then makes loading a firmware
    update from the application impossible due to it assuming that a
    revert will happen upon device reboot
