### PR TITLE
scripts: imgtool: added fixed signature script option

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -27,6 +27,8 @@ import copy
 from enum import Enum
 import array
 from intelhex import IntelHex
+import subprocess
+import base64
 import hashlib
 import array
 import os.path
@@ -461,7 +463,8 @@ class Image:
                sw_type=None, custom_tlvs=None, compression_tlvs=None,
                compression_type=None, encrypt_keylen=128, clear=False,
                fixed_sig=None, pub_key=None, vector_to_sign=None,
-               user_sha='auto', is_pure=False, keep_comp_size=False, dont_encrypt=False):
+               user_sha='auto', is_pure=False, keep_comp_size=False, dont_encrypt=False,
+               fixed_sig_script=None):
         self.enckey = enckey
 
         # key decides on sha, then pub_key; of both are none default is used
@@ -638,7 +641,16 @@ class Image:
             else:
                 tlv.add('PUBKEY', pub)
 
-            if key is not None and fixed_sig is None:
+            if fixed_sig_script is not None:
+                # Call fixed signature script with payload and digest to get signature
+                # The script should return the signature in binary format
+                digest_base64 = base64.b64encode(digest).decode('ascii')
+                print(os.path.basename(__file__) + ": call fixed signature script with digest and input file")
+                result = subprocess.run([fixed_sig_script, digest_base64], stdout=subprocess.PIPE, check=True, input=self.payload)
+                stdout = result.stdout
+                self.signature = base64.b64decode(stdout.decode('ascii'))
+                tlv.add(pub_key.sig_tlv(), self.signature)
+            elif key is not None and fixed_sig is None:
                 # `sign` expects the full image payload (hashing done
                 # internally), while `sign_digest` expects only the digest
                 # of the payload

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -427,6 +427,8 @@ class BasedIntParamType(click.ParamType):
               'the signature calculated using the public key')
 @click.option('--fix-sig-pubkey', metavar='filename',
               help='public key relevant to fixed signature')
+@click.option('--fix-sig-script', metavar='filename',
+              help='script to generate fixed signature')
 @click.option('--pure', 'is_pure', is_flag=True, default=False, show_default=True,
               help='Expected Pure variant of signature; the Pure variant is '
               'expected to be signature done over an image rather than hash of '
@@ -449,8 +451,8 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
          endian, encrypt_keylen, encrypt, compression, infile, outfile,
          dependencies, load_addr, hex_addr, erased_val, save_enctlv,
          security_counter, boot_record, custom_tlv, rom_fixed, max_align,
-         clear, fix_sig, fix_sig_pubkey, sig_out, user_sha, is_pure,
-         vector_to_sign, non_bootable):
+         clear, fix_sig, fix_sig_pubkey, fix_sig_script, sig_out, user_sha,
+         is_pure, vector_to_sign, non_bootable):
 
     if confirm:
         # Confirmed but non-padded images don't make much sense, because
@@ -506,16 +508,17 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
     baked_signature = None
     pub_key = None
 
-    if raw_signature is not None:
+    if raw_signature is not None or fix_sig_script is not None:
         if fix_sig_pubkey is None:
             raise click.UsageError(
                 'public key of the fixed signature is not specified')
 
         pub_key = load_key(fix_sig_pubkey)
 
-        baked_signature = {
-            'value': raw_signature
-        }
+        if raw_signature is not None:
+            baked_signature = {
+                'value': raw_signature
+            }
 
     if is_pure and user_sha != 'auto':
         raise click.UsageError(


### PR DESCRIPTION
This PR adds the option of passing `fixed_sig_script` as an external script to be called for signature generation, to then let the process continue "normally".

### The current flow
To use a public key and an external signature provider, you'd have to:
1. Run `imgtool` with `--vector-to-sign` to save the vector
2. Fetch public key for signing
3. Call external script with the vector to sign, save or otherwise pass signature
4. Run `imgtool` again, this time providing it with `--fix-sig` and `--fix-sig-pubkey`
5. Have signed image

### New possible flow with proposed changes
1. Fetch public key for signing
2. Run `imgtool` with `--fix-sig-script` and `fix-sig-pubkey` matching
3. Have signed image


Codebases or other downstream dependencies that rely on baking in calls to `imgtool` and mainly having a singular call in the normal path, but otherwise taking in all `imgtool` options now gets to keep that, and simply provide the script as an extra option, but not needing a different flow from e.g. a debug build.

This lets the difference between e.g. a debug and a release build be entirely managed in the signature script, and so lets the same pipeline be used opaquely while still generating different builds signed with different keys depending on environment.