### PR TITLE
Single app ram load fixes

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil_public.h
+++ b/boot/bootutil/include/bootutil/bootutil_public.h
@@ -319,11 +319,13 @@ boot_image_load_header(const struct flash_area *fa_p,
  *
  * @param[in]   state   boot loader state
  * @param[in]   hdr     image header
+ * @param[in]   fa      flash area pointer
  *
  * @return              0 on success, error code otherwise
  */
 int boot_load_image_from_flash_to_sram(struct boot_loader_state *state,
-                                       struct image_header *hdr);
+                                       struct image_header *hdr,
+                                       const struct flash_area *fa);
 
 /**
  * Removes an image from SRAM, by overwriting it with zeros.

--- a/boot/bootutil/src/ram_load.c
+++ b/boot/bootutil/src/ram_load.c
@@ -419,7 +419,8 @@ boot_remove_image_from_flash(struct boot_loader_state *state, uint32_t slot)
 }
 
 int boot_load_image_from_flash_to_sram(struct boot_loader_state *state,
-                                       struct image_header *hdr)
+                                       struct image_header *hdr,
+                                       const struct flash_area *fap)
 {
     int active_slot;
 
@@ -428,6 +429,7 @@ int boot_load_image_from_flash_to_sram(struct boot_loader_state *state,
      */
     active_slot = state->slot_usage[BOOT_CURR_IMG(state)].active_slot;
     BOOT_IMG(state, active_slot).hdr = *hdr;
+    BOOT_IMG_AREA(state, active_slot) = fap;
 
     return boot_load_image_to_sram(state);
 }

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -154,7 +154,7 @@ static void do_boot(struct boot_rsp *rsp)
      * consecutively. Manually set the stack pointer and jump into the
      * reset vector
      */
-#ifdef CONFIG_BOOT_RAM_LOAD
+#ifdef MCUBOOT_RAM_LOAD
     /* Get ram address for image */
     vt = (struct arm_vector_table *)(rsp->br_hdr->ih_load_addr + rsp->br_hdr->ih_hdr_size);
 #else
@@ -576,7 +576,7 @@ int main(void)
         FIH_PANIC;
     }
 
-#ifdef CONFIG_BOOT_RAM_LOAD
+#ifdef MCUBOOT_RAM_LOAD
     BOOT_LOG_INF("Bootloader chainload address offset: 0x%x",
                  rsp.br_hdr->ih_load_addr);
 #else

--- a/boot/zephyr/single_loader.c
+++ b/boot/zephyr/single_loader.c
@@ -121,6 +121,7 @@ boot_go(struct boot_rsp *rsp)
 
 #ifdef MCUBOOT_RAM_LOAD
         static struct boot_loader_state state;
+        BOOT_IMG_AREA(&state, 0) = _fa_p;
         state.imgs[0][0].hdr = _hdr;
 
         rc = boot_load_image_to_sram(&state);

--- a/samples/runtime-source/zephyr/hooks/hooks.c
+++ b/samples/runtime-source/zephyr/hooks/hooks.c
@@ -72,7 +72,7 @@ fih_ret boot_go_hook(struct boot_rsp *rsp)
 #ifdef MCUBOOT_RAM_LOAD
 		state = boot_get_loader_state();
 
-		rc = boot_load_image_from_flash_to_sram(state, &_hdr);
+		rc = boot_load_image_from_flash_to_sram(state, &_hdr, _fa_p);
 		if (rc != 0) {
 			flash_area_close(_fa_p);
 			continue;


### PR DESCRIPTION
Two fixes, basically:

 - Fix RAM load code and sample that become broken since 1b2fc096d9a683a7481b13749d01ca8fa78e7afd;
 - Use right define for RAM loading on boot/zephyr.