### PR TITLE
Conditionally include crypto/common.h in ecdsa.h

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/ecdsa.h
+++ b/boot/bootutil/include/bootutil/crypto/ecdsa.h
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright (c) 2023-2024 Arm Limited
+ * Copyright (c) 2023-2025 Arm Limited
  */
 
 /*
@@ -68,7 +68,9 @@
 #include "mbedtls/oid.h"
 #include "mbedtls/asn1.h"
 #include "bootutil/sign_key.h"
-#include "common.h"
+#if !defined(MCUBOOT_USE_PSA_CRYPTO)
+#include "bootutil/crypto/common.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This is an Mbed TLS header including mbedtls/version.h which can cause build errors when the PSA Crypto backend is used with the TF-PSA-Crypto library.

Do not include crypto/common.h for builds with PSA Crypto (it is not even used).
