### PR TITLE
boot: bootutil: Fix security counter updated before revert after resuming upgrade

### DIFF
--- a/sim/mcuboot-sys/src/api.rs
+++ b/sim/mcuboot-sys/src/api.rs
@@ -388,3 +388,13 @@ pub extern "C" fn sim_get_nv_counter_for_image(image_index: u32, security_counte
     });
     return rc;
 }
+
+pub fn sim_reset_nv_counters() {
+    NV_COUNTER_CTX.with(|ctx| {
+        let mut counter_storage = ctx.borrow_mut();
+
+        for i in 0..counter_storage.storage.len() {
+            counter_storage.storage[i] = 0;
+        }
+    });
+}

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -166,6 +166,10 @@ pub fn get_security_counter(image_index: u32) -> u32 {
     return counter_val;
 }
 
+pub fn reset_security_counters() {
+    api::sim_reset_nv_counters();
+}
+
 mod raw {
     use crate::area::CAreaDesc;
     use crate::api::{BootRsp, CSimContext};

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -239,7 +239,7 @@ impl ImagesBuilder {
                 let upgr   = match deps.depends[image_num] {
                     DepType::NoUpgrade => install_no_image(),
                     _ => install_image(&mut flash, &self.areadesc, &slots, 1,
-                        maximal(46928), &ram, &*dep, ImageManipulation::BadSignature, Some(0))
+                        maximal(46928), &ram, &*dep, ImageManipulation::BadSignature, Some(1))
                 };
                 (prim, upgr)
             } else {
@@ -248,7 +248,7 @@ impl ImagesBuilder {
                 let upgr = match deps.depends[image_num] {
                         DepType::NoUpgrade => install_no_image(),
                         _ => install_image(&mut flash, &self.areadesc, &slots, 1,
-                            maximal(46928), &ram, &*dep, img_manipulation, Some(0))
+                            maximal(46928), &ram, &*dep, img_manipulation, Some(1))
                     };
                 (prim, upgr)
             };
@@ -288,6 +288,10 @@ impl ImagesBuilder {
                     panic!("Unable to perform basic upgrade");
                 }
         };
+
+        // As a side effect, the upgrade performed above has updated the security counters. Reset
+        // them to their original value.
+        c::reset_security_counters();
 
         images.total_count = Some(total_count);
         images

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -21,6 +21,7 @@ use std::{
     env,
     sync::atomic::{AtomicUsize, Ordering},
 };
+use mcuboot_sys::c;
 
 /// A single test, after setting up logging and such.  Within the $body,
 /// $arg will be bound to each device.
@@ -90,6 +91,7 @@ test_shell!(dependency_combos, r, {
         let image = r.clone().make_image(&dep, true);
         dump_image(&image, "dependency_combos");
         assert!(!image.run_check_deps(&dep));
+        c::reset_security_counters();
     }
 });
 


### PR DESCRIPTION
This PR fixes an issue that was preventing an interrupted then resumed upgrade to be reverted when the hardware rollback protection is enabled and the swap-scratch, swap-move or swap-offset strategy is used.

After a "test" upgrade has been performed, the security counter of every image must not be updated immediately to be able to roll back in case the upgrade is not confirmed. To that end, the `boot_update_hw_rollback_protection` routine, called just before exiting MCUboot, was checking the swap type of the image and updating the security counter only if the swap type was none, with the assumption that it implies no upgrade has been performed by MCUboot. This was working properly in the nominal case, when the upgrades are not interrupted, however this assumption is false if MCUboot has just resumed an upgrade after a power cycle because in that case the swap type is set to none after the end of the upgrade process:
https://github.com/mcu-tools/mcuboot/blob/81315483fcbdf1f1524c2b34a1fd4de6c77cd0f4/boot/bootutil/src/loader.c#L2251-L2252

So, let's suppose an image A with a security counter N is upgraded, in "test" mode, to an image B with a security counter M > N:
1. MCUboot starts the upgrade from A to B.
2. During the upgrade, the device is power cycled.
3. MCUboot resumes and completes the upgrade.
4. Before booting image B, MCUboot updates the security counter value to M.
5. The image B is faulty and is therefore not confirmed, the device is rebooted.
6. MCUboot wants to revert the upgrade but refuses to roll back to image A since its security counter is lower than M. Therefore no revert is performed and the device might be bricked since B is faulty.

This was not detected by the tests since in the simulator the upgrades were performed with images having the same security counter value. In addition to fixing the issue, this MR also updates the simulator to use images with different security counter values, enabling to catch such kind of bugs.