### PR TITLE
boot: bootutil: Fix last sector index computation for swap-offset

### DIFF
--- a/boot/bootutil/src/swap_offset.c
+++ b/boot/bootutil/src/swap_offset.c
@@ -68,10 +68,10 @@ uint32_t find_last_idx(struct boot_loader_state *state, uint32_t swap_size)
 
     while (1) {
         sz += sector_sz;
-        last_idx++;
         if (sz >= swap_size) {
             break;
         }
+        last_idx++;
     }
 
     return last_idx;


### PR DESCRIPTION
I'm currently trying to modify the simulator to test upgrades with the largest possible images for all possible upgrade strategies (currently this is not made for some strategies such as swap-offset). While playing with the simulator I noticed the swap-offset upgrade was failing if an image is large enough to use all the available sectors.

Let's consider this very simple scenario, with slots containing a single sector for the firmware image:
 ```
             PRIMARY                               SECONDARY
    +-----------------------+              +-----------------------+
    |        Firmware       |   Sector 0   |        (empty)        |
    +-----------------------+              +-----------------------+
    |        Trailer        |   Sector 1   |        Firmware       |
    +-----------------------+              +-----------------------+
                                Sector 2   |        Trailer        |
                                           +-----------------------+
```
Here, the swap-offset needs to swap a single sector and the index of the last sector of the primary slot to be swapped is `0`.

However, the `find_last_idx` is in fact returning `1`. And in the general case, it is returning the number of sectors to swap rather than the index of the last sector to swap.

In `swap_run`, this is causing the swap to be aborted because of a supposedly too large image if the image uses all the available sectors:
```C
        if (last_idx >= first_trailer_idx) {
            BOOT_LOG_WRN("Not enough free space to run swap upgrade");
            BOOT_LOG_WRN("required %d bytes but only %d are available",
                         (last_idx + 1) * sector_sz,
                         first_trailer_idx * sector_sz);
            bs->swap_type = BOOT_SWAP_TYPE_NONE;
            return;
        }
```