### PR TITLE
bootutil: Fix crash when bootutil_sha_init() is called in loop

### DIFF
--- a/boot/bootutil/src/image_rsa.c
+++ b/boot/bootutil/src/image_rsa.c
@@ -97,6 +97,7 @@ pss_mgf1(uint8_t *mask, const uint8_t *hash)
         bootutil_sha_update(&ctx, hash, PSS_HLEN);
         bootutil_sha_update(&ctx, counter, 4);
         bootutil_sha_finish(&ctx, htmp);
+        bootutil_sha_drop(&ctx);
 
         counter[3]++;
 
@@ -108,8 +109,6 @@ pss_mgf1(uint8_t *mask, const uint8_t *hash)
         mask += bytes;
         count -= bytes;
     }
-
-    bootutil_sha_drop(&ctx);
 }
 
 /*

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -289,12 +289,11 @@ bootutil_find_key(uint8_t *keyhash, uint8_t keyhash_len)
         bootutil_sha_init(&sha_ctx);
         bootutil_sha_update(&sha_ctx, key->key, *key->len);
         bootutil_sha_finish(&sha_ctx, hash);
+        bootutil_sha_drop(&sha_ctx);
         if (!memcmp(hash, keyhash, keyhash_len)) {
-            bootutil_sha_drop(&sha_ctx);
             return i;
         }
     }
-    bootutil_sha_drop(&sha_ctx);
     return -1;
 }
 #else /* !MCUBOOT_HW_KEY */


### PR DESCRIPTION
For mynewt hardware implementation of hash functionality calling bootutil_sha_init() in a loop without call to bootutil_sha_drop() result in a failure.

In two places where bootutil_sha_drop() was called after the loop, call is move into the loop to match
calls to bootutil_sha_init().

This will not impact default implementation where calling bootutil_sha_drop() in a loop does not change anything.

This fixes #2264 