### PR TITLE
boot/zephyr/boards: nrf54h20dk 'iron' board configuration

### DIFF
--- a/boot/zephyr/boards/nrf54h20dk_nrf54h20_cpuapp_iron.conf
+++ b/boot/zephyr/boards/nrf54h20dk_nrf54h20_cpuapp_iron.conf
@@ -1,0 +1,11 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Ensure that the SPI NOR driver is disabled by default
+CONFIG_SPI_NOR=n
+
+CONFIG_BOOT_WATCHDOG_FEED=n
+
+CONFIG_MULTITHREADING=y


### PR DESCRIPTION
Added configuration for the nRF54H20 DK 'iron' board variant.