### PR TITLE
imgtool: dumpinfo avoid exit

### DIFF
--- a/scripts/imgtool/dumpinfo.py
+++ b/scripts/imgtool/dumpinfo.py
@@ -251,7 +251,7 @@ def dump_imginfo(imgfile, outfile=None, silent=False):
     ###############################################################################
 
     if silent:
-        sys.exit(0)
+        return
 
     print("Printing content of signed image:", os.path.basename(imgfile), "\n")
 

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -259,7 +259,8 @@ def verify(key, imgfile):
                     'of a signed image')
 def dumpinfo(imgfile, outfile, silent):
     dump_imginfo(imgfile, outfile, silent)
-    print("dumpinfo has run successfully")
+    if not silent:
+        print("dumpinfo has run successfully")
 
 
 def validate_version(ctx, param, value):


### PR DESCRIPTION
Hi,

I'm using `dump_imginfo` to export image info in a yaml file from another python source code. I don't want that this script stop when calling this function with `silent=True`.

Regards,

GG