### PR TITLE
boot: bootutil: Refactor erase functionality to fix watchdog feeding, also fix swap scratch corrupt image issue

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -875,7 +875,7 @@ static off_t erase_range(const struct flash_area *fap, off_t start, off_t end)
     BOOT_LOG_DBG("Erasing range 0x%jx:0x%jx", (intmax_t)start,
 		 (intmax_t)(start + size - 1));
 
-    rc = boot_erase_region(fap, start, size);
+    rc = boot_erase_region(fap, start, size, false);
     if (rc != 0) {
         BOOT_LOG_ERR("Error %d while erasing range", rc);
         return -EINVAL;
@@ -1019,7 +1019,7 @@ bs_upload(char *buf, int len)
         /* Non-progressive erase erases entire image slot when first chunk of
          * an image is received.
          */
-        rc = boot_erase_region(fap, 0, area_size);
+        rc = boot_erase_region(fap, 0, area_size, false);
         if (rc) {
             goto out_invalid_data;
         }

--- a/boot/boot_serial/src/boot_serial_encryption.c
+++ b/boot/boot_serial/src/boot_serial_encryption.c
@@ -187,7 +187,7 @@ decrypt_region_inplace(struct boot_loader_state *state,
                     (off + bytes_copied + idx) - hdr->ih_hdr_size, blk_sz,
                     blk_off, &buf[idx]);
         }
-        rc = boot_erase_region(fap, off + bytes_copied, chunk_sz);
+        rc = boot_erase_region(fap, off + bytes_copied, chunk_sz, false);
         if (rc != 0) {
             return BOOT_EFLASH;
         }

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -346,11 +346,9 @@ int boot_copy_region(struct boot_loader_state *state,
 /* Prepare for write device that requires erase prior to write. This will
  * do nothing on devices without erase requirement.
  */
-int boot_erase_region(const struct flash_area *fap, uint32_t off, uint32_t sz);
+int boot_erase_region(const struct flash_area *fap, uint32_t off, uint32_t sz, bool backwards);
 /* Similar to boot_erase_region but will always remove data */
-int boot_scramble_region(const struct flash_area *fap, uint32_t off, uint32_t sz);
-/* Similar to boot_scramble_region but works backwards */
-int boot_scramble_region_backwards(const struct flash_area *fap, uint32_t off, uint32_t sz);
+int boot_scramble_region(const struct flash_area *fap, uint32_t off, uint32_t sz, bool backwards);
 /* Makes slot unbootable, either by scrambling header magic, header sector
  * or entire slot, depending on settings.
  * Note: slot is passed here becuase at this point there is no function

--- a/boot/bootutil/src/swap_misc.c
+++ b/boot/bootutil/src/swap_misc.c
@@ -61,7 +61,7 @@ swap_erase_trailer_sectors(const struct boot_loader_state *state,
             uint32_t sz = boot_img_sector_size(state, slot, sector);
             uint32_t off = boot_img_sector_off(state, slot, sector);
 
-            rc = boot_erase_region(fap, off, sz);
+            rc = boot_erase_region(fap, off, sz, false);
             assert(rc == 0);
 
             sector--;
@@ -87,7 +87,7 @@ swap_scramble_trailer_sectors(const struct boot_loader_state *state,
     if (rc < 0) {
         return BOOT_EFLASH;
     }
-    rc = boot_scramble_region_backwards(fap, off, flash_area_get_size(fap) - off);
+    rc = boot_scramble_region(fap, off, (flash_area_get_size(fap) - off), true);
     if (rc < 0) {
         return BOOT_EFLASH;
     }

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -413,7 +413,7 @@ boot_move_sector_up(int idx, uint32_t sz, struct boot_loader_state *state,
         assert(rc == 0);
     }
 
-    rc = boot_erase_region(fap_pri, new_off, sz);
+    rc = boot_erase_region(fap_pri, new_off, sz, false);
     assert(rc == 0);
 
     rc = boot_copy_region(state, fap_pri, fap_pri, old_off, new_off, sz);
@@ -440,7 +440,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
     sec_off = boot_img_sector_off(state, BOOT_SECONDARY_SLOT, idx - 1);
 
     if (bs->state == BOOT_STATUS_STATE_0) {
-        rc = boot_erase_region(fap_pri, pri_off, sz);
+        rc = boot_erase_region(fap_pri, pri_off, sz, false);
         assert(rc == 0);
 
         rc = boot_copy_region(state, fap_sec, fap_pri, sec_off, pri_off, sz);
@@ -452,7 +452,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
     }
 
     if (bs->state == BOOT_STATUS_STATE_1) {
-        rc = boot_erase_region(fap_sec, sec_off, sz);
+        rc = boot_erase_region(fap_sec, sec_off, sz, false);
         assert(rc == 0);
 
         rc = boot_copy_region(state, fap_pri, fap_sec, pri_up_off, sec_off, sz);

--- a/boot/bootutil/src/swap_offset.c
+++ b/boot/bootutil/src/swap_offset.c
@@ -470,7 +470,7 @@ static void boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *st
         } else {
             /* Copy from slot 0 X to slot 1 X */
             BOOT_LOG_DBG("Erasing secondary 0x%x of 0x%x", sec_off, sz);
-            rc = boot_erase_region(fap_sec, sec_off, sz);
+            rc = boot_erase_region(fap_sec, sec_off, sz, false);
             assert(rc == 0);
 
             BOOT_LOG_DBG("Copying primary 0x%x -> secondary 0x%x of 0x%x", pri_off, sec_off, sz);
@@ -490,7 +490,7 @@ static void boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *st
         } else {
             /* Erase slot 0 X */
             BOOT_LOG_DBG("Erasing primary 0x%x of 0x%x", pri_off, sz);
-            rc = boot_erase_region(fap_pri, pri_off, sz);
+            rc = boot_erase_region(fap_pri, pri_off, sz, false);
             assert(rc == 0);
 
             /* Copy from slot 1 (X + 1) to slot 0 X */
@@ -531,7 +531,7 @@ static void boot_swap_sectors_revert(int idx, uint32_t sz, struct boot_loader_st
         } else {
             /* Copy from slot 0 X to slot 1 X */
             BOOT_LOG_DBG("Erasing secondary 0x%x of 0x%x", sec_off, sz);
-            rc = boot_erase_region(fap_sec, sec_off, sz);
+            rc = boot_erase_region(fap_sec, sec_off, sz, false);
             assert(rc == 0);
 
             BOOT_LOG_DBG("Copying primary 0x%x -> secondary 0x%x of 0x%x", pri_off, sec_off, sz);
@@ -551,7 +551,7 @@ static void boot_swap_sectors_revert(int idx, uint32_t sz, struct boot_loader_st
         } else {
             /* Erase slot 0 X */
             BOOT_LOG_DBG("Erasing primary 0x%x of 0x%x", pri_off, sz);
-            rc = boot_erase_region(fap_pri, pri_off, sz);
+            rc = boot_erase_region(fap_pri, pri_off, sz, false);
             assert(rc == 0);
 
             /* Copy from slot 1 (X + 1) to slot 0 X */
@@ -710,7 +710,7 @@ void swap_run(struct boot_loader_state *state, struct boot_status *bs,
          * to allow for a future update to be loaded
          */
         rc = boot_scramble_region(fap_sec, boot_img_sector_off(state, BOOT_SECONDARY_SLOT, 0),
-                                  sector_sz);
+                                  sector_sz, false);
         assert(rc == 0);
         rc = swap_scramble_trailer_sectors(state, fap_sec);
         assert(rc == 0);

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -617,7 +617,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
 
     if (bs->state == BOOT_STATUS_STATE_0) {
         BOOT_LOG_DBG("erasing scratch area");
-        rc = boot_erase_region(fap_scratch, 0, flash_area_get_size(fap_scratch));
+        rc = boot_erase_region(fap_scratch, 0, flash_area_get_size(fap_scratch), false);
         assert(rc == 0);
 
         if (bs->idx == BOOT_STATUS_IDX_0) {
@@ -641,7 +641,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
 
                 /* Erase the temporary trailer from the scratch area. */
                 rc = boot_erase_region(fap_scratch, 0,
-                        flash_area_get_size(fap_scratch));
+                        flash_area_get_size(fap_scratch), false);
                 assert(rc == 0);
             }
         }
@@ -683,7 +683,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
         }
 
         if (erase_sz > 0) {
-            rc = boot_erase_region(fap_secondary_slot, img_off, erase_sz);
+            rc = boot_erase_region(fap_secondary_slot, img_off, erase_sz, false);
             assert(rc == 0);
         }
 
@@ -716,7 +716,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
         }
 
         if (erase_sz > 0) {
-            rc = boot_erase_region(fap_primary_slot, img_off, erase_sz);
+            rc = boot_erase_region(fap_primary_slot, img_off, erase_sz, false);
             assert(rc == 0);
         }
 
@@ -778,7 +778,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
         BOOT_STATUS_ASSERT(rc == 0);
 
         if (erase_scratch) {
-            rc = boot_erase_region(fap_scratch, 0, flash_area_get_size(fap_scratch));
+            rc = boot_erase_region(fap_scratch, 0, flash_area_get_size(fap_scratch), false);
             assert(rc == 0);
         }
     }

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -778,7 +778,12 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
         BOOT_STATUS_ASSERT(rc == 0);
 
         if (erase_scratch) {
-            rc = boot_erase_region(fap_scratch, 0, flash_area_get_size(fap_scratch), false);
+           /* Scratch trailers MUST be erased backwards, this is to avoid an issue whereby a
+            * device reboots in the process of erasing the scratch if it erased forwards, if that
+            * happens then the scratch which is partially erased would be wrote back to the
+            * primary slot, causing a corrupt unbootable image
+            */
+            rc = boot_erase_region(fap_scratch, 0, flash_area_get_size(fap_scratch), true);
             assert(rc == 0);
         }
     }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -66,6 +66,16 @@
   MCUboot is compiled without support for them
 - Added support for devices that do not require erase prior to write operation.
 - Add corrections to the max app size calculations.
+- Fixed issue with swap using scratch mode that would cause the
+  primary image to be corrupt and unbootable after an update if the
+  device was rebooted whilst the scratch area was being erased.
+- Fixed issue with serial recovery if canonical CBOR mode was
+  enabled.
+- Fixed issue with serial recovery set image state not checking
+  primary slot images.
+- Fixed issue with watchdog not being fed during flash erase
+  operations, which could cause the watchdog to time out on long
+  erase operations and prevent firmware updates from being possible.
 
 ## Version 2.1.0
 


### PR DESCRIPTION
Refactors the erase functionality in bootutil so that it can be used alongside feeding the watchdog. This has also optimised some functions out.

Also fixes a serious issue with swap using scratch that would leave primary slot images unbootable and potentially brick devices