### PR TITLE
imgtool: fix verify tlv offset before main scan

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -843,7 +843,7 @@ class Image:
             tlv_off += TLV_SIZE + tlv_len
 
         digest = None
-        tlv_off = header_size + img_size
+        tlv_off = prot_tlv_size
         tlv_end = tlv_off + tlv_tot
         tlv_off += TLV_INFO_SIZE  # skip tlv info
         while tlv_off < tlv_end:


### PR DESCRIPTION
After #2063 the imgtool verify fails to validate an image signed with a previous imgtool version.

The PR corrects `tlv_off` by accounting for protected TLVs found before the main scan.

Fixes #2302.