### PR TITLE
boot: bootutil: swap-move: Allow trailer area not be a multiple of the sector size

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -477,7 +477,14 @@ uint32_t bootutil_max_image_size(struct boot_loader_state *state, const struct f
     }
 
     return slot_trailer_off - trailer_padding;
-#elif defined(MCUBOOT_SWAP_USING_MOVE) || defined(MCUBOOT_SWAP_USING_OFFSET)
+#elif defined(MCUBOOT_SWAP_USING_MOVE)
+    (void) fap;
+
+    const struct flash_area *fap_pri = BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT);
+    assert(fap_pri != NULL);
+
+    return boot_status_off(fap_pri) - boot_img_sector_size(state, BOOT_PRIMARY_SLOT, 0);
+#elif defined(MCUBOOT_SWAP_USING_OFFSET)
     (void) state;
 
     struct flash_sector sector;

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -365,19 +365,18 @@ int boot_read_enc_key(const struct flash_area *fap, uint8_t slot,
                       struct boot_status *bs);
 #endif
 
-#ifdef MCUBOOT_SWAP_USING_SCRATCH
+#if defined(MCUBOOT_SWAP_USING_SCRATCH) || defined(MCUBOOT_SWAP_USING_MOVE)
 /**
  * Finds the first sector of a given slot that holds image trailer data.
  *
  * @param state      Current bootloader's state.
  * @param slot       The index of the slot to consider.
- * @param trailer_sz The size of the trailer, in bytes.
  *
  * @return The index of the first sector of the slot that holds image trailer data.
  */
 size_t
-boot_get_first_trailer_sector(struct boot_loader_state *state, size_t slot, size_t trailer_sz);
-#endif
+boot_get_first_trailer_sector(struct boot_loader_state *state, size_t slot);
+#endif /* MCUBOOT_SWAP_USING_SCRATCH || MCUBOOT_SWAP_USING_MOVE */
 
 /**
  * Checks that a buffer is erased according to what the erase value for the

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -84,9 +84,9 @@ struct boot_swap_table {
     uint8_t image_ok_primary_slot;
     uint8_t image_ok_secondary_slot;
     uint8_t copy_done_primary_slot;
-#if defined(MCUBOOT_SWAP_USING_OFFSET)
+#if defined(MCUBOOT_SWAP_USING_OFFSET) || defined(MCUBOOT_SWAP_USING_MOVE)
     uint8_t copy_done_secondary_slot;
-#endif
+#endif /* MCUBOOT_SWAP_USING_OFFSET || MCUBOOT_SWAP_USING_MOVE */
 
     uint8_t swap_type;
 };
@@ -103,9 +103,9 @@ struct boot_swap_table {
  * the bootloader, as in starting/finishing a swap operation.
  */
 static const struct boot_swap_table boot_swap_tables[] = {
-#if defined(MCUBOOT_SWAP_USING_OFFSET)
+#if defined(MCUBOOT_SWAP_USING_OFFSET) || defined(MCUBOOT_SWAP_USING_MOVE)
     {
-        .magic_primary_slot =       BOOT_MAGIC_ANY,
+        .magic_primary_slot =       BOOT_MAGIC_NOTGOOD,
         .magic_secondary_slot =     BOOT_MAGIC_GOOD,
         .image_ok_primary_slot =    BOOT_FLAG_ANY,
         .image_ok_secondary_slot =  BOOT_FLAG_UNSET,
@@ -113,16 +113,25 @@ static const struct boot_swap_table boot_swap_tables[] = {
         .copy_done_secondary_slot = BOOT_FLAG_SET,
         .swap_type =                BOOT_SWAP_TYPE_REVERT,
     },
-#endif
+    {
+        .magic_primary_slot =       BOOT_MAGIC_GOOD,
+        .magic_secondary_slot =     BOOT_MAGIC_GOOD,
+        .image_ok_primary_slot =    BOOT_FLAG_UNSET,
+        .image_ok_secondary_slot =  BOOT_FLAG_UNSET,
+        .copy_done_primary_slot =   BOOT_FLAG_ANY,
+        .copy_done_secondary_slot = BOOT_FLAG_SET,
+        .swap_type =                BOOT_SWAP_TYPE_REVERT,
+    },
+#endif /* MCUBOOT_SWAP_USING_OFFSET || MCUBOOT_SWAP_USING_MOVE */
     {
         .magic_primary_slot =       BOOT_MAGIC_ANY,
         .magic_secondary_slot =     BOOT_MAGIC_GOOD,
         .image_ok_primary_slot =    BOOT_FLAG_ANY,
         .image_ok_secondary_slot =  BOOT_FLAG_UNSET,
         .copy_done_primary_slot =   BOOT_FLAG_ANY,
-#if defined(MCUBOOT_SWAP_USING_OFFSET)
-        .copy_done_secondary_slot = BOOT_FLAG_ANY,
-#endif
+#if defined(MCUBOOT_SWAP_USING_OFFSET) || defined(MCUBOOT_SWAP_USING_MOVE)
+        .copy_done_secondary_slot = BOOT_FLAG_UNSET,
+#endif /* MCUBOOT_SWAP_USING_OFFSET || MCUBOOT_SWAP_USING_MOVE */
         .swap_type =                BOOT_SWAP_TYPE_TEST,
     },
     {
@@ -131,9 +140,9 @@ static const struct boot_swap_table boot_swap_tables[] = {
         .image_ok_primary_slot =    BOOT_FLAG_ANY,
         .image_ok_secondary_slot =  BOOT_FLAG_SET,
         .copy_done_primary_slot =   BOOT_FLAG_ANY,
-#if defined(MCUBOOT_SWAP_USING_OFFSET)
-        .copy_done_secondary_slot = BOOT_FLAG_ANY,
-#endif
+#if defined(MCUBOOT_SWAP_USING_OFFSET) || defined(MCUBOOT_SWAP_USING_MOVE)
+        .copy_done_secondary_slot = BOOT_FLAG_UNSET,
+#endif /* MCUBOOT_SWAP_USING_OFFSET || MCUBOOT_SWAP_USING_MOVE */
         .swap_type =                BOOT_SWAP_TYPE_PERM,
     },
     {
@@ -142,9 +151,9 @@ static const struct boot_swap_table boot_swap_tables[] = {
         .image_ok_primary_slot =    BOOT_FLAG_UNSET,
         .image_ok_secondary_slot =  BOOT_FLAG_ANY,
         .copy_done_primary_slot =   BOOT_FLAG_SET,
-#if defined(MCUBOOT_SWAP_USING_OFFSET)
+#if defined(MCUBOOT_SWAP_USING_OFFSET) || defined(MCUBOOT_SWAP_USING_MOVE)
         .copy_done_secondary_slot = BOOT_FLAG_ANY,
-#endif
+#endif /* MCUBOOT_SWAP_USING_OFFSET || MCUBOOT_SWAP_USING_MOVE */
         .swap_type =                BOOT_SWAP_TYPE_REVERT,
     },
 };
@@ -463,10 +472,10 @@ boot_swap_type_multi(int image_index)
                 table->image_ok_secondary_slot == secondary_slot.image_ok) &&
             (table->copy_done_primary_slot == BOOT_FLAG_ANY  ||
                 table->copy_done_primary_slot == primary_slot.copy_done)
-#if defined(MCUBOOT_SWAP_USING_OFFSET)
+#if defined(MCUBOOT_SWAP_USING_OFFSET) || defined(MCUBOOT_SWAP_USING_MOVE)
             && (table->copy_done_secondary_slot == BOOT_FLAG_ANY  ||
                 table->copy_done_secondary_slot == secondary_slot.copy_done)
-#endif
+#endif /* MCUBOOT_SWAP_USING_OFFSET || MCUBOOT_SWAP_USING_MOVE */
             ) {
             BOOT_LOG_INF("Image index: %d, Swap type: %s", image_index,
                          table->swap_type == BOOT_SWAP_TYPE_TEST   ? "test"   :

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -360,9 +360,14 @@ swap_status_source(struct boot_loader_state *state)
     BOOT_LOG_SWAP_STATE("Secondary image", &state_secondary_slot);
 
     if (state_primary_slot.magic == BOOT_MAGIC_GOOD &&
-            state_primary_slot.copy_done == BOOT_FLAG_UNSET &&
-            state_secondary_slot.magic != BOOT_MAGIC_GOOD) {
-
+            state_primary_slot.copy_done == BOOT_FLAG_UNSET) {
+        /* In this case, either:
+         *   - A swap operation was interrupted and can be resumed from the status stored in the
+         *     primary slot's trailer.
+         *   - No swap was ever made and the initial firmware image has been written with a MCUboot
+         *     trailer. In this case, the status in the primary slot's trailer is empty and there is
+         *     no harm in loading it.
+         */
         source = BOOT_STATUS_SOURCE_PRIMARY_SLOT;
 
         BOOT_LOG_INF("Boot source: primary slot");
@@ -378,8 +383,7 @@ swap_status_source(struct boot_loader_state *state)
  */
 static void
 boot_move_sector_up(size_t idx, uint32_t sz, struct boot_loader_state *state,
-        struct boot_status *bs, const struct flash_area *fap_pri,
-        const struct flash_area *fap_sec)
+        struct boot_status *bs, const struct flash_area *fap_pri)
 {
     uint32_t new_off;
     uint32_t old_off;
@@ -423,12 +427,6 @@ boot_move_sector_up(size_t idx, uint32_t sz, struct boot_loader_state *state,
             copy_sz = bs->swap_size % sz;
             sector_erased_with_trailer = true;
         }
-
-        /* Remove status from secondary slot trailer, in case of device with
-	 * erase requirement this will also prepare traier for write.
-	 */
-        rc = swap_scramble_trailer_sectors(state, fap_sec);
-        assert(rc == 0);
     }
 
     if (!sector_erased_with_trailer) {
@@ -446,7 +444,7 @@ boot_move_sector_up(size_t idx, uint32_t sz, struct boot_loader_state *state,
 }
 
 static void
-boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
+boot_swap_sectors(size_t idx, size_t last_idx, uint32_t sz, struct boot_loader_state *state,
         struct boot_status *bs, const struct flash_area *fap_pri,
         const struct flash_area *fap_sec)
 {
@@ -472,10 +470,43 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
     }
 
     if (bs->state == BOOT_STATUS_STATE_1) {
-        rc = boot_erase_region(fap_sec, sec_off, sz);
-        assert(rc == 0);
+        bool sector_erased_with_trailer = false;
+        uint32_t copy_sz = sz;
 
-        rc = boot_copy_region(state, fap_pri, fap_sec, pri_up_off, sec_off, sz);
+        if (idx == last_idx) {
+            rc = swap_scramble_trailer_sectors(state, fap_sec);
+            assert(rc == 0);
+
+            size_t first_trailer_sector_pri =
+                boot_get_first_trailer_sector(state, BOOT_PRIMARY_SLOT);
+            size_t first_trailer_sector_sec =
+                boot_get_first_trailer_sector(state, BOOT_SECONDARY_SLOT);
+
+            if (first_trailer_sector_sec == idx - 1) {
+                /* The destination sector was containing part of the trailer and has therefore
+                 * already been erased.
+                 */
+                sector_erased_with_trailer = true;
+            }
+
+            if (first_trailer_sector_pri == idx) {
+                /* The source sector contains both firmware and trailer data, so only the firmware
+                 * data must be copied to the destination sector.
+                 *
+                 * Swap-move => constant sector size, so 'sz' is the size of a sector and 'swap_size
+                 * % sz' gives the number of bytes used by the largest firmware image in the last
+                 * sector to be moved.
+                 */
+                copy_sz = bs->swap_size % sz;
+            }
+        }
+
+        if (!sector_erased_with_trailer) {
+            rc = boot_erase_region(fap_sec, sec_off, sz);
+            assert(rc == 0);
+        }
+
+        rc = boot_copy_region(state, fap_pri, fap_sec, pri_up_off, sec_off, copy_sz);
         assert(rc == 0);
 
         rc = boot_write_status(state, bs);
@@ -590,7 +621,7 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
         idx = last_idx;
         while (idx > 0) {
             if (idx <= (last_idx - bs->idx + 1)) {
-                boot_move_sector_up(idx, sector_sz, state, bs, fap_pri, fap_sec);
+                boot_move_sector_up(idx, sector_sz, state, bs, fap_pri);
             }
             idx--;
         }
@@ -602,7 +633,7 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
     idx = 1;
     while (idx <= last_idx) {
         if (idx >= bs->idx) {
-            boot_swap_sectors(idx, sector_sz, state, bs, fap_pri, fap_sec);
+            boot_swap_sectors(idx, last_idx, sector_sz, state, bs, fap_pri, fap_sec);
         }
         idx++;
     }

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -377,13 +377,15 @@ swap_status_source(struct boot_loader_state *state)
  * "Moves" the sector located at idx - 1 to idx.
  */
 static void
-boot_move_sector_up(int idx, uint32_t sz, struct boot_loader_state *state,
+boot_move_sector_up(size_t idx, uint32_t sz, struct boot_loader_state *state,
         struct boot_status *bs, const struct flash_area *fap_pri,
         const struct flash_area *fap_sec)
 {
     uint32_t new_off;
     uint32_t old_off;
+    uint32_t copy_sz;
     int rc;
+    bool sector_erased_with_trailer;
 
     /*
      * FIXME: assuming sectors of size == sz, a single off variable
@@ -394,14 +396,32 @@ boot_move_sector_up(int idx, uint32_t sz, struct boot_loader_state *state,
     new_off = boot_img_sector_off(state, BOOT_PRIMARY_SLOT, idx);
     old_off = boot_img_sector_off(state, BOOT_PRIMARY_SLOT, idx - 1);
 
-    if (bs->idx == BOOT_STATUS_IDX_0) {
-        if (bs->source != BOOT_STATUS_SOURCE_PRIMARY_SLOT) {
-            /* Remove data and prepare for write on devices requiring erase */
-            rc = swap_scramble_trailer_sectors(state, fap_pri);
-            assert(rc == 0);
+    copy_sz = sz;
+    sector_erased_with_trailer = false;
 
-            rc = swap_status_init(state, fap_pri, bs);
-            assert(rc == 0);
+    if (bs->idx == BOOT_STATUS_IDX_0) {
+        rc = swap_scramble_trailer_sectors(state, fap_pri);
+        assert(rc == 0);
+
+        rc = swap_status_init(state, fap_pri, bs);
+        assert(rc == 0);
+
+        /* The first sector to be moved is the last sector containing part of the firmware image. If
+         * the trailer size is not a multiple of the sector size, the destination sector will
+         * contain both firmware and trailer data. In that case:
+         *   - Only the firmware data must be copied to the destination sector to avoid overwriting
+         *     the trailer data.
+         *   - The destination sector has already been erased with the trailer.
+         */
+        size_t first_trailer_idx = boot_get_first_trailer_sector(state, BOOT_PRIMARY_SLOT);
+
+        if (idx == first_trailer_idx) {
+            /* Swap-move => constant sector size, so 'sz' is the size of a sector and 'swap_size %
+             * sz' gives the number of bytes used by the largest firmware image in the last sector
+             * to be moved.
+             */
+            copy_sz = bs->swap_size % sz;
+            sector_erased_with_trailer = true;
         }
 
         /* Remove status from secondary slot trailer, in case of device with
@@ -411,10 +431,12 @@ boot_move_sector_up(int idx, uint32_t sz, struct boot_loader_state *state,
         assert(rc == 0);
     }
 
-    rc = boot_erase_region(fap_pri, new_off, sz);
-    assert(rc == 0);
+    if (!sector_erased_with_trailer) {
+        rc = boot_erase_region(fap_pri, new_off, sz);
+        assert(rc == 0);
+    }
 
-    rc = boot_copy_region(state, fap_pri, fap_pri, old_off, new_off, sz);
+    rc = boot_copy_region(state, fap_pri, fap_pri, old_off, new_off, copy_sz);
     assert(rc == 0);
 
     rc = boot_write_status(state, bs);

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -546,11 +546,8 @@ void
 swap_run(struct boot_loader_state *state, struct boot_status *bs,
          uint32_t copy_size)
 {
-    uint32_t sz;
     uint32_t sector_sz;
     uint32_t idx;
-    uint32_t trailer_sz;
-    uint32_t first_trailer_idx;
     uint32_t last_idx;
     const struct flash_area *fap_pri;
     const struct flash_area *fap_sec;
@@ -559,32 +556,6 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
 
     last_idx = find_last_idx(state, copy_size);
     sector_sz = boot_img_sector_size(state, BOOT_PRIMARY_SLOT, 0);
-
-    /*
-     * When starting a new swap upgrade, check that there is enough space.
-     */
-    if (boot_status_is_reset(bs)) {
-        sz = 0;
-        trailer_sz = boot_trailer_sz(BOOT_WRITE_SZ(state));
-        first_trailer_idx = boot_img_num_sectors(state, BOOT_PRIMARY_SLOT) - 1;
-
-        while (1) {
-            sz += sector_sz;
-            if  (sz >= trailer_sz) {
-                break;
-            }
-            first_trailer_idx--;
-        }
-
-        if (last_idx >= first_trailer_idx) {
-            BOOT_LOG_WRN("Not enough free space to run swap upgrade");
-            BOOT_LOG_WRN("required %d bytes but only %d are available",
-                         (last_idx + 1) * sector_sz,
-                         first_trailer_idx * sector_sz);
-            bs->swap_type = BOOT_SWAP_TYPE_NONE;
-            return;
-        }
-    }
 
     fap_pri = BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT);
     assert(fap_pri != NULL);

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -477,6 +477,32 @@ boot_swap_sectors(size_t idx, size_t last_idx, uint32_t sz, struct boot_loader_s
             rc = swap_scramble_trailer_sectors(state, fap_sec);
             assert(rc == 0);
 
+            /* When starting a revert the swap status of the primary slot is erased then
+             * re-initialized. If a reset occurs after the erasure but before the re-initialization
+             * is complete, there has to be, somewhere, a flag indicating a revert is in progress.
+             * Otherwise, the bootloader wouldn't be able to resume the revert operation.
+             *
+             * Initially, the swap-move algorithm was assuming the trailers were stored in dedicated
+             * sectors and it was therefore possible to rewrite the secondary trailer before
+             * starting the revert process, to make the revert look like a permanent upgrade in case
+             * an unfortunate reset occurs during the rewriting of the primary trailer.
+             *
+             * However, considering now the first trailer sector could also hold firmware data, this
+             * trick is no more possible since it could potentially erase part of the firmware image
+             * to be restored. A solution is to rewrite here the secondary trailer with the
+             * 'copy_done' flag set, meaning after an upgrade the secondary trailer is no more
+             * erased. The bootloader will consider a revert must be started or resumed if the
+             * primary image is not confirmed and the 'copy_done' flag is set in the secondary
+             * trailer.
+             */
+            if (bs->swap_type != BOOT_SWAP_TYPE_REVERT) {
+                rc = boot_write_copy_done(fap_sec);
+                assert(rc == 0);
+
+                rc = boot_write_magic(fap_sec);
+                assert(rc == 0);
+            }
+
             size_t first_trailer_sector_pri =
                 boot_get_first_trailer_sector(state, BOOT_PRIMARY_SLOT);
             size_t first_trailer_sector_sec =
@@ -513,55 +539,6 @@ boot_swap_sectors(size_t idx, size_t last_idx, uint32_t sz, struct boot_loader_s
         bs->idx++;
         bs->state = BOOT_STATUS_STATE_0;
         BOOT_STATUS_ASSERT(rc == 0);
-    }
-}
-
-/*
- * When starting a revert the swap status exists in the primary slot, and
- * the status in the secondary slot is erased. To start the swap, the status
- * area in the primary slot must be re-initialized; if during the small
- * window of time between re-initializing it and writing the first metadata
- * a reset happens, the swap process is broken and cannot be resumed.
- *
- * This function handles the issue by making the revert look like a permanent
- * upgrade (by initializing the secondary slot).
- */
-void
-fixup_revert(const struct boot_loader_state *state, struct boot_status *bs,
-        const struct flash_area *fap_sec)
-{
-    struct boot_swap_state swap_state;
-    int rc;
-
-#if (BOOT_IMAGE_NUMBER == 1)
-    (void)state;
-#endif
-
-    /* No fixup required */
-    if (bs->swap_type != BOOT_SWAP_TYPE_REVERT ||
-        bs->op != BOOT_STATUS_OP_MOVE ||
-        bs->idx != BOOT_STATUS_IDX_0) {
-        return;
-    }
-
-    rc = boot_read_swap_state(fap_sec, &swap_state);
-    assert(rc == 0);
-
-    BOOT_LOG_SWAP_STATE("Secondary image", &swap_state);
-
-    if (swap_state.magic == BOOT_MAGIC_UNSET) {
-        /* Remove trailer and prepare area for write on devices requiring erase */
-        rc = swap_scramble_trailer_sectors(state, fap_sec);
-        assert(rc == 0);
-
-        rc = boot_write_image_ok(fap_sec);
-        assert(rc == 0);
-
-        rc = boot_write_swap_size(fap_sec, bs->swap_size);
-        assert(rc == 0);
-
-        rc = boot_write_magic(fap_sec);
-        assert(rc == 0);
     }
 }
 
@@ -614,8 +591,6 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
 
     fap_sec = BOOT_IMG_AREA(state, BOOT_SECONDARY_SLOT);
     assert(fap_sec != NULL);
-
-    fixup_revert(state, bs, fap_sec);
 
     if (bs->op == BOOT_STATUS_OP_MOVE) {
         idx = last_idx;

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -592,8 +592,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
      * NOTE: `use_scratch` is a temporary flag (never written to flash) which
      * controls if special handling is needed (swapping the first trailer sector).
      */
-    first_trailer_sector_primary =
-        boot_get_first_trailer_sector(state, BOOT_PRIMARY_SLOT, trailer_sz);
+    first_trailer_sector_primary = boot_get_first_trailer_sector(state, BOOT_PRIMARY_SLOT);
 
     /* Check if the currently swapped sector(s) contain the trailer or part of it */
     if ((img_off + sz) >
@@ -673,7 +672,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
                  * sector(s) containing the beginning of the trailer won't be erased again.
                  */
                 size_t trailer_sector_secondary =
-                    boot_get_first_trailer_sector(state, BOOT_SECONDARY_SLOT, trailer_sz);
+                    boot_get_first_trailer_sector(state, BOOT_SECONDARY_SLOT);
 
                 uint32_t trailer_sector_offset =
                     boot_img_sector_off(state, BOOT_SECONDARY_SLOT, trailer_sector_secondary);

--- a/docs/design.md
+++ b/docs/design.md
@@ -672,39 +672,49 @@ types described above via a set of tables.  These tables are reproduced below.
 ---
 
 ```
-    State I (swap using offset only)
+    State I (swap using offset and swap using move only)
                      | primary slot | secondary slot |
     -----------------+--------------+----------------|
-               magic | Any          | Good           |
+               magic | Not good     | Good           |
             image-ok | Any          | Unset          |
            copy-done | Any          | Set            |
     -----------------+--------------+----------------'
      result: BOOT_SWAP_TYPE_REVERT                   |
     -------------------------------------------------'
 
-    State II
+    State II (swap using offset and swap using move only)
                      | primary slot | secondary slot |
     -----------------+--------------+----------------|
-               magic | Any          | Good           |
-            image-ok | Any          | Unset          |
-           copy-done | Any          | Any            |
+               magic | Good         | Good           |
+            image-ok | Unset        | Unset          |
+           copy-done | Any          | Set            |
     -----------------+--------------+----------------'
-     result: BOOT_SWAP_TYPE_TEST                     |
+     result: BOOT_SWAP_TYPE_REVERT                   |
     -------------------------------------------------'
-
 
     State III
                      | primary slot | secondary slot |
     -----------------+--------------+----------------|
                magic | Any          | Good           |
+            image-ok | Any          | Unset          |
+           copy-done | Any          | Unset          |
+    -----------------+--------------+----------------'
+     result: BOOT_SWAP_TYPE_TEST                     |
+    -------------------------------------------------'
+
+
+    State IV
+                     | primary slot | secondary slot |
+    -----------------+--------------+----------------|
+               magic | Any          | Good           |
             image-ok | Any          | 0x01           |
-           copy-done | Any          | Any            |
+           copy-done | Any          | Unset          |
     -----------------+--------------+----------------'
      result: BOOT_SWAP_TYPE_PERM                     |
     -------------------------------------------------'
 
 
-    State IV
+    State V
                      | primary slot | secondary slot |
     -----------------+--------------+----------------|
                magic | Good         | Any            |
@@ -715,13 +725,13 @@ types described above via a set of tables.  These tables are reproduced below.
     -------------------------------------------------'
 ```
 
-Any of the above three states results in MCUboot attempting to swap images.
+Any of the above five states results in MCUboot attempting to swap images.
 
 Otherwise, MCUboot does not attempt to swap images, resulting in one of the
-other three swap types, as illustrated by State IV.
+other three swap types, as illustrated by State VI.
 
 ```
-    State V
+    State VI
                      | primary slot | secondary slot |
     -----------------+--------------+----------------|
                magic | Any          | Any            |
@@ -734,7 +744,7 @@ other three swap types, as illustrated by State IV.
     -------------------------------------------------'
 ```
 
-In State V, when no errors occur, MCUboot will attempt to boot the contents of
+In State VI, when no errors occur, MCUboot will attempt to boot the contents of
 the primary slot directly, and the result is `BOOT_SWAP_TYPE_NONE`. If the image
 in the primary slot is not valid, the result is `BOOT_SWAP_TYPE_FAIL`. If a
 fatal error occurs during boot, the result is `BOOT_SWAP_TYPE_PANIC`. If the
@@ -746,7 +756,7 @@ rather than booting an invalid or compromised image.
 
 *An important caveat to the above is the result when a swap is requested*
 *and the image in the secondary slot fails to validate, due to a hashing or*
-*signing error. This state behaves as State IV with the extra action of*
+*signing error. This state behaves as State VI with the extra action of*
 *marking the image in the primary slot as "OK", to prevent further attempts*
 *to swap.*
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -296,7 +296,6 @@ This algorithm is designed so that the higher sector of the primary slot is
 used only for allowing sectors to move up. Therefore the most
 memory-size-effective slot layout is when the primary slot is larger than
 the secondary slot by exactly one sector plus the size of the swap status area,
-rounded up to the total size of the sectors it occupies,
 although same-sized slots are allowed as well.
 The algorithm is limited to support sectors of the same
 sector layout. All slot's sectors should be of the same size.
@@ -304,15 +303,12 @@ sector layout. All slot's sectors should be of the same size.
 When using this algorithm the maximum image size available for the application
 will be:
 ```
-maximum-image-size = (N-1) * slot-sector-size - image-trailer-sectors-size
+maximum-image-size = (N-1) * slot-sector-size - image-trailer-size
 ```
 
 Where:
   `N` is the number of sectors in the primary slot.
-  `image-trailer-sectors-size` is the size of the image trailer rounded up to
-  the total size of sectors its occupied. For instance if the image-trailer-size
-  is equal to 1056 B and the sector size is equal to 1024 B, then
-  `image-trailer-sectors-size` will be equal to 2048 B.
+  `image-trailer-size` is the size of the image trailer.
 
 The algorithm does two erase cycles on the primary slot and one on the secondary
 slot during each swap. Assuming that receiving a new image by the DFU

--- a/docs/release-notes.d/swap-move-unaligned-trailers.md
+++ b/docs/release-notes.d/swap-move-unaligned-trailers.md
@@ -1,0 +1,3 @@
+- The swap-move strategy no more requires using dedicated sectors for the
+  trailer. Any byte not allocated to the trailer in the first sector holding
+  trailer data can now be used by the firmware image.

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1807,9 +1807,11 @@ fn image_largest_trailer(dev: &dyn Flash, areadesc: &AreaDesc, slot: &SlotInfo) 
             let trailer = if Caps::OverwriteUpgrade.present() {
                 // magic + image-ok + copy-done + swap-info
                 c::boot_magic_sz() + 3 * c::boot_max_align()
-            } else if Caps::SwapUsingOffset.present() || Caps::SwapUsingMove.present() {
+            } else if Caps::SwapUsingOffset.present() {
                 let sector_size = dev.sector_iter().next().unwrap().size as u32;
                 align_up(c::boot_trailer_sz(dev.align() as u32), sector_size) as usize
+            } else if Caps::SwapUsingMove.present() {
+                c::boot_trailer_sz(dev.align() as u32) as usize
             } else if Caps::SwapUsingScratch.present() {
                 estimate_swap_scratch_trailer_size(dev, areadesc, slot)
             } else {

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -234,21 +234,21 @@ impl ImagesBuilder {
 
             let (primaries,upgrades) =  if img_manipulation == ImageManipulation::CorruptHigherVersionImage && !higher_version_corrupted {
                 higher_version_corrupted = true;
-               let prim =  install_image(&mut flash, &self.areadesc, &slots[0],
-                    maximal(42784), &ram, &*dep, ImageManipulation::None, Some(0), false);
+                let prim =  install_image(&mut flash, &self.areadesc, &slots, 0,
+                    maximal(42784), &ram, &*dep, ImageManipulation::None, Some(0));
                 let upgr   = match deps.depends[image_num] {
                     DepType::NoUpgrade => install_no_image(),
-                    _ => install_image(&mut flash, &self.areadesc, &slots[1],
-                        maximal(46928), &ram, &*dep, ImageManipulation::BadSignature, Some(0), true)
+                    _ => install_image(&mut flash, &self.areadesc, &slots, 1,
+                        maximal(46928), &ram, &*dep, ImageManipulation::BadSignature, Some(0))
                 };
                 (prim, upgr)
             } else {
-                let prim = install_image(&mut flash, &self.areadesc, &slots[0],
-                    maximal(42784), &ram, &*dep, img_manipulation, Some(0), false);
+                let prim = install_image(&mut flash, &self.areadesc, &slots, 0,
+                    maximal(42784), &ram, &*dep, img_manipulation, Some(0));
                 let upgr = match deps.depends[image_num] {
                         DepType::NoUpgrade => install_no_image(),
-                        _ => install_image(&mut flash, &self.areadesc, &slots[1],
-                            maximal(46928), &ram, &*dep, img_manipulation, Some(0), true)
+                        _ => install_image(&mut flash, &self.areadesc, &slots, 1,
+                            maximal(46928), &ram, &*dep, img_manipulation, Some(0))
                     };
                 (prim, upgr)
             };
@@ -298,10 +298,10 @@ impl ImagesBuilder {
         let ram = self.ram.clone(); // TODO: Avoid this clone.
         let images = self.slots.into_iter().enumerate().map(|(image_num, slots)| {
             let dep = BoringDep::new(image_num, &NO_DEPS);
-            let primaries = install_image(&mut bad_flash, &self.areadesc, &slots[0],
-                maximal(32784), &ram, &dep, ImageManipulation::None, Some(0), false);
-            let upgrades = install_image(&mut bad_flash, &self.areadesc, &slots[1],
-                maximal(41928), &ram, &dep, ImageManipulation::BadSignature, Some(0), true);
+            let primaries = install_image(&mut bad_flash, &self.areadesc, &slots, 0,
+                maximal(32784), &ram, &dep, ImageManipulation::None, Some(0));
+            let upgrades = install_image(&mut bad_flash, &self.areadesc, &slots, 1,
+                maximal(41928), &ram, &dep, ImageManipulation::BadSignature, Some(0));
             OneImage {
                 slots,
                 primaries,
@@ -321,10 +321,10 @@ impl ImagesBuilder {
         let ram = self.ram.clone(); // TODO: Avoid this clone.
         let images = self.slots.into_iter().enumerate().map(|(image_num, slots)| {
             let dep = BoringDep::new(image_num, &NO_DEPS);
-            let primaries = install_image(&mut bad_flash, &self.areadesc, &slots[0],
-                maximal(32784), &ram, &dep, ImageManipulation::None, Some(0), false);
-            let upgrades = install_image(&mut bad_flash, &self.areadesc, &slots[1],
-                ImageSize::Oversized, &ram, &dep, ImageManipulation::None, Some(0), true);
+            let primaries = install_image(&mut bad_flash, &self.areadesc, &slots, 0,
+                maximal(32784), &ram, &dep, ImageManipulation::None, Some(0));
+            let upgrades = install_image(&mut bad_flash, &self.areadesc, &slots, 1,
+                ImageSize::Oversized, &ram, &dep, ImageManipulation::None, Some(0));
             OneImage {
                 slots,
                 primaries,
@@ -344,8 +344,8 @@ impl ImagesBuilder {
         let ram = self.ram.clone(); // TODO: Avoid this clone.
         let images = self.slots.into_iter().enumerate().map(|(image_num, slots)| {
             let dep = BoringDep::new(image_num, &NO_DEPS);
-            let primaries = install_image(&mut flash, &self.areadesc, &slots[0],
-                maximal(32784), &ram, &dep,ImageManipulation::None, Some(0), false);
+            let primaries = install_image(&mut flash, &self.areadesc, &slots, 0,
+                maximal(32784), &ram, &dep,ImageManipulation::None, Some(0));
             let upgrades = install_no_image();
             OneImage {
                 slots,
@@ -367,8 +367,8 @@ impl ImagesBuilder {
         let images = self.slots.into_iter().enumerate().map(|(image_num, slots)| {
             let dep = BoringDep::new(image_num, &NO_DEPS);
             let primaries = install_no_image();
-            let upgrades = install_image(&mut flash, &self.areadesc, &slots[1],
-                maximal(32784), &ram, &dep, ImageManipulation::None, Some(0), true);
+            let upgrades = install_image(&mut flash, &self.areadesc, &slots, 1,
+                maximal(32784), &ram, &dep, ImageManipulation::None, Some(0));
             OneImage {
                 slots,
                 primaries,
@@ -389,8 +389,8 @@ impl ImagesBuilder {
         let images = self.slots.into_iter().enumerate().map(|(image_num, slots)| {
             let dep = BoringDep::new(image_num, &NO_DEPS);
             let primaries = install_no_image();
-            let upgrades = install_image(&mut flash, &self.areadesc, &slots[1],
-                ImageSize::Oversized, &ram, &dep, ImageManipulation::None, Some(0), true);
+            let upgrades = install_image(&mut flash, &self.areadesc, &slots, 1,
+                ImageSize::Oversized, &ram, &dep, ImageManipulation::None, Some(0));
             OneImage {
                 slots,
                 primaries,
@@ -411,10 +411,10 @@ impl ImagesBuilder {
         let ram = self.ram.clone(); // TODO: Avoid this clone.
         let images = self.slots.into_iter().enumerate().map(|(image_num, slots)| {
             let dep = BoringDep::new(image_num, &NO_DEPS);
-            let primaries = install_image(&mut flash, &self.areadesc, &slots[0],
-                maximal(32784), &ram, &dep,  ImageManipulation::None, security_cnt, false);
-            let upgrades = install_image(&mut flash, &self.areadesc, &slots[1],
-                maximal(41928), &ram, &dep, ImageManipulation::None, security_cnt.map(|v| v + 1), true);
+            let primaries = install_image(&mut flash, &self.areadesc, &slots, 0,
+                maximal(32784), &ram, &dep,  ImageManipulation::None, security_cnt);
+            let upgrades = install_image(&mut flash, &self.areadesc, &slots, 1,
+                maximal(41928), &ram, &dep, ImageManipulation::None, security_cnt.map(|v| v + 1));
             OneImage {
                 slots,
                 primaries,
@@ -1819,19 +1819,50 @@ fn image_largest_trailer(dev: &dyn Flash, areadesc: &AreaDesc, slot: &SlotInfo) 
             trailer
 }
 
+// Computes the padding required in the primary or secondary slot to be able to perform an upgrade.
+// This is needed only for the swap-move and swap-offset upgrade strategies.
+fn required_slot_padding(dev: &dyn Flash) -> usize {
+    let required_padding = if Caps::SwapUsingMove.present() || Caps::SwapUsingOffset.present() {
+        // Assumes equally-sized sectors
+        dev.sector_iter().next().unwrap().size
+    } else {
+        0
+    };
+
+    required_padding
+}
+
+// Computes the largest possible firmware image size, not including the header and TLV area.
+fn compute_largest_image_size(dev: &dyn Flash, areadesc: &AreaDesc, slots: &[SlotInfo],
+                              slot_ind: usize, hdr_size: usize, tlv: &dyn ManifestGen) -> usize {
+    let slot_len = if Caps::SwapUsingOffset.present() {
+        slots[1].len
+    } else {
+        slots[0].len
+    };
+
+    let trailer = image_largest_trailer(dev, areadesc, &slots[slot_ind]);
+    let padding = required_slot_padding(dev);
+    let tlv_len = tlv.estimate_size();
+    info!("slot: 0x{:x}, HDR: 0x{:x}, trailer: 0x{:x}, tlv_len: 0x{:x}, padding: 0x{:x}",
+        slot_len, hdr_size, trailer, tlv_len, padding);
+
+    slot_len - hdr_size - trailer - tlv_len - padding
+}
+
 /// Install a "program" into the given image.  This fakes the image header, or at least all of the
 /// fields used by the given code.  Returns a copy of the image that was written.
-fn install_image(flash: &mut SimMultiFlash, areadesc: &AreaDesc, slot: &SlotInfo, len: ImageSize,
-                 ram: &RamData,
-                 deps: &dyn Depender, img_manipulation: ImageManipulation, security_counter:Option<u32>, secondary_slot:bool) -> ImageData {
+fn install_image(flash: &mut SimMultiFlash, areadesc: &AreaDesc, slots: &[SlotInfo],
+                 slot_ind: usize, len: ImageSize, ram: &RamData,
+                 deps: &dyn Depender, img_manipulation: ImageManipulation, security_counter:Option<u32>) -> ImageData {
+    let slot = &slots[slot_ind];
     let mut offset = slot.base_off;
-    let slot_len = slot.len;
     let dev_id = slot.dev_id;
     let dev = flash.get_mut(&dev_id).unwrap();
 
     let mut tlv: Box<dyn ManifestGen> = Box::new(make_tlv());
 
-    if Caps::SwapUsingOffset.present() && secondary_slot {
+    if Caps::SwapUsingOffset.present() && slot_ind == 1 {
         let sector_size = dev.sector_iter().next().unwrap().size as usize;
         offset += sector_size;
     }
@@ -1863,30 +1894,13 @@ fn install_image(flash: &mut SimMultiFlash, areadesc: &AreaDesc, slot: &SlotInfo
 
     let len = match len {
         ImageSize::Given(size) => size,
-        ImageSize::Largest => {
-            let trailer = image_largest_trailer(dev, &areadesc, &slot);
-            let tlv_len = tlv.estimate_size();
-            info!("slot: 0x{:x}, HDR: 0x{:x}, trailer: 0x{:x}",
-                slot_len, HDR_SIZE, trailer);
-            slot_len - HDR_SIZE - trailer - tlv_len
-        },
+        ImageSize::Largest => compute_largest_image_size(dev, areadesc, slots, slot_ind,
+                                                         HDR_SIZE, tlv.as_ref()),
         ImageSize::Oversized => {
-            let trailer = image_largest_trailer(dev, &areadesc, &slot);
-            let tlv_len = tlv.estimate_size();
-            let mut sector_offset = 0;
-
-            if Caps::SwapUsingOffset.present() && secondary_slot {
-                // This accounts for when both slots have the same size, it will not work where
-                // the second slot is one sector larger than the primary
-                sector_offset = dev.sector_iter().next().unwrap().size as usize;
-            }
-
-            info!("slot: 0x{:x}, HDR: 0x{:x}, trailer: 0x{:x}",
-                slot_len, HDR_SIZE, trailer);
-
-            slot_len - HDR_SIZE - trailer - tlv_len - sector_offset + dev.align()
+            let largest_img_sz = compute_largest_image_size(dev, areadesc, slots, slot_ind,
+                                                            HDR_SIZE, tlv.as_ref());
+            largest_img_sz + dev.align()
         }
-
     };
 
     // Generate a boot header.  Note that the size doesn't include the header.
@@ -1995,7 +2009,7 @@ fn install_image(flash: &mut SimMultiFlash, areadesc: &AreaDesc, slot: &SlotInfo
 
             enc_copy = Some(enc);
 
-            dev.erase(offset, slot_len).unwrap();
+            dev.erase(offset, slot.len).unwrap();
         } else {
             enc_copy = None;
         }
@@ -2020,7 +2034,7 @@ fn install_image(flash: &mut SimMultiFlash, areadesc: &AreaDesc, slot: &SlotInfo
         let enc_copy: Option<Vec<u8>>;
 
         if is_encrypted {
-            dev.erase(offset, slot_len).unwrap();
+            dev.erase(offset, slot.len).unwrap();
 
             dev.write(offset, &encbuf).unwrap();
 
@@ -2395,10 +2409,7 @@ trait AsRaw : Sized {
 /// Determine whether it makes sense to test this configuration with a maximally-sized image.
 /// Returns an ImageSize representing the best size to test, possibly just with the given size.
 fn maximal(size: usize) -> ImageSize {
-    if Caps::OverwriteUpgrade.present() ||
-        Caps::SwapUsingOffset.present() ||
-        Caps::SwapUsingMove.present()
-    {
+    if Caps::OverwriteUpgrade.present() {
         ImageSize::Given(size)
     } else {
         ImageSize::Largest

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -742,8 +742,7 @@ impl Images {
                 fails += 1;
             }
 
-            if !self.verify_trailers(&flash, 1, BOOT_MAGIC_UNSET,
-                                     BOOT_FLAG_UNSET, BOOT_FLAG_UNSET) {
+            if !self.verify_post_upgrade_secondary_trailer(&flash) {
                 warn!("Mismatched trailer for the secondary slot");
                 fails += 1;
             }
@@ -792,8 +791,7 @@ impl Images {
             error!("Mismatched trailer for the primary slot");
             fails += 1;
         }
-        if !self.verify_trailers(&flash, 1, BOOT_MAGIC_UNSET,
-                                 BOOT_FLAG_UNSET, BOOT_FLAG_UNSET) {
+        if !self.verify_post_upgrade_secondary_trailer(&flash) {
             error!("Mismatched trailer for the secondary slot");
             fails += 1;
         }
@@ -852,13 +850,14 @@ impl Images {
             warn!("Primary slot image verification FAIL");
             fails += 1;
         }
+
         if !self.verify_trailers(&flash, 0, BOOT_MAGIC_GOOD,
                                  BOOT_FLAG_UNSET, BOOT_FLAG_SET) {
             warn!("Mismatched trailer for the primary slot");
             fails += 1;
         }
-        if !self.verify_trailers(&flash, 1, BOOT_MAGIC_UNSET,
-                                 BOOT_FLAG_UNSET, BOOT_FLAG_UNSET) {
+
+        if !self.verify_post_upgrade_secondary_trailer(&flash) {
             warn!("Mismatched trailer for the secondary slot");
             fails += 1;
         }
@@ -1530,8 +1529,7 @@ impl Images {
             warn!("Mismatched trailer for the primary slot before revert");
             fails += 1;
         }
-        if !self.verify_trailers(&flash, 1, BOOT_MAGIC_UNSET,
-                                BOOT_FLAG_UNSET, BOOT_FLAG_UNSET) {
+        if !self.verify_post_upgrade_secondary_trailer(&flash) {
             warn!("Mismatched trailer for the secondary slot before revert");
             fails += 1;
         }
@@ -1668,6 +1666,17 @@ impl Images {
             verify_trailer(flash, &image.slots[slot],
                            magic, image_ok, copy_done)
         })
+    }
+
+    // Verify the trailers in the secondary slot contains the expected values after an upgrade.
+    fn verify_post_upgrade_secondary_trailer(&self, flash: &SimMultiFlash) -> bool {
+        if Caps::SwapUsingMove.present() {
+            return self.verify_trailers(&flash, 1, BOOT_MAGIC_GOOD,
+                                        BOOT_FLAG_UNSET, BOOT_FLAG_SET);
+        } else {
+            return self.verify_trailers(&flash, 1, BOOT_MAGIC_UNSET,
+                                        BOOT_FLAG_UNSET, BOOT_FLAG_UNSET);
+        }
     }
 
     /// Mark each of the images for permanent upgrade.


### PR DESCRIPTION
When using swap-move, the area allocated to the trailer has currently to be a multiple of the sector size. This is not a big deal on devices having small sectors, but on devices having a large sector size, such most STM32 MCUs, this typically means losing a significant amount of flash memory. For example, on an STM32F4 device with 128-KiB sectors, the trailer is usually only a few hundreds of bytes long but a whole 128 KiB has still to be reserved for storing the trailer and can't therefore be used for firmware data.

The idea of this PR is to relax the need of having a sector-aligned trailer area, enabling therefore to use all the bytes not needed by the trailer, in the first sector holding trailer data, to store firmware data.

To illustrate the solution, let's imagine a device having 4096-byte sectors and a primary slot composed of `N` sectors. Let's assume the trailer needs 4224 bytes. Before this MR, two entire sectors would have to be allocated to the trailer, so the layout would have been something like:
```
         PRIMARY                               SECONDARY
|          ...          |              |          ...          |
+-----------------------+              +-----------------------+
| Firmware (4096 bytes) | Sector N-3   | Firmware (4096 bytes) | Sector N-3
|           .           |              |           .           |
+-----------------------+              +-----------------------+
|  Padding (4096 bytes) | Sector N-2   |  Trailer (4096 bytes) | Sector N-2
|           .           |              |           .           |
+-----------------------+              +-----------------------+
|  Trailer (4096 bytes) | Sector N-1   |  Trailer (4096 bytes) | Sector N-1
|                       |              |           .           |
+-----------------------+              +-----------------------+
|  Trailer (4096 bytes) | Sector N
|           .           |
+-----------------------+
```

With this MR, only the exact amount of bytes actually needed by the trailer have to be allocated to the trailer, so we have 3968 additional bytes available to store the firmware image:
```
         PRIMARY                               SECONDARY
|          ...          |              |          ...          |
+-----------------------+              +-----------------------+
| Firmware (4096 bytes) | Sector N-3   | Firmware (4096 bytes) | Sector N-3
|           .           |              |           .           |
+-----------------------+              +-----------------------+
| Firmware (3968 bytes) | Sector N-2   | Firmware (3968 bytes) | Sector N-2
|  Padding (128 bytes)  |              |  Trailer (128 bytes)  |
+-----------------------+              +-----------------------+
|  Padding (3968 bytes) | Sector N-1   |  Trailer (4096 bytes) | Sector N-1
|  Trailer (128 bytes)  |              |           .           |
+-----------------------+              +-----------------------+
|  Trailer (4096 bytes) | Sector N
|           .           |
+-----------------------+
```

At the beginning of an upgrade or revert process, all the sectors in the primary slot are "moved up", ending up with:
```
         PRIMARY                               SECONDARY
|          ...          |              |          ...          |
+-----------------------+              +-----------------------+
| Firmware (4096 bytes) | Sector N-3   | Firmware (4096 bytes) | Sector N-3
|           .           |              |           .           |
+-----------------------+              +-----------------------+
| Firmware (4096 bytes) | Sector N-2   | Firmware (3968 bytes) | Sector N-2
|           .           |              |  Trailer (128 bytes)  |
+-----------------------+              +-----------------------+
| Firmware (3968 bytes) | Sector N-1   |  Trailer (4096 bytes) | Sector N-1
|  Trailer (128 bytes)  |              |           .           |
+-----------------------+              +-----------------------+
|  Trailer (4096 bytes) | Sector N
|           .           |
+-----------------------+
``` 

To main ideas of the solution implemented by this PR is:
* To copy only the part used by the firmware image when moving up the last sector (sector N-2 in the example), to avoid overwriting the trailer data.
* To erase the secondary slot's trailer when swapping the last sector holding firmware data in the secondary slot, to ensure no firmware data will be lost when erasing the secondary trailer. Previously the erasure was performed at the beginning of the move process, just after the erasure of the primary trailer, by simplicity.
* To avoid the need of rewriting the secondary slot's trailer when starting a revert process.

The latter is the most difficult part. Indeed, at the beginning of the revert process, the secondary trailer was rewritten to make the revert look like a permanent upgrade in case an unfortunate reset occurs during the rewriting of the primary trailer. This was a clever trick, but is unfortunately no longer possible if the trailers are not stored in dedicated sectors. The solution proposed by this PR is inspired from the implementation of the swap-offset strategy, which uses the `copy_done` flag in the secondary trailer to indicate a revert process is ongoing. For the swap-move, since we cannot rewrite the trailer at the beginning of the revert process, the idea is to rewrite it at the time it is erased, at the end of the upgrade process. This means the secondary trailer is now valid after an upgrade, which required a few changes in the swap tables and in the simulator.

If the improvement proposed by this MR is merged, I will try to port those changes to the swap-offset strategy, which should be quite easy, at least in theory.

Resolves #2052