### PR TITLE
bootutil: Remove duplicate definitions

### DIFF
--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -469,8 +469,6 @@ boot_img_slot_off(struct boot_loader_state *state, size_t slot)
     return flash_area_get_off(BOOT_IMG_AREA(state, slot));
 }
 
-#ifndef MCUBOOT_USE_FLASH_AREA_GET_SECTORS
-
 static inline size_t
 boot_img_sector_size(const struct boot_loader_state *state,
                      size_t slot, size_t sector)
@@ -489,25 +487,6 @@ boot_img_sector_off(const struct boot_loader_state *state, size_t slot,
     return flash_area_get_off(&BOOT_IMG(state, slot).sectors[sector]) -
            flash_area_get_off(&BOOT_IMG(state, slot).sectors[0]);
 }
-
-#else  /* defined(MCUBOOT_USE_FLASH_AREA_GET_SECTORS) */
-
-static inline size_t
-boot_img_sector_size(const struct boot_loader_state *state,
-                     size_t slot, size_t sector)
-{
-    return flash_sector_get_size(&BOOT_IMG(state, slot).sectors[sector]);
-}
-
-static inline uint32_t
-boot_img_sector_off(const struct boot_loader_state *state, size_t slot,
-                    size_t sector)
-{
-    return flash_sector_get_off(&BOOT_IMG(state, slot).sectors[sector]) -
-           flash_sector_get_off(&BOOT_IMG(state, slot).sectors[0]);
-}
-
-#endif  /* !defined(MCUBOOT_USE_FLASH_AREA_GET_SECTORS) */
 
 #ifdef MCUBOOT_RAM_LOAD
 #   ifdef __BOOTSIM__


### PR DESCRIPTION
Removed duplicate definitions of boot_img_sector_size and boot_img_sector_off.