### PR TITLE
sim: Ensure the estimated TLV area size is always equal to the actual size

### DIFF
--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1827,9 +1827,8 @@ fn install_image(flash: &mut SimMultiFlash, slot: &SlotInfo, len: ImageSize,
 
             info!("slot: 0x{:x}, HDR: 0x{:x}, trailer: 0x{:x}",
                 slot_len, HDR_SIZE, trailer);
-            // the overflow size is rougly estimated to work for all
-            // configurations. It might be precise if tlv_len will be maked precise.
-            slot_len - HDR_SIZE - trailer - tlv_len - sector_offset + dev.align()*4
+
+            slot_len - HDR_SIZE - trailer - tlv_len - sector_offset + dev.align()
         }
 
     };

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1748,9 +1748,8 @@ fn image_largest_trailer(dev: &dyn Flash) -> usize {
             // Using the header size we know, the trailer size, and the slot size, we can compute
             // the largest image possible.
             let trailer = if Caps::OverwriteUpgrade.present() {
-                // This computation is incorrect, and we need to figure out the correct size.
-                // c::boot_status_sz(dev.align() as u32) as usize
-                16 + 4 * dev.align()
+                // magic + image-ok + copy-done + swap-info
+                c::boot_magic_sz() + 3 * c::boot_max_align()
             } else if Caps::SwapUsingOffset.present() || Caps::SwapUsingMove.present() {
                 let sector_size = dev.sector_iter().next().unwrap().size as u32;
                 align_up(c::boot_trailer_sz(dev.align() as u32), sector_size) as usize


### PR DESCRIPTION
To generate largest possible and oversized images, the simulator needs to determine first the maximum size of an image. When signing the images using ECDSA, the actual size of the generated image was not exactly always the desired size. Indeed, in that case, the size of the TLV area estimated during the computation of the maximum image size might not be always equal to the actual TLV area size. This is because the ECDSA signatures are encoded as ASN.1 and the size of the ASN.1 representation can vary depending on the value of the two integers the signature is composed of.

This was not a big deal but was adding a bit of randomness in the simulation and was for example making difficult to generate reliably an oversized image, possibly leading to occasional false failures of the tests using oversized images.

To avoid the issue, a very simple workaround is implemented: when using ECDSA, each image is signed repeatedly until a signature with the maximum size is obtained. This is possible without modifying the image because ECDSA signing is not a deterministic process and gives a completely different signature at each try. On average, four attempts should be required to get the desired signature size.