### PR TITLE
Logical sectors

### DIFF
--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -221,7 +221,9 @@ struct boot_loader_state {
     struct {
         struct image_header hdr;
         const struct flash_area *area;
+#if !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0
         boot_sector_t *sectors;
+#endif
         uint32_t num_sectors;
 #if defined(MCUBOOT_SWAP_USING_OFFSET)
         uint16_t unprotected_tlv_size;
@@ -231,7 +233,9 @@ struct boot_loader_state {
 #if MCUBOOT_SWAP_USING_SCRATCH
     struct {
         const struct flash_area *area;
+#if !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0
         boot_sector_t *sectors;
+#endif
         uint32_t num_sectors;
     } scratch;
 #endif
@@ -469,6 +473,7 @@ boot_img_slot_off(struct boot_loader_state *state, size_t slot)
     return flash_area_get_off(BOOT_IMG_AREA(state, slot));
 }
 
+#if !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0
 #ifndef MCUBOOT_USE_FLASH_AREA_GET_SECTORS
 
 static inline size_t
@@ -508,6 +513,32 @@ boot_img_sector_off(const struct boot_loader_state *state, size_t slot,
 }
 
 #endif  /* !defined(MCUBOOT_USE_FLASH_AREA_GET_SECTORS) */
+#else
+static inline size_t
+boot_img_sector_size(const struct boot_loader_state *state,
+                     size_t slot, size_t sector)
+{
+    (void)state;
+    (void)slot;
+    (void)sector;
+
+    return MCUBOOT_LOGICAL_SECTOR_SIZE;
+}
+
+/*
+ * Offset of the sector from the beginning of the image, NOT the flash
+ * device.
+ */
+static inline uint32_t
+boot_img_sector_off(const struct boot_loader_state *state, size_t slot,
+                    size_t sector)
+{
+    (void)state;
+    (void)slot;
+
+    return MCUBOOT_LOGICAL_SECTOR_SIZE * sector;
+}
+#endif
 
 #ifdef MCUBOOT_RAM_LOAD
 #   ifdef __BOOTSIM__

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -460,6 +460,7 @@ boot_write_status(const struct boot_loader_state *state, struct boot_status *bs)
 #endif /* !MCUBOOT_DIRECT_XIP */
 
 #if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)
+#if !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0
 static fih_ret
 split_image_check(struct image_header *app_hdr,
                   const struct flash_area *app_fap,
@@ -490,6 +491,7 @@ split_image_check(struct image_header *app_hdr,
 out:
     FIH_RET(fih_rc);
 }
+#endif /* !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0 */
 #endif /* !MCUBOOT_DIRECT_XIP && !MCUBOOT_RAM_LOAD */
 
 #if defined(MCUBOOT_DIRECT_XIP)
@@ -1695,10 +1697,12 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
 
     BOOT_LOG_DBG("context_boot_go");
 
+#if !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0
 #if defined(__BOOTSIM__)
     struct boot_sector_buffer sector_buf;
     sectors = &sector_buf;
 #endif
+#endif /* !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0 */
 
     has_upgrade = false;
 
@@ -1958,6 +1962,7 @@ out:
     FIH_RET(fih_rc);
 }
 
+#if !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0
 fih_ret
 split_go(int loader_slot, int split_slot, void **entry)
 {
@@ -2023,6 +2028,7 @@ done:
 
     FIH_RET(fih_rc);
 }
+#endif /* !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0 */
 
 #else /* MCUBOOT_DIRECT_XIP || MCUBOOT_RAM_LOAD */
 

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1264,6 +1264,27 @@ config BOOT_FIH_PROFILE_DEFAULT_HIGH
 
 endmenu
 
+config MCUBOOT_LOGICAL_SECTOR_SIZE
+	int "Size of a logical sector"
+	default 0
+	help
+	  Set to 0 to use hardware sectors. Any other value here should be
+	  aligned to hardware sectors in size and alignment.
+
+config MCUBOOT_LOGICAL_SECTOR_SIZE_SET
+	bool
+	default y
+	depends on MCUBOOT_LOGICAL_SECTOR_SIZE != 0
+
+config MCUBOOT_VERIFY_LOGICAL_SECTORS
+	bool "Validate logical sector layout"
+	default y
+	depends on MCUBOOT_LOGICAL_SECTOR_SIZE_SET
+	help
+	  Validation of logical sector size against hardware constrains.
+	  Should be used to validate compile-time configuration against run-time
+	  system.
+
 config MCUBOOT_DEVICE_SETTINGS
 	# Hidden selector for device-specific settings
 	bool
@@ -1271,7 +1292,8 @@ config MCUBOOT_DEVICE_SETTINGS
         # CPU options
 	select MCUBOOT_DEVICE_CPU_CORTEX_M0 if CPU_CORTEX_M0
         # Enable flash page layout if available
-	select FLASH_PAGE_LAYOUT if FLASH_HAS_PAGE_LAYOUT
+	select FLASH_PAGE_LAYOUT if FLASH_HAS_PAGE_LAYOUT && !MCUBOOT_LOGICAL_SECTOR_SIZE_SET
+	select FLASH_PAGE_LAYOUT if FLASH_HAS_PAGE_LAYOUT && MCUBOOT_VERIFY_LOGICAL_SECTORS
 	# Enable flash_map module as flash I/O back-end
 	select FLASH_MAP
 

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -399,6 +399,27 @@
 #  endif
 #endif
 
+/* If set to non-0 it will use logical sectors rather than querying
+ * device for sector sizes. This slightly reduces code and RAM usage.
+ * Note that the logical sector size has to be multiple of erase
+ * sector size that is biggest for of all devices in the system.
+ */
+#if defined(CONFIG_MCUBOOT_LOGICAL_SECTOR_SIZE)
+#define MCUBOOT_LOGICAL_SECTOR_SIZE		CONFIG_MCUBOOT_LOGICAL_SECTOR_SIZE
+#endif
+
+/* Enable to validate compile time logical sector setup vs the real device layout.
+ * This increases the size of bootloader, but is useful to check whether
+ * selected logical sector size can be used with provided partitions
+ * and devices they are placed on.
+ * Once layout is tested, this option should be disabled for production
+ * devices, as it is pointless to re-validate non-changing setup on
+ * every MCUboot run.
+ */
+#if defined(CONFIG_MCUBOOT_VERIFY_LOGICAL_SECTORS)
+#define MCUBOOT_VERIFY_LOGICAL_SECTORS	1
+#endif
+
 #if defined(CONFIG_BOOT_MAX_IMG_SECTORS_AUTO) && defined(MIN_SECTOR_COUNT)
 
 #define MCUBOOT_MAX_IMG_SECTORS       MIN_SECTOR_COUNT

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -35,6 +35,7 @@ downgrade-prevention = ["mcuboot-sys/downgrade-prevention"]
 max-align-32 = ["mcuboot-sys/max-align-32"]
 hw-rollback-protection = ["mcuboot-sys/hw-rollback-protection"]
 check-load-addr = ["mcuboot-sys/check-load-addr"]
+logical-sectors-4k= ["mcuboot-sys/logical-sectors-4k"]
 
 [dependencies]
 byteorder = "1.4"

--- a/sim/mcuboot-sys/Cargo.toml
+++ b/sim/mcuboot-sys/Cargo.toml
@@ -93,6 +93,9 @@ downgrade-prevention = []
 # Support images with 32-byte maximum write alignment value.
 max-align-32 = []
 
+# Use logical sectors
+logical-sectors-4k = []
+
 # Enable hardware rollback protection
 hw-rollback-protection = []
 

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -40,6 +40,7 @@ fn main() {
     let max_align_32 = env::var("CARGO_FEATURE_MAX_ALIGN_32").is_ok();
     let hw_rollback_protection = env::var("CARGO_FEATURE_HW_ROLLBACK_PROTECTION").is_ok();
     let check_load_addr = env::var("CARGO_FEATURE_CHECK_LOAD_ADDR").is_ok();
+    let logical_sectors_4k = env::var("CARGO_FEATURE_LOGICAL_SECTORS_4K").is_ok();
 
     let mut conf = CachedBuild::new();
     conf.conf.define("__BOOTSIM__", None);
@@ -52,6 +53,10 @@ fn main() {
         conf.conf.define("MCUBOOT_BOOT_MAX_ALIGN", Some("32"));
     } else {
         conf.conf.define("MCUBOOT_BOOT_MAX_ALIGN", Some("8"));
+    }
+
+    if logical_sectors_4k {
+        conf.conf.define("MCUBOOT_LOGICAL_SECTOR_SIZE", Some("4096"));
     }
 
     conf.conf.define("MCUBOOT_IMAGE_NUMBER", Some(if multiimage { "2" } else { "1" }));


### PR DESCRIPTION
So far tested on nrf52840 with internal memory only.
Normal build from main, with hardware pages/sectors

```
Memory region         Used Size  Region Size  %age Used
           FLASH:       32716 B        48 KB     66.56%
             RAM:       22464 B       256 KB      8.57%
        IDT_LIST:          0 GB        32 KB      0.00%
```

Logical sectors ( -DCONFIG_MCUBOOT_LOGICAL_SECTOR_SIZE=4096 -DCONFIG_FLASH_PAGE_LAYOUT=n)
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       32188 B        48 KB     65.49%
             RAM:       20544 B       256 KB      7.84%
        IDT_LIST:          0 GB        32 KB      0.00%
```

Logical sectors validation build (-DCONFIG_MCUBOOT_LOGICAL_SECTOR_SIZE=4096 -DCONFIG_MCUBOOT_VERIFY_LOGICAL_SECTORS=y)
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       33452 B        48 KB     68.06%
             RAM:       20544 B       256 KB      7.84%
        IDT_LIST:          0 GB        32 KB      0.00%
```