### PR TITLE
boot: zephyr: Refactor USB DFU entry logic

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2012-2014 Wind River Systems, Inc.
  * Copyright (c) 2020 Arm Limited
  * Copyright (c) 2021-2023 Nordic Semiconductor ASA
+ * Copyright (c) 2025 Aerlync Labs Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -434,6 +435,9 @@ int main(void)
 {
     struct boot_rsp rsp;
     int rc;
+#if defined(CONFIG_BOOT_USB_DFU_GPIO) || defined(CONFIG_BOOT_USB_DFU_WAIT)
+    bool usb_dfu_requested = false;
+#endif
     FIH_DECLARE(fih_rc, FIH_FAILURE);
 
     MCUBOOT_WATCHDOG_SETUP();
@@ -473,34 +477,36 @@ int main(void)
 
 #if defined(CONFIG_BOOT_USB_DFU_GPIO)
     if (io_detect_pin()) {
+        usb_dfu_requested = true;
+
 #ifdef CONFIG_MCUBOOT_INDICATION_LED
         io_led_set(1);
 #endif
 
         mcuboot_status_change(MCUBOOT_STATUS_USB_DFU_ENTERED);
-
-        rc = usb_enable(NULL);
-        if (rc) {
-            BOOT_LOG_ERR("Cannot enable USB");
-        } else {
-            BOOT_LOG_INF("Waiting for USB DFU");
-            wait_for_usb_dfu(K_FOREVER);
-            BOOT_LOG_INF("USB DFU wait time elapsed");
-        }
     }
 #elif defined(CONFIG_BOOT_USB_DFU_WAIT)
-    rc = usb_enable(NULL);
-    if (rc) {
-        BOOT_LOG_ERR("Cannot enable USB");
-    } else {
-        BOOT_LOG_INF("Waiting for USB DFU");
+    usb_dfu_requested = true;
+#endif
 
-        mcuboot_status_change(MCUBOOT_STATUS_USB_DFU_WAITING);
+#if defined(CONFIG_BOOT_USB_DFU_GPIO) || defined(CONFIG_BOOT_USB_DFU_WAIT)
+    if (usb_dfu_requested) {
+        rc = usb_enable(NULL);
+        if (rc) {
+            BOOT_LOG_ERR("Cannot enable USB: %d", rc);
+        } else {
+            BOOT_LOG_INF("Waiting for USB DFU");
 
-        wait_for_usb_dfu(K_MSEC(CONFIG_BOOT_USB_DFU_WAIT_DELAY_MS));
-        BOOT_LOG_INF("USB DFU wait time elapsed");
-
-        mcuboot_status_change(MCUBOOT_STATUS_USB_DFU_TIMED_OUT);
+#if defined(CONFIG_BOOT_USB_DFU_WAIT)
+            mcuboot_status_change(MCUBOOT_STATUS_USB_DFU_WAITING);
+            wait_for_usb_dfu(K_MSEC(CONFIG_BOOT_USB_DFU_WAIT_DELAY_MS));
+            BOOT_LOG_INF("USB DFU wait time elapsed");
+            mcuboot_status_change(MCUBOOT_STATUS_USB_DFU_TIMED_OUT);
+#else
+            wait_for_usb_dfu(K_FOREVER);
+            BOOT_LOG_INF("USB DFU wait terminated");
+#endif
+        }
     }
 #endif
 


### PR DESCRIPTION
Consolidates USB DFU entry logic by unifying GPIO and timeout-based DFU triggers under a common flag. This avoids code duplication and improves maintainability.
Also improves log clarity for different DFU exit conditions.