### PR TITLE
zephyr: nRF54l15_cpuapp configuration with LTO enabled

### DIFF
--- a/boot/zephyr/socs/nrf54l15_cpuapp.conf
+++ b/boot/zephyr/socs/nrf54l15_cpuapp.conf
@@ -1,0 +1,3 @@
+# Link Time Optimizations
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+CONFIG_LTO=y


### PR DESCRIPTION
Enable LTO to cut down the MCUboot size for nrf54l15