### PR TITLE
boot: zephyr: kconfig: Default to swap using offset for nRF devices

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -397,6 +397,7 @@ config BOOT_VALIDATE_SLOT0_ONCE
 
 config BOOT_PREFER_SWAP_OFFSET
 	bool "Prefer the newer swap offset algorithm"
+	default y if SOC_FAMILY_NORDIC_NRF
 	help
 	  If y, the BOOT_IMAGE_UPGRADE_MODE will default to using "offset" instead of "scratch".
 	  This is a separate bool config option, because Kconfig doesn't allow defaults to be
@@ -404,7 +405,6 @@ config BOOT_PREFER_SWAP_OFFSET
 
 config BOOT_PREFER_SWAP_MOVE
 	bool "Prefer the newer swap move algorithm"
-	default y if SOC_FAMILY_NORDIC_NRF
 	default y if !$(dt_nodelabel_enabled,scratch_partition)
 	help
 	  If y, the BOOT_IMAGE_UPGRADE_MODE will default to using


### PR DESCRIPTION
Defaults to the new swap using offset mode