### PR TITLE
boot: zephyr: flash_map_extended: Add pointless workaround for clang

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -66,7 +66,8 @@ int flash_device_base(uint8_t fd_id, uintptr_t *ret)
  */
 int flash_area_id_from_multi_image_slot(int image_index, int slot)
 {
-    int rc, id;
+    int rc;
+    int id = -1;
 
     rc = BOOT_HOOK_FLASH_AREA_CALL(flash_area_id_from_multi_image_slot_hook,
                                    BOOT_HOOK_REGULAR, image_index, slot, &id);


### PR DESCRIPTION
Clang wrongly throws a warning, which will be treated as an error in twister builds, add pointless workaround to set variable that is already set by the hook function to avoid this