### PR TITLE
boot: zephyr: kconfig: Fix issues and re-order

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -755,6 +755,32 @@ config BOOT_FIH_PROFILE_HIGH
 
 endchoice
 
+config BOOT_USE_BENCH
+        bool "Enable benchmark code"
+        help
+          If y, adds support for simple benchmarking that can record
+          time intervals between two calls.  The time printed depends
+          on the particular Zephyr target, and is generally ticks of a
+          specific board-specific timer.
+
+module = MCUBOOT
+module-str = MCUBoot bootloader
+source "subsys/logging/Kconfig.template.log_config"
+
+config MCUBOOT_LOG_THREAD_STACK_SIZE
+	int "Stack size for the MCUBoot log processing thread"
+	depends on LOG && !LOG_IMMEDIATE
+	default 2048 if COVERAGE_GCOV
+	default 1024 if NO_OPTIMIZATIONS
+	default 1024 if XTENSA
+	default 4096 if (X86 && X86_64)
+	default 4096 if ARM64
+	default 768
+	help
+	  Set the internal stack size for MCUBoot log processing thread.
+
+menu "USB DFU"
+
 choice BOOT_USB_DFU
 	prompt "USB DFU"
 	default BOOT_USB_DFU_NO
@@ -807,43 +833,23 @@ endif # BOOT_USB_DFU_GPIO
 
 config BOOT_USB_DFU_NO_APPLICATION
 	bool "Stay in bootloader if no application"
+	depends on !BOOT_USB_DFU_NO
 	help
 	  Allows for entering USB DFU recovery mode if there is no bootable
 	  application that the bootloader can jump to.
 
-config BOOT_USE_BENCH
-        bool "Enable benchmark code"
-        help
-          If y, adds support for simple benchmarking that can record
-          time intervals between two calls.  The time printed depends
-          on the particular Zephyr target, and is generally ticks of a
-          specific board-specific timer.
+endmenu
 
-module = MCUBOOT
-module-str = MCUBoot bootloader
-source "subsys/logging/Kconfig.template.log_config"
-
-config MCUBOOT_LOG_THREAD_STACK_SIZE
-	int "Stack size for the MCUBoot log processing thread"
-	depends on LOG && !LOG_IMMEDIATE
-	default 2048 if COVERAGE_GCOV
-	default 1024 if NO_OPTIMIZATIONS
-	default 1024 if XTENSA
-	default 4096 if (X86 && X86_64)
-	default 4096 if ARM64
-	default 768
-	help
-	  Set the internal stack size for MCUBoot log processing thread.
+rsource "Kconfig.serial_recovery"
 
 config MCUBOOT_INDICATION_LED
 	bool "Turns on LED indication when device is in DFU"
 	select GPIO
+	depends on MCUBOOT_SERIAL || !BOOT_USB_DFU_NO
 	help
 	  Device device activates the LED while in bootloader mode.
 	  mcuboot-led0 alias must be set in the device's .dts
 	  definitions for this to work.
-
-rsource "Kconfig.serial_recovery"
 
 rsource "Kconfig.firmware_loader"
 
@@ -1012,24 +1018,6 @@ endif # BOOT_DECOMPRESSION
 
 endif # BOOT_DECOMPRESSION_SUPPORT
 
-menu "Defaults"
-	# Items in this menu should not be manually set. These options are for modules/sysbuild to
-	# set as defaults to allow MCUboot's default configuration to be set, but still allow it
-	# to be overridden by users.
-
-config BOOT_FIH_PROFILE_DEFAULT_LOW
-	bool "Default to low fault inject hardening level"
-
-config BOOT_FIH_PROFILE_DEFAULT_MEDIUM
-	bool "Default to medium fault inject hardening level"
-
-config BOOT_FIH_PROFILE_DEFAULT_HIGH
-	bool "Default to high fault inject hardening level"
-
-endmenu
-
-endmenu
-
 config MCUBOOT_STORAGE_WITHOUT_ERASE
 	bool "Support for devices without erase"
 	depends on FLASH_HAS_NO_EXPLICIT_ERASE
@@ -1053,7 +1041,8 @@ config MCUBOOT_STORAGE_WITH_ERASE
 	  Support for devices with erase
 
 config MCUBOOT_STORAGE_MINIMAL_SCRAMBLE
-	bool "Do minimal required work to remove data (EXPERIMENTAL)"
+	bool "Do minimal required work to remove data [EXPERIMENTAL]"
+	select EXPERIMENTAL
 	help
 	  In some cases MCUboot has to remove data, which usually means make
 	  it non-viable for MCUboot rather then completely destroyed.
@@ -1067,6 +1056,22 @@ config MCUBOOT_STORAGE_MINIMAL_SCRAMBLE
 	  data from slot to not recognize it as image anymore.
 	  Depending on type of device this may be done by erase of minimal
 	  number of pages or overwrite of part of image.
+
+menu "Defaults"
+	# Items in this menu should not be manually set. These options are for modules/sysbuild to
+	# set as defaults to allow MCUboot's default configuration to be set, but still allow it
+	# to be overridden by users.
+
+config BOOT_FIH_PROFILE_DEFAULT_LOW
+	bool "Default to low fault inject hardening level"
+
+config BOOT_FIH_PROFILE_DEFAULT_MEDIUM
+	bool "Default to medium fault inject hardening level"
+
+config BOOT_FIH_PROFILE_DEFAULT_HIGH
+	bool "Default to high fault inject hardening level"
+
+endmenu
 
 config MCUBOOT_DEVICE_SETTINGS
 	# Hidden selector for device-specific settings
@@ -1083,6 +1088,8 @@ config MCUBOOT_DEVICE_CPU_CORTEX_M0
 	# Hidden selector for Cortex-M0 settings
 	bool
 	select SW_VECTOR_RELAY if !CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP
+
+endmenu
 
 comment "Zephyr configuration options"
 


### PR DESCRIPTION
Fixes issues with Kconfigs being placed outside of the MCUboot group and not selecting experimental symbols. Also fixes ordering to place USB DFU into a menu rather than being all over the place