### PR TITLE
Bootutil: always initialise the size returned by boot_util_image_size()

### DIFF
--- a/boot/bootutil/src/swap_offset.c
+++ b/boot/bootutil/src/swap_offset.c
@@ -752,6 +752,9 @@ int boot_read_image_size(struct boot_loader_state *state, int slot, uint32_t *si
 
     fap = BOOT_IMG_AREA(state, slot);
     assert(fap != NULL);
+    assert(size != NULL);
+
+    *size = 0;
 
     off = BOOT_TLV_OFF(boot_img_hdr(state, slot));
 


### PR DESCRIPTION
Assert on the pointer validity in debug builds and make sure that an initialised value of 0 is always returned even in case of errors.

This is useful to silence _potentially uninitialised_ warnings.
