### PR TITLE
boot: bootutil: loader: Add include for flash function

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -36,6 +36,7 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+#include "flash_map_backend/flash_map_backend.h"
 #include "bootutil/bootutil.h"
 #include "bootutil/bootutil_public.h"
 #include "bootutil/image.h"


### PR DESCRIPTION
Adds an include which provides a definition for the flash_area_get_sector() function