### PR TITLE
boot: zephyr: boards: Add frdm-mcxn236 configuration

### DIFF
--- a/boot/zephyr/boards/frdm_mcxn236.conf
+++ b/boot/zephyr/boards/frdm_mcxn236.conf
@@ -1,0 +1,5 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+#MCXN236 does not support the MCUBoot swap mode.
+CONFIG_BOOT_UPGRADE_ONLY=y


### PR DESCRIPTION
Adds default configuration for the frdm-mcxn236 board.