### PR TITLE
mynewt: Start watchdog when enable by syscfg

### DIFF
--- a/boot/mynewt/src/main.c
+++ b/boot/mynewt/src/main.c
@@ -226,6 +226,7 @@ mynewt_main(void)
 #if !MYNEWT_VAL(OS_SCHEDULING) && MYNEWT_VAL(WATCHDOG_INTERVAL)
     rc = hal_watchdog_init(MYNEWT_VAL(WATCHDOG_INTERVAL));
     assert(rc == 0);
+    hal_watchdog_enable();
 #endif
 
 #if defined(MCUBOOT_SERIAL) || defined(MCUBOOT_HAVE_LOGGING) || \


### PR DESCRIPTION
Code implied that WATCHDOG_INTERVAL will enable watchdog in bootloader however it never did hal_watchdog_init sets up some watchdog data but for most mcu is does not start watchdog.

Now hal_watchdog_enable() is called when WATCHDOG_INTERVAL is set to non zero as git history suggested .