### PR TITLE
Revert "zephyr: arm: Update reading the flash image reset vector"

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -155,21 +155,8 @@ int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
 
 uint8_t flash_area_get_device_id(const struct flash_area *fa)
 {
-    uint8_t device_id;
-    int rc;
-
-    rc = BOOT_HOOK_FLASH_AREA_CALL(flash_area_get_device_id_hook,
-                                   BOOT_HOOK_REGULAR, fa, &device_id);
-    if (rc != BOOT_HOOK_REGULAR) {
-        return device_id;
-    }
-
-#if defined(CONFIG_ARM)
-    return fa->fa_id;
-#else
     (void)fa;
     return FLASH_DEVICE_ID;
-#endif
 }
 
 #define ERASED_VAL 0xff


### PR DESCRIPTION
This reverts commit 453096b17ddc3aac7bf6afb97c40591d5ea3aa9c.

Comment from @de-nordic 

> This is revert of commit which was supposed to allow picking interrupt vector table from flash area but the whole modification unfortunately misunderstood difference between flash device ID and flash area ID.