### PR TITLE
imgtool: bump minimal required version to 2.2.0

### DIFF
--- a/zephyr/requirements.txt
+++ b/zephyr/requirements.txt
@@ -1,2 +1,2 @@
 cbor>=1.0.0
-imgtool>=2.1.0
+imgtool>=2.2.0


### PR DESCRIPTION
Making 2.2.0 the minimum required version of imgtool, to benefit from its numerous fixes.