### PR TITLE
sim: Enable oversized_secondary_slot test with max-align-32

### DIFF
--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -58,8 +58,6 @@ sim_test!(revert_with_fails, make_image(&NO_DEPS, false), run_revert_with_fails(
 sim_test!(perm_with_fails, make_image(&NO_DEPS, true), run_perm_with_fails());
 sim_test!(perm_with_random_fails, make_image(&NO_DEPS, true), run_perm_with_random_fails(5));
 sim_test!(norevert, make_image(&NO_DEPS, true), run_norevert());
-
-#[cfg(not(feature = "max-align-32"))]
 sim_test!(oversized_secondary_slot, make_oversized_secondary_slot_image(), run_oversizefail_upgrade());
 
 sim_test!(status_write_fails_complete, make_image(&NO_DEPS, true), run_with_status_fails_complete());


### PR DESCRIPTION
The test case `oversized_secondary_slot`, introduced by https://github.com/mcu-tools/mcuboot/pull/1286 was not enabled when the `max-align-32` feature was selected because the test case was failing with some configurations.

From the PR description:
>  added oversized_secondary_slot test for ensure that too big image upgrade attempt will be rejected. I doesn't work for max-align-32 feature due to not precise operations on flash image in sim code. Fixing of this problem is out of scope for this PR.

Since 88294be188c25e4b7d02cc9c55fabfc9286c83b7, the `oversized_secondary_slot` test is now passing with `max-align-32` in all configurations and can therefore be enabled.