### PR TITLE
bootutil: swap-scratch: Fix conflicts after support of device without erase

### DIFF
--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -665,7 +665,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
              * trailer since in case the trailer spreads over multiple sector erasing the [img_off,
              * img_off + sz) might not erase the entire trailer.
               */
-            rc = swap_erase_trailer_sectors(state, fap_secondary_slot);
+            rc = swap_scramble_trailer_sectors(state, fap_secondary_slot);
             assert(rc == 0);
 
             if (bs->use_scratch) {
@@ -691,14 +691,6 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
                               img_off, img_off, copy_sz);
         assert(rc == 0);
 
-        if (bs->idx == BOOT_STATUS_IDX_0 && !bs->use_scratch) {
-            /* If not all sectors of the slot are being swapped,
-             * guarantee here that only the primary slot will have the state.
-             */
-            rc = swap_scramble_trailer_sectors(state, fap_secondary_slot);
-            assert(rc == 0);
-        }
-
         rc = boot_write_status(state, bs);
         bs->state = BOOT_STATUS_STATE_2;
         BOOT_STATUS_ASSERT(rc == 0);
@@ -713,7 +705,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
              * able to write the new trailer. This is not always equivalent to erasing the [img_off,
              * img_off + sz) range when the trailer spreads across multiple sectors.
              */
-            rc = swap_erase_trailer_sectors(state, fap_primary_slot);
+            rc = swap_scramble_trailer_sectors(state, fap_primary_slot);
             assert(rc == 0);
 
             /* Ensure the sector(s) containing the beginning of the trailer won't be erased twice */


### PR DESCRIPTION
Before the PR #2206 fixing issues in the swap-scratch logic when the trailer is larger than the last sector was merged, the PR #2114 was reverted (see #2211). This changes made by #2211 were then reapplied (see #2216) after #2206 was merged, leading to some conflicts: a call to `swap_erase_trailer_sectors` was moved by #2206 but the old call to that function was added back by #2216 and a new call to `swap_erase_trailer_sectors` was added by #2206 but not converted to a call to swap_scramble_trailer_sectors by #2216.