### PR TITLE
boot: zephyr: add support for mcx_n9xx_evk

### DIFF
--- a/boot/zephyr/boards/mcx_n9xx_evk_mcxn947_cpu0.conf
+++ b/boot/zephyr/boards/mcx_n9xx_evk_mcxn947_cpu0.conf
@@ -1,0 +1,5 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+#MCXN94x does not support the MCUBoot swap mode.
+CONFIG_BOOT_UPGRADE_ONLY=y

--- a/boot/zephyr/boards/mcx_n9xx_evk_mcxn947_cpu0_qspi.conf
+++ b/boot/zephyr/boards/mcx_n9xx_evk_mcxn947_cpu0_qspi.conf
@@ -1,0 +1,4 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BOOT_UPGRADE_ONLY=y

--- a/boot/zephyr/boards/mcx_n9xx_evk_mcxn947_cpu0_qspi.overlay
+++ b/boot/zephyr/boards/mcx_n9xx_evk_mcxn947_cpu0_qspi.overlay
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+        chosen {
+                zephyr,flash = &flash;
+                zephyr,code-partition = &boot_partition;
+        };
+};


### PR DESCRIPTION
Add default configuration for mcx_n9xx_evk.