### PR TITLE
boot: bootutil: Use BOOT_IMG_AREA to get boot_loader_state area

### DIFF
--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -433,7 +433,7 @@ boot_img_num_sectors(const struct boot_loader_state *state, size_t slot)
 static inline uint32_t
 boot_img_slot_off(struct boot_loader_state *state, size_t slot)
 {
-    return flash_area_get_off(BOOT_IMG(state, slot).area);
+    return flash_area_get_off(BOOT_IMG_AREA(state, slot));
 }
 
 #ifndef MCUBOOT_USE_FLASH_AREA_GET_SECTORS

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -2213,7 +2213,7 @@ check_downgrade_prevention(struct boot_loader_state *state)
     if (MCUBOOT_DOWNGRADE_PREVENTION_SECURITY_COUNTER) {
         /* If there was security no counter in slot 0, allow swap */
         rc = bootutil_get_img_security_cnt(state, BOOT_PRIMARY_SLOT,
-                                           BOOT_IMG(state, 0).area,
+                                           BOOT_IMG_AREA(state, 0),
                                            &security_counter[0]);
         if (rc != 0) {
             return 0;
@@ -2221,7 +2221,7 @@ check_downgrade_prevention(struct boot_loader_state *state)
         /* If there is no security counter in slot 1, or it's lower than
          * that of slot 0, prevent downgrade */
         rc = bootutil_get_img_security_cnt(state, BOOT_SECONDARY_SLOT,
-                                           BOOT_IMG(state, 1).area,
+                                           BOOT_IMG_AREA(state, 1),
                                            &security_counter[1]);
         if (rc != 0 || security_counter[0] > security_counter[1]) {
             rc = -1;
@@ -2234,8 +2234,8 @@ check_downgrade_prevention(struct boot_loader_state *state)
     if (rc < 0) {
         /* Image in slot 0 prevents downgrade, delete image in slot 1 */
         BOOT_LOG_INF("Image %d in slot 1 erased due to downgrade prevention", BOOT_CURR_IMG(state));
-        flash_area_erase(BOOT_IMG(state, 1).area, 0,
-                         flash_area_get_size(BOOT_IMG(state, 1).area));
+        flash_area_erase(BOOT_IMG_AREA(state, 1), 0,
+                         flash_area_get_size(BOOT_IMG_AREA(state, 1)));
     } else {
         rc = 0;
     }


### PR DESCRIPTION
There have been invocations of BOOT_IMG(...).area used where BOOT_IMG_AREA could be used to obtain the same result.