### PR TITLE
boot: bootutil: Fix swap-scratch when the trailer is larger than the last sector

### DIFF
--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -344,6 +344,20 @@ int boot_read_enc_key(const struct flash_area *fap, uint8_t slot,
                       struct boot_status *bs);
 #endif
 
+#ifdef MCUBOOT_SWAP_USING_SCRATCH
+/**
+ * Finds the first sector of a given slot that holds image trailer data.
+ *
+ * @param state      Current bootloader's state.
+ * @param slot       The index of the slot to consider.
+ * @param trailer_sz The size of the trailer, in bytes.
+ *
+ * @return The index of the first sector of the slot that holds image trailer data.
+ */
+size_t
+boot_get_first_trailer_sector(struct boot_loader_state *state, size_t slot, size_t trailer_sz);
+#endif
+
 /**
  * Checks that a buffer is erased according to what the erase value for the
  * flash device provided in `flash_area` is.
@@ -511,7 +525,7 @@ int boot_load_image_to_sram(struct boot_loader_state *state);
 
 #endif /* MCUBOOT_RAM_LOAD */
 
-uint32_t bootutil_max_image_size(const struct flash_area *fap);
+uint32_t bootutil_max_image_size(struct boot_loader_state *state, const struct flash_area *fap);
 
 int boot_read_image_size(struct boot_loader_state *state, int slot,
                          uint32_t *size);

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -555,7 +555,7 @@ bootutil_img_validate(struct boot_loader_state *state,
         goto out;
     }
 
-    if (it.tlv_end > bootutil_max_image_size(fap)) {
+    if (it.tlv_end > bootutil_max_image_size(state, fap)) {
         rc = -1;
         goto out;
     }

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -560,6 +560,17 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
     uint8_t image_index;
     int rc;
 
+    image_index = BOOT_CURR_IMG(state);
+
+    rc = flash_area_open(FLASH_AREA_IMAGE_PRIMARY(image_index), &fap_primary_slot);
+    assert (rc == 0);
+
+    rc = flash_area_open(FLASH_AREA_IMAGE_SECONDARY(image_index), &fap_secondary_slot);
+    assert (rc == 0);
+
+    rc = flash_area_open(FLASH_AREA_IMAGE_SCRATCH, &fap_scratch);
+    assert (rc == 0);
+
     /* Calculate offset from start of image area. */
     img_off = boot_img_sector_off(state, BOOT_PRIMARY_SLOT, idx);
 
@@ -591,25 +602,13 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
         }
     }
 
+    /* Check if the currently swapped sector(s) contain the trailer or part of it */
     if ((img_off + sz) >
         boot_img_sector_off(state, BOOT_PRIMARY_SLOT, last_sector)) {
-        copy_sz -= trailer_sz;
+        copy_sz = flash_area_get_size(fap_primary_slot) - img_off - trailer_sz;
     }
 
     bs->use_scratch = (bs->idx == BOOT_STATUS_IDX_0 && copy_sz != sz);
-
-    image_index = BOOT_CURR_IMG(state);
-
-    rc = flash_area_open(FLASH_AREA_IMAGE_PRIMARY(image_index),
-            &fap_primary_slot);
-    assert (rc == 0);
-
-    rc = flash_area_open(FLASH_AREA_IMAGE_SECONDARY(image_index),
-            &fap_secondary_slot);
-    assert (rc == 0);
-
-    rc = flash_area_open(FLASH_AREA_IMAGE_SCRATCH, &fap_scratch);
-    assert (rc == 0);
 
     if (bs->state == BOOT_STATUS_STATE_0) {
         BOOT_LOG_DBG("erasing scratch area");

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -532,6 +532,33 @@ find_swap_count(const struct boot_loader_state *state, uint32_t copy_size)
 }
 
 /**
+ * Finds the first sector of a given slot that holds image trailer data.
+ *
+ * @param state      Current bootloader's state.
+ * @param slot       The index of the slot to consider.
+ * @param trailer_sz The size of the trailer, in bytes.
+ *
+ * @return The index of the first sector of the slot that holds image trailer data.
+ */
+static size_t
+get_first_trailer_sector(struct boot_loader_state *state, size_t slot, size_t trailer_sz)
+{
+    size_t first_trailer_sector = boot_img_num_sectors(state, slot) - 1;
+    size_t sector_sz = boot_img_sector_size(state, slot, first_trailer_sector);
+    size_t trailer_sector_sz = sector_sz;
+
+    while (trailer_sector_sz < trailer_sz) {
+        /* Consider that the image trailer may span across sectors of different sizes */
+        --first_trailer_sector;
+        sector_sz = boot_img_sector_size(state, slot, first_trailer_sector);
+
+        trailer_sector_sz += sector_sz;
+    }
+
+    return first_trailer_sector;
+}
+
+/**
  * Swaps the contents of two flash regions within the two image slots.
  *
  * @param idx                   The index of the first sector in the range of
@@ -551,11 +578,10 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
     const struct flash_area *fap_scratch;
     uint32_t copy_sz;
     uint32_t trailer_sz;
-    uint32_t sector_sz;
     uint32_t img_off;
     uint32_t scratch_trailer_off;
     struct boot_swap_state swap_state;
-    size_t last_sector;
+    size_t first_trailer_sector_primary;
     bool erase_scratch;
     uint8_t image_index;
     int rc;
@@ -578,33 +604,23 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
     trailer_sz = boot_trailer_sz(BOOT_WRITE_SZ(state));
 
     /* sz in this function is always sized on a multiple of the sector size.
-     * The check against the start offset of the last sector
-     * is to determine if we're swapping the last sector. The last sector
-     * needs special handling because it's where the trailer lives. If we're
-     * copying it, we need to use scratch to write the trailer temporarily.
+     * The check against the start offset of the first trailer sector is to determine if we're
+     * swapping that sector, which might contains both part of the firmware image and part of the
+     * trailer (or the whole trailer if the latter is small enough). Therefore, that sector needs
+     * special handling: if we're copying it, we need to use scratch to write the trailer
+     * temporarily.
+     *
+     * Since the primary and secondary slots don't necessarily have the same layout, the index of
+     * the first trailer sector may be different for each slot.
      *
      * NOTE: `use_scratch` is a temporary flag (never written to flash) which
-     * controls if special handling is needed (swapping last sector).
+     * controls if special handling is needed (swapping the first trailer sector).
      */
-    last_sector = boot_img_num_sectors(state, BOOT_PRIMARY_SLOT) - 1;
-    sector_sz = boot_img_sector_size(state, BOOT_PRIMARY_SLOT, last_sector);
-
-    if (sector_sz < trailer_sz) {
-        uint32_t trailer_sector_sz = sector_sz;
-
-        while (trailer_sector_sz < trailer_sz) {
-            /* Consider that the image trailer may span across sectors of
-             * different sizes.
-             */
-            sector_sz = boot_img_sector_size(state, BOOT_PRIMARY_SLOT, --last_sector);
-
-            trailer_sector_sz += sector_sz;
-        }
-    }
+    first_trailer_sector_primary = get_first_trailer_sector(state, BOOT_PRIMARY_SLOT, trailer_sz);
 
     /* Check if the currently swapped sector(s) contain the trailer or part of it */
     if ((img_off + sz) >
-        boot_img_sector_off(state, BOOT_PRIMARY_SLOT, last_sector)) {
+        boot_img_sector_off(state, BOOT_PRIMARY_SLOT, first_trailer_sector_primary)) {
         copy_sz = flash_area_get_size(fap_primary_slot) - img_off - trailer_sz;
 
         /* Check if the computed copy size would cause the beginning of the trailer in the scratch
@@ -663,20 +679,40 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
     }
 
     if (bs->state == BOOT_STATUS_STATE_1) {
-        rc = boot_erase_region(fap_secondary_slot, img_off, sz);
-        assert(rc == 0);
+        uint32_t erase_sz = sz;
+
+        if (bs->idx == BOOT_STATUS_IDX_0) {
+            /* Guarantee here that only the primary slot will have the state.
+             *
+             * This is necessary even though the current area being swapped contains part of the
+             * trailer since in case the trailer spreads over multiple sector erasing the [img_off,
+             * img_off + sz) might not erase the entire trailer.
+              */
+            rc = swap_erase_trailer_sectors(state, fap_secondary_slot);
+            assert(rc == 0);
+
+            if (bs->use_scratch) {
+                /* If the area being swapped contains the trailer or part of it, ensure the
+                 * sector(s) containing the beginning of the trailer won't be erased again.
+                 */
+                size_t trailer_sector_secondary =
+                    get_first_trailer_sector(state, BOOT_SECONDARY_SLOT, trailer_sz);
+
+                uint32_t trailer_sector_offset =
+                    boot_img_sector_off(state, BOOT_SECONDARY_SLOT, trailer_sector_secondary);
+
+                erase_sz = trailer_sector_offset - img_off;
+            }
+        }
+
+        if (erase_sz > 0) {
+            rc = boot_erase_region(fap_secondary_slot, img_off, erase_sz);
+            assert(rc == 0);
+        }
 
         rc = boot_copy_region(state, fap_primary_slot, fap_secondary_slot,
                               img_off, img_off, copy_sz);
         assert(rc == 0);
-
-        if (bs->idx == BOOT_STATUS_IDX_0 && !bs->use_scratch) {
-            /* If not all sectors of the slot are being swapped,
-             * guarantee here that only the primary slot will have the state.
-             */
-            rc = swap_erase_trailer_sectors(state, fap_secondary_slot);
-            assert(rc == 0);
-        }
 
         rc = boot_write_status(state, bs);
         bs->state = BOOT_STATUS_STATE_2;
@@ -684,8 +720,28 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
     }
 
     if (bs->state == BOOT_STATUS_STATE_2) {
-        rc = boot_erase_region(fap_primary_slot, img_off, sz);
-        assert(rc == 0);
+        uint32_t erase_sz = sz;
+
+        if (bs->use_scratch) {
+            /* The current area that is being swapped contains the trailer or part of it. In that
+             * case, make sure to erase all sectors containing the trailer in the primary slot to be
+             * able to write the new trailer. This is not always equivalent to erasing the [img_off,
+             * img_off + sz) range when the trailer spreads across multiple sectors.
+             */
+            rc = swap_erase_trailer_sectors(state, fap_primary_slot);
+            assert(rc == 0);
+
+            /* Ensure the sector(s) containing the beginning of the trailer won't be erased twice */
+            uint32_t trailer_sector_off =
+                boot_img_sector_off(state, BOOT_PRIMARY_SLOT, first_trailer_sector_primary);
+
+            erase_sz = trailer_sector_off - img_off;
+        }
+
+        if (erase_sz > 0) {
+            rc = boot_erase_region(fap_primary_slot, img_off, erase_sz);
+            assert(rc == 0);
+        }
 
         /* NOTE: If this is the final sector, we exclude the image trailer from
          * this copy (copy_sz was truncated earlier).

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -532,33 +532,6 @@ find_swap_count(const struct boot_loader_state *state, uint32_t copy_size)
 }
 
 /**
- * Finds the first sector of a given slot that holds image trailer data.
- *
- * @param state      Current bootloader's state.
- * @param slot       The index of the slot to consider.
- * @param trailer_sz The size of the trailer, in bytes.
- *
- * @return The index of the first sector of the slot that holds image trailer data.
- */
-static size_t
-get_first_trailer_sector(struct boot_loader_state *state, size_t slot, size_t trailer_sz)
-{
-    size_t first_trailer_sector = boot_img_num_sectors(state, slot) - 1;
-    size_t sector_sz = boot_img_sector_size(state, slot, first_trailer_sector);
-    size_t trailer_sector_sz = sector_sz;
-
-    while (trailer_sector_sz < trailer_sz) {
-        /* Consider that the image trailer may span across sectors of different sizes */
-        --first_trailer_sector;
-        sector_sz = boot_img_sector_size(state, slot, first_trailer_sector);
-
-        trailer_sector_sz += sector_sz;
-    }
-
-    return first_trailer_sector;
-}
-
-/**
  * Swaps the contents of two flash regions within the two image slots.
  *
  * @param idx                   The index of the first sector in the range of
@@ -616,7 +589,8 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
      * NOTE: `use_scratch` is a temporary flag (never written to flash) which
      * controls if special handling is needed (swapping the first trailer sector).
      */
-    first_trailer_sector_primary = get_first_trailer_sector(state, BOOT_PRIMARY_SLOT, trailer_sz);
+    first_trailer_sector_primary =
+        boot_get_first_trailer_sector(state, BOOT_PRIMARY_SLOT, trailer_sz);
 
     /* Check if the currently swapped sector(s) contain the trailer or part of it */
     if ((img_off + sz) >
@@ -696,7 +670,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
                  * sector(s) containing the beginning of the trailer won't be erased again.
                  */
                 size_t trailer_sector_secondary =
-                    get_first_trailer_sector(state, BOOT_SECONDARY_SLOT, trailer_sz);
+                    boot_get_first_trailer_sector(state, BOOT_SECONDARY_SLOT, trailer_sz);
 
                 uint32_t trailer_sector_offset =
                     boot_img_sector_off(state, BOOT_SECONDARY_SLOT, trailer_sector_secondary);

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -606,6 +606,18 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
     if ((img_off + sz) >
         boot_img_sector_off(state, BOOT_PRIMARY_SLOT, last_sector)) {
         copy_sz = flash_area_get_size(fap_primary_slot) - img_off - trailer_sz;
+
+        /* Check if the computed copy size would cause the beginning of the trailer in the scratch
+         * area to be overwritten. If so, adjust the copy size to avoid this.
+         *
+         * This could happen if the trailer is larger than a single sector since in that case the
+         * first part of the trailer may be smaller than the trailer in the scratch area.
+         */
+        scratch_trailer_off = boot_status_off(fap_scratch);
+
+        if (copy_sz > scratch_trailer_off) {
+            copy_sz = scratch_trailer_off;
+        }
     }
 
     bs->use_scratch = (bs->idx == BOOT_STATUS_IDX_0 && copy_sz != sz);

--- a/sim/mcuboot-sys/src/area.rs
+++ b/sim/mcuboot-sys/src/area.rs
@@ -149,6 +149,13 @@ impl AreaDesc {
     pub fn iter_areas(&self) -> impl Iterator<Item = &FlashArea> {
         self.whole.iter()
     }
+
+    /// Return the list of sectors of a given flash area.
+    pub fn get_area_sectors(&self, flash_id: FlashId) -> Option<&Vec<FlashArea>> {
+        self.areas.iter()
+            .filter(|area| !area.is_empty())
+            .find(|area| area[0].flash_id == flash_id)
+    }
 }
 
 /// The area descriptor, C format.


### PR DESCRIPTION
When swap-scratch is used and the trailer is larger than the last sector of the primary and/or the secondary slot, the upgrade would fail and a potential flash memory corruption could occur due to an underflow in case a sector contains both part of the firmware image and part of the trailer.

This issue was not shown by the simulator since when `max-align-32` is not selected, the trailer fit in a single sector in all tested configuration, and when `max-align-32` is selected, the firmware image size is chosen so that no sector contain both part of the firmware image and part of the trailer. So, perhaps that's a known limitation and it is expected the users ensure their firmware images are small enough so that this issue doesn't occur, but since I didn't find any documentation mentioning that point and that using a too large image could lead to potentially dangerous underflow, I've considered that as being a bug and attempted to fix it.

The first commit modifies the simulator to compute the maximum firmware image size the same way, irrespective of whether or not `max-align-32` is selected, allowing in both case the sector containing the first part of the trailer (or the whole trailer if it is small enough) to also contain part of the firmware image. As expected, this leads to the tests to fail in the configuration where the trailer doesn't fit in a single sector.

The following commits fixes the issue in the swap-scratch implementation.

---

Example of configuration where the issue occurs:
* Primary slot: 680 KiB -> 170 * 4096-byte sectors
* Secondary slot: 680 KiB -> 85 * 8192-byte sectors
* Scratch area: 8 KiB -> 1 * 8192-byte sector
* Flash write size: 32 bytes

Therefore:
* Slot trailer size: (3 * 85 * 32) + (32 * 5) = 8320 bytes
* Scratch trailer size: (3 * 1 * 32) + (32 * 5) = 256 bytes

This leads to:
```
         PRIMARY                               SECONDARY                              SCRATCH
|          ...          |              |          ...          |
+-----------------------+              +-----------------------+             +-----------------------+
| Firmware (4096 bytes) | Sector 166   | Firmware (8064 bytes) | Sector 83   | Firmware (7936 bytes) |
|           .           |              |           .           |             |           .           |
+-----------------------+              |           .           |             |           .           |
| Firmware (3968 bytes) | Sector 167   |           .           |             |  Trailer (256 bytes)  |
|  Trailer (128 bytes)  |              | Trailer  (128 bytes)  |             |           .           |
+-----------------------+              +-----------------------+             +-----------------------+
|  Trailer (4096 bytes) | Sector 168   | Trailer  (8192 bytes) | Sector 84
|           .           |              |           .           |
+-----------------------+              |           .           |
|  Trailer (4096 bytes) | Sector 169   |           .           |
|           .           |              |           .           |
+-----------------------+              +-----------------------+
```

The first operation performed by the swap-scratch algorithm is to swap the last sector containing part of the firmware image. Assuming the image is larger than 672 KiB, this means swapping sectors 166+167 (primary) and 83 (secondary) in this example. This operation is performed by the `boot_swap_sectors` routine with `sz == 8192`. Before the fixes introduced by this MR:
* `copy_sz` was computed as `sz - trailer_sz = 8192 - 8320 = -128`, so `copy_sz == 4294967167` after wrap around.
* `copy_sz` was computed without taking the size of the scratch area into account. In this example, it is clear that if the whole 8064 bytes of firmware data are copied from sector 83 (secondary) to the scratch area, the trailer of the scratch area would be overwritten. `copy_sz` must therefore be adjusted to ensure the scratch trailer won't be corrupted.
* Only sectors 166+167 (primary) and 83 (secondary) were erased, causing in particular issues when attempting to rewrite the trailer in the primary slot.