### PR TITLE
zephyr: flash map: fix comparison signedness

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -178,7 +178,7 @@ int flash_area_get_sector(const struct flash_area *fap, off_t off,
     struct flash_pages_info fpi;
     int rc;
 
-    if (off >= fap->fa_size) {
+    if (off < 0 || (size_t) off >= fap->fa_size) {
         return -ERANGE;
     }
 


### PR DESCRIPTION
This resolves a warning when building with `-Wsign-compare`.

`struct flash_area.fa_size` is declared as `size_t` in the Zephyr source tree ([in `include/zephyr/storage/flash_map.h`](https://github.com/zephyrproject-rtos/zephyr/blob/v4.1.0/include/zephyr/storage/flash_map.h#L48-L68)).