### PR TITLE
boot: bootutil: Fix invalid last sector computation for swap-scratch 

### DIFF
--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -464,13 +464,15 @@ boot_copy_sz(const struct boot_loader_state *state, int last_sector_idx,
 static int
 find_last_sector_idx(const struct boot_loader_state *state, uint32_t copy_size)
 {
-    int last_sector_idx;
+    int last_sector_idx_primary;
+    int last_sector_idx_secondary;
     uint32_t primary_slot_size;
     uint32_t secondary_slot_size;
 
     primary_slot_size = 0;
     secondary_slot_size = 0;
-    last_sector_idx = 0;
+    last_sector_idx_primary = 0;
+    last_sector_idx_secondary = 0;
 
     /*
      * Knowing the size of the largest image between both slots, here we
@@ -483,23 +485,24 @@ find_last_sector_idx(const struct boot_loader_state *state, uint32_t copy_size)
             (primary_slot_size < secondary_slot_size)) {
            primary_slot_size += boot_img_sector_size(state,
                                                      BOOT_PRIMARY_SLOT,
-                                                     last_sector_idx);
+                                                     last_sector_idx_primary);
+            ++last_sector_idx_primary;
         }
         if ((secondary_slot_size < copy_size) ||
             (secondary_slot_size < primary_slot_size)) {
            secondary_slot_size += boot_img_sector_size(state,
                                                        BOOT_SECONDARY_SLOT,
-                                                       last_sector_idx);
+                                                       last_sector_idx_secondary);
+            ++last_sector_idx_secondary;
         }
         if (primary_slot_size >= copy_size &&
                 secondary_slot_size >= copy_size &&
                 primary_slot_size == secondary_slot_size) {
             break;
         }
-        last_sector_idx++;
     }
 
-    return last_sector_idx;
+    return last_sector_idx_primary - 1;
 }
 
 /**

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -453,6 +453,29 @@ impl ImagesBuilder {
                 flash.insert(dev_id, dev);
                 (flash, Rc::new(areadesc), &[Caps::SwapUsingMove, Caps::SwapUsingOffset])
             }
+            DeviceName::Stm32f4SpiFlash => {
+                // STM style internal flash and external SPI flash.
+                let dev0 = SimFlash::new(vec![
+                                        16 * 1024, 16 * 1024, 16 * 1024, 16 * 1024, 64 * 1024,
+                                        32 * 1024, 32 * 1024, 64 * 1024,
+                                        32 * 1024, 32 * 1024, 64 * 1024,
+                                        128 * 1024],
+                                        align as usize, erased_val);
+
+                let dev1: SimFlash = SimFlash::new(vec![8192; 64], align as usize, erased_val);
+
+                let mut areadesc = AreaDesc::new();
+                areadesc.add_flash_sectors(0, &dev0);
+                areadesc.add_flash_sectors(1, &dev1);
+                areadesc.add_image(0x020000, 0x020000, FlashId::Image0, 0);
+                areadesc.add_image(0x000000, 0x020000, FlashId::Image1, 1);
+                areadesc.add_image(0x020000, 0x020000, FlashId::ImageScratch, 1);
+
+                let mut flash = SimMultiFlash::new();
+                flash.insert(0, dev0);
+                flash.insert(1, dev1);
+                (flash, Rc::new(areadesc), &[Caps::SwapUsingMove, Caps::SwapUsingOffset])
+            }
             DeviceName::K64f => {
                 // NXP style flash.  Small sectors, one small sector for scratch.
                 let dev = SimFlash::new(vec![4096; 128], align as usize, erased_val);

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -63,12 +63,13 @@ struct Args {
 
 #[derive(Copy, Clone, Debug, Deserialize)]
 pub enum DeviceName {
-    Stm32f4, K64f, K64fBig, K64fMulti, Nrf52840, Nrf52840SpiFlash,
+    Stm32f4, Stm32f4SpiFlash, K64f, K64fBig, K64fMulti, Nrf52840, Nrf52840SpiFlash,
     Nrf52840UnequalSlots, Nrf52840UnequalSlotsLargerSlot1,
 }
 
 pub static ALL_DEVICES: &[DeviceName] = &[
     DeviceName::Stm32f4,
+    DeviceName::Stm32f4SpiFlash,
     DeviceName::K64f,
     DeviceName::K64fBig,
     DeviceName::K64fMulti,
@@ -82,6 +83,7 @@ impl fmt::Display for DeviceName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match *self {
             DeviceName::Stm32f4 => "stm32f4",
+            DeviceName::Stm32f4SpiFlash => "stm32f4SpiFlash",
             DeviceName::K64f => "k64f",
             DeviceName::K64fBig => "k64fbig",
             DeviceName::K64fMulti => "k64fmulti",


### PR DESCRIPTION
At the beginning of a swap-scratch upgrade, the index of the last sector in the primary slot that needs to be swapped is computed using the `find_last_sector_idx` routine. However, if the primary slot is composed of larger sectors than the secondary slot, this routine could return a wrong sector index for the primary slot. The index might even be outside the primary slot, which would lead to at best a simple failure of the upgrade and at worst a corruption of the flash memory bricking the device.
    
The issue hasn't be detected in the simulator until now since among the tested configurations, none used a primary slot composed of larger sectors than the secondary slot. This MR adds such a configuration, which as expected lead to the tests to fail:
```
$ cargo test --features "validate-primary-slot" -- norevert
[...]
core-e6747e257778d78c: ../../boot/bootutil/src/swap_scratch.c:647: boot_swap_sectors: Assertion `rc == 0' failed.
error: test failed, to rerun pass `-p bootsim --test core`
```

The problem is that, with such a configuration, the `find_last_sector_idx` returns an index of a sector in the secondary slot. This MR fixes that by ensuring `find_last_sector_idx` always returns a valid sector index for the primary slot.