### PR TITLE
boot/zephyr/main: fix placement of pointer to arm vector

### DIFF
--- a/.github/workflows/zephyr_build.yaml
+++ b/.github/workflows/zephyr_build.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Zephyr
         working-directory: repos/zephyr
         run: |
-          west config --system manifest.project-filter -- -.*,+cmsis,+hal_nordic,+hal_nxp,+hal_stm32,+libmetal,+littlefs,+mbedtls,+mcuboot,+open-amp,+picolibc,+segger,+tinycrypt,+trusted-firmware-m,+zcbor
+          west config --system manifest.project-filter -- -.*,+cmsis,+cmsis_6,+hal_nordic,+hal_nxp,+hal_stm32,+libmetal,+littlefs,+mbedtls,+mcuboot,+open-amp,+picolibc,+segger,+tinycrypt,+trusted-firmware-m,+zcbor
           west init -l .
           west update
 

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -147,7 +147,10 @@ struct arm_vector_table {
 
 static void do_boot(struct boot_rsp *rsp)
 {
-    struct arm_vector_table *vt;
+    /* vt is static as it shall not land on the stack,
+     * as this procedure modifies stack pointer before usage of *vt
+     */
+    static struct arm_vector_table *vt;
 
     /* The beginning of the image is the ARM vector table, containing
      * the initial stack pointer address and the reset vector


### PR DESCRIPTION
pointer to the image ARM vector table should be placed out of stack which is being reconfigured before vt is used for branch to the application. This caused transient boot failure when CONFIG_LTO=y.

Moved vt to static data scope.

fixes #2307