### PR TITLE
bootutil: Fix boot_scramble_region escaping flash area

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1274,7 +1274,7 @@ boot_scramble_region(const struct flash_area *fa, uint32_t off, uint32_t size, b
             end_offset = ALIGN_DOWN((off + size), write_block);
         }
 
-        while (true) {
+        while (off != end_offset) {
             /* Write over the area to scramble data that is there */
             rc = flash_area_write(fa, off, buf, write_block);
             if (rc != 0) {
@@ -1291,12 +1291,12 @@ boot_scramble_region(const struct flash_area *fa, uint32_t off, uint32_t size, b
 
                 off -= write_block;
             } else {
-                if (end_offset < off) {
+                off += write_block;
+
+                if (end_offset <= off) {
                     /* Reached the end offset in range and already scrambled it */
                     break;
                 }
-
-                off += write_block;
             }
         }
     }

--- a/docs/release-notes.d/fix-boot-scramble-region.md
+++ b/docs/release-notes.d/fix-boot-scramble-region.md
@@ -1,0 +1,3 @@
+ - Fixed issue in boot_scramble_regions, where incorrect boundary
+   check would cause function to attempt to write pass a designated
+   flash area.


### PR DESCRIPTION
Incorrect range check fix.