### PR TITLE
Allow bypasing signature hash key matching

### DIFF
--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -278,6 +278,8 @@ bootutil_img_hash(struct boot_loader_state *state,
 #   define KEY_BUF_SIZE         (SIG_BUF_SIZE + 24)
 #endif /* !MCUBOOT_HW_KEY */
 
+#if !defined(MCUBOOT_BYPASS_KEY_MATCH)
+/* Find functions are only needed when key is checked first */
 #if !defined(MCUBOOT_HW_KEY)
 static int
 bootutil_find_key(uint8_t *keyhash, uint8_t keyhash_len)
@@ -347,6 +349,18 @@ bootutil_find_key(uint8_t image_index, uint8_t *key, uint16_t key_len)
 #endif /* !MCUBOOT_HW_KEY */
 #endif /* !MCUBOOT_BUILTIN_KEY */
 #endif /* EXPECTED_SIG_TLV */
+#else  /* !MCUBOOT_BYPASS_KEY_MATCH */
+static inline int
+bootutil_find_key(uint8_t image_index, uint8_t *key, uint16_t key_len)
+{
+    (void)image_index;
+    (void)key;
+    (void)key_len;
+
+    /* There is only one key, so it always matches */
+    return 0;
+}
+#endif /* !MCUBOOT_BYPASS_KEY_MATCH */
 
 /**
  * Reads the value of an image's security counter.

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -325,6 +325,19 @@ endif
 
 endchoice
 
+config BOOT_BYPASS_KEY_MATCH
+	bool "Do not match TLV key hash against built in key"
+	depends on !BOOT_SIGNATURE_TYPE_NONE
+	depends on !BOOT_HW_KEY
+	help
+	  MCUboot reads, from TLV, hash of a key that should be used to verify
+	  a signature and uses it to find a builtin key.
+	  This action is pointless when there is single key compiled in,
+	  as the signature verification process will just fail if that is not
+	  the right key.
+	  Enabling this option turns off key matching, slightly reducing
+	  MCUboot code and boot time.
+
 config BOOT_SIGNATURE_KEY_FILE
 	string "PEM key file"
 	default "root-ec-p256.pem" if BOOT_SIGNATURE_TYPE_ECDSA_P256

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -164,6 +164,15 @@
 #define MCUBOOT_HMAC_SHA512
 #endif
 
+/* Turn off check of public key hash against compiled in key
+ * before attempting signature verification. When there is only
+ * one key, matching is pointless, the signature may just be
+ * verified with the only key that there is.
+ */
+#ifdef CONFIG_BOOT_BYPASS_KEY_MATCH
+#define MCUBOOT_BYPASS_KEY_MATCH
+#endif
+
 #ifdef CONFIG_BOOT_DECOMPRESSION
 #define MCUBOOT_DECOMPRESS_IMAGES
 #endif


### PR DESCRIPTION
Currently MCUboot checks whether key hash in TLV matches any known builtin public keys.
When only one key in compiled in, most cases, then this match is pointless as image signature verification will just verify validity of the key anyway.
The PR adds MCUBOOT_BYPASS_KEY_MATCH option that allows to turn of the key matching and slightly reduces the binary size.