### PR TITLE
swap_move: correct appsize calcs and warning

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -314,6 +314,12 @@ Where:
   is equal to 1056 B and the sector size is equal to 1024 B, then
   `image-trailer-sectors-size` will be equal to 2048 B.
 
+This does imply, if there is any doubt, that the primary slot will be exactly
+one sector larger than the secondary slot due to the swap sector alone. It is
+the case that both the primary and secondary slots both have a trailer in
+addition to the application payload and these trailers are identical in size
+to one another.
+
 The algorithm does two erase cycles on the primary slot and one on the secondary
 slot during each swap. Assuming that receiving a new image by the DFU
 application requires 1 erase cycle on the secondary slot, this should result in


### PR DESCRIPTION
app_max_sectors() is always off by one in its calculation. This corrects that calculation as well as the warning which should only be comparing the two slot sector counts and checking to see if they are different by one sector for the swap sector. The size of the application is not relevant in that warning for optimal sector distribution.

Additionally app_max_size() suffers similarly in that it is not taking into account the fact that the secondary slot does also contain a trailer.

Finally makes a minor addition to the design document which further clarifies the primary and secondary partition size differences.