### PR TITLE
zephyr: Fix trailer size computation for swap-scratch

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -677,8 +677,10 @@ if(SYSBUILD)
       set(boot_status_data_size 0)
     endif()
 
-    math(EXPR required_size "${key_size} + ${boot_magic_size} + ${boot_swap_data_size} + ${boot_status_data_size} + ${boot_tlv_estimate}")
-    align_up(${required_size} ${erase_size} required_size)
+    math(EXPR trailer_size "${key_size} + ${boot_magic_size} + ${boot_swap_data_size} + ${boot_status_data_size}")
+    align_up(${trailer_size} ${erase_size} trailer_size)
+
+    math(EXPR required_size "${trailer_size} + ${boot_tlv_estimate}")
 
     if(CONFIG_SINGLE_APPLICATION_SLOT OR CONFIG_BOOT_FIRMWARE_LOADER)
       set(required_upgrade_size "0")

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -678,7 +678,10 @@ if(SYSBUILD)
     endif()
 
     math(EXPR trailer_size "${key_size} + ${boot_magic_size} + ${boot_swap_data_size} + ${boot_status_data_size}")
-    align_up(${trailer_size} ${erase_size} trailer_size)
+
+    if(CONFIG_BOOT_SWAP_USING_MOVE OR CONFIG_BOOT_SWAP_USING_OFFSET)
+      align_up(${trailer_size} ${erase_size} trailer_size)
+    endif()
 
     math(EXPR required_size "${trailer_size} + ${boot_tlv_estimate}")
 
@@ -686,7 +689,10 @@ if(SYSBUILD)
       set(required_upgrade_size "0")
     else()
       math(EXPR required_upgrade_size "${boot_magic_size} + ${boot_swap_data_size} + ${boot_status_data_size}")
-      align_up(${required_upgrade_size} ${erase_size} required_upgrade_size)
+
+      if(CONFIG_BOOT_SWAP_USING_MOVE OR CONFIG_BOOT_SWAP_USING_OFFSET)
+        align_up(${required_upgrade_size} ${erase_size} required_upgrade_size)
+      endif()
     endif()
 
     if(CONFIG_BOOT_SWAP_USING_MOVE)


### PR DESCRIPTION
When computing the maximum image size, the Zephyr build system was wrongly considering the trailers have to be sector-aligned for swap-scratch. This is not the case, as swap-scratch support having a sector containing both firmware and trailer data. This issue was preventing e.g. to build an application using swap-scratch with single-sector slots.

Additionally, this PR also fix a minor fix for swap-move and swap-offset: the TLV area size was added to trailer size before rounding up to the next multiple of the sector size. The TLV area is not part of the trailer so shouldn't be considered when rounding up the trailer size.

This MR was tested with Zephyr v4.1.0 on a STM32H747 MCU. 