### PR TITLE
boot: zephyr: update NXP MPU define to new name

### DIFF
--- a/boot/zephyr/arm_cleanup.c
+++ b/boot/zephyr/arm_cleanup.c
@@ -7,7 +7,7 @@
 #include <zephyr/toolchain.h>
 
 #include <cmsis_core.h>
-#if CONFIG_CPU_HAS_NXP_MPU
+#if CONFIG_CPU_HAS_NXP_SYSMPU
 #include <fsl_sysmpu.h>
 #endif
 
@@ -38,7 +38,7 @@ __weak void z_arm_clear_arm_mpu_config(void)
 		ARM_MPU_ClrRegion(i);
 	}
 }
-#elif CONFIG_CPU_HAS_NXP_MPU
+#elif CONFIG_CPU_HAS_NXP_SYSMPU
 __weak void z_arm_clear_arm_mpu_config(void)
 {
 	int i;

--- a/boot/zephyr/include/arm_cleanup.h
+++ b/boot/zephyr/include/arm_cleanup.h
@@ -13,7 +13,7 @@
  */
 void cleanup_arm_nvic(void);
 
-#if defined(CONFIG_CPU_HAS_ARM_MPU) || defined(CONFIG_CPU_HAS_NXP_MPU)
+#if defined(CONFIG_CPU_HAS_ARM_MPU) || defined(CONFIG_CPU_HAS_NXP_SYSMPU)
 /**
  * Cleanup all ARM MPU region configuration
  */

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -192,7 +192,7 @@ static void do_boot(struct boot_rsp *rsp)
     sys_cache_data_disable();
 #endif
 
-#if CONFIG_CPU_HAS_ARM_MPU || CONFIG_CPU_HAS_NXP_MPU
+#if CONFIG_CPU_HAS_ARM_MPU || CONFIG_CPU_HAS_NXP_SYSMPU
     z_arm_clear_arm_mpu_config();
 #endif
 


### PR DESCRIPTION
Zephyr 4.1 changes `CONFIG_CPU_HAS_NXP_MPU` to `CONFIG_CPU_HAS_NXP_SYSMPU`. This change reflects that.

Relates to https://github.com/mcu-tools/mcuboot/issues/2332