### PR TITLE
boot: Reuse pointers for flash_area objects from state

### DIFF
--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -297,7 +297,8 @@ fih_ret bootutil_verify_img(uint8_t *img, uint32_t size,
 
 fih_ret boot_fih_memequal(const void *s1, const void *s2, size_t n);
 
-int boot_find_status(int image_index, const struct flash_area **fap);
+const struct flash_area *boot_find_status(const struct boot_loader_state *state,
+                                          int image_index);
 int boot_magic_compatible_check(uint8_t tbl_val, uint8_t val);
 uint32_t boot_status_sz(uint32_t min_write_sz);
 uint32_t boot_trailer_sz(uint32_t min_write_sz);
@@ -305,8 +306,6 @@ int boot_status_entries(int image_index, const struct flash_area *fap);
 uint32_t boot_status_off(const struct flash_area *fap);
 int boot_read_swap_state(const struct flash_area *fap,
                          struct boot_swap_state *state);
-int boot_read_swap_state_by_id(int flash_area_id,
-                               struct boot_swap_state *state);
 int boot_write_magic(const struct flash_area *fap);
 int boot_write_status(const struct boot_loader_state *state, struct boot_status *bs);
 int boot_write_copy_done(const struct flash_area *fap);

--- a/boot/bootutil/src/swap_misc.c
+++ b/boot/bootutil/src/swap_misc.c
@@ -41,22 +41,13 @@ swap_erase_trailer_sectors(const struct boot_loader_state *state,
     uint32_t total_sz;
     uint32_t off;
     uint32_t sz;
-    int fa_id_primary;
-    int fa_id_secondary;
-    uint8_t image_index;
     int rc;
 
     BOOT_LOG_DBG("erasing trailer; fa_id=%d", flash_area_get_id(fap));
 
-    image_index = BOOT_CURR_IMG(state);
-    fa_id_primary = flash_area_id_from_multi_image_slot(image_index,
-            BOOT_PRIMARY_SLOT);
-    fa_id_secondary = flash_area_id_from_multi_image_slot(image_index,
-            BOOT_SECONDARY_SLOT);
-
-    if (flash_area_get_id(fap) == fa_id_primary) {
+    if (fap == BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT)) {
         slot = BOOT_PRIMARY_SLOT;
-    } else if (flash_area_get_id(fap) == fa_id_secondary) {
+    } else if (fap == BOOT_IMG_AREA(state, BOOT_SECONDARY_SLOT)) {
         slot = BOOT_SECONDARY_SLOT;
     } else {
         return BOOT_EFLASH;
@@ -96,8 +87,8 @@ swap_status_init(const struct boot_loader_state *state,
 
     BOOT_LOG_DBG("initializing status; fa_id=%d", flash_area_get_id(fap));
 
-    rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_SECONDARY(image_index),
-            &swap_state);
+    rc = boot_read_swap_state(state->imgs[image_index][BOOT_SECONDARY_SLOT].area,
+                              &swap_state);
     assert(rc == 0);
 
     if (bs->swap_type != BOOT_SWAP_TYPE_NONE) {

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -356,12 +356,12 @@ swap_status_source(struct boot_loader_state *state)
 #endif
 
     image_index = BOOT_CURR_IMG(state);
-    rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_PRIMARY(image_index),
-            &state_primary_slot);
+    rc = boot_read_swap_state(state->imgs[image_index][BOOT_PRIMARY_SLOT].area,
+                              &state_primary_slot);
     assert(rc == 0);
 
 #if MCUBOOT_SWAP_USING_SCRATCH
-    rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_SCRATCH, &state_scratch);
+    rc = boot_read_swap_state(state->scratch.area, &state_scratch);
     assert(rc == 0);
 #endif
 
@@ -854,19 +854,15 @@ int app_max_size(struct boot_loader_state *state)
 #else
 int app_max_size(struct boot_loader_state *state)
 {
-    const struct flash_area *fap;
-    int fa_id;
-    int rc;
+    const struct flash_area *fap = NULL;
     uint32_t active_slot;
     int primary_sz, secondary_sz;
 
     active_slot = state->slot_usage[BOOT_CURR_IMG(state)].active_slot;
 
-    fa_id = flash_area_id_from_multi_image_slot(BOOT_CURR_IMG(state), active_slot);
-    rc = flash_area_open(fa_id, &fap);
-    assert(rc == 0);
+    fap = BOOT_IMG_AREA(state, active_slot);
+    assert(fap != NULL);
     primary_sz = flash_area_get_size(fap);
-    flash_area_close(fap);
 
     if (active_slot == BOOT_PRIMARY_SLOT) {
         active_slot = BOOT_SECONDARY_SLOT;
@@ -874,11 +870,9 @@ int app_max_size(struct boot_loader_state *state)
         active_slot = BOOT_PRIMARY_SLOT;
     }
 
-    fa_id = flash_area_id_from_multi_image_slot(BOOT_CURR_IMG(state), active_slot);
-    rc = flash_area_open(fa_id, &fap);
-    assert(rc == 0);
+    fap = BOOT_IMG_AREA(state, active_slot);
+    assert(fap != NULL);
     secondary_sz = flash_area_get_size(fap);
-    flash_area_close(fap);
 
     return (secondary_sz < primary_sz ? secondary_sz : primary_sz);
 }
@@ -894,7 +888,6 @@ boot_read_image_header(struct boot_loader_state *state, int slot,
     uint32_t swap_count;
     uint32_t swap_size;
 #endif
-    int area_id;
     int hdr_slot;
     int rc = 0;
 
@@ -913,7 +906,7 @@ boot_read_image_header(struct boot_loader_state *state, int slot,
      * other slot depending on the progress of the swap process.
      */
     if (bs && !boot_status_is_reset(bs)) {
-        rc = boot_find_status(BOOT_CURR_IMG(state), &fap);
+        fap = boot_find_status(state, BOOT_CURR_IMG(state));
 
         if (rc != 0) {
             rc = BOOT_EFLASH;
@@ -953,19 +946,16 @@ boot_read_image_header(struct boot_loader_state *state, int slot,
     }
 
     if (hdr_slot == BOOT_NUM_SLOTS) {
-        area_id = FLASH_AREA_IMAGE_SCRATCH;
+        fap = state->scratch.area;
     } else {
-        area_id = flash_area_id_from_multi_image_slot(BOOT_CURR_IMG(state), hdr_slot);
+        fap = BOOT_IMG_AREA(state, hdr_slot);
     }
 #else
-    area_id = flash_area_id_from_multi_image_slot(BOOT_CURR_IMG(state), hdr_slot);
+    fap = BOOT_IMG_AREA(state, hdr_slot);
 #endif
+    assert(fap != NULL);
 
-    rc = flash_area_open(area_id, &fap);
-    if (rc == 0) {
-        rc = flash_area_read(fap, 0, out_hdr, sizeof *out_hdr);
-        flash_area_close(fap);
-    }
+    rc = flash_area_read(fap, 0, out_hdr, sizeof *out_hdr);
 
     if (rc != 0) {
         rc = BOOT_EFLASH;


### PR DESCRIPTION
Reduce flash_area_open/flash_area_close calls by re-using pointers to flash_area objects stored in boot_loader_state, that should be populated by context_boot_go.