### PR TITLE
boot: zephyr: RAM cleanup debug loop

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -364,6 +364,13 @@ config MCUBOOT_CLEANUP_RAM
 	help
 	  Sets contents of memory to 0 before jumping to application.
 
+config MCUBOOT_INFINITE_LOOP_AFTER_RAM_CLEANUP
+	bool "Infinite loop after RAM cleanup"
+	depends on MCUBOOT_CLEANUP_RAM
+	help
+	  Verification option that keeps execution in infinite loop after
+	  RAM cleanup has been performed.
+
 config MBEDTLS_CFG_FILE
 	# It might be awkward to define an Mbed TLS header file when TinyCrypt
 	# is used, but the fact is that Mbed TLS' ASN1 parse module is used

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -249,6 +249,9 @@ static void do_boot(struct boot_rsp *rsp)
         "   b       clear\n"
         "out:\n"
         "   dsb\n"
+#if CONFIG_MCUBOOT_INFINITE_LOOP_AFTER_RAM_CLEANUP
+        "   b       out\n"
+#endif /*CONFIG_MCUBOOT_INFINITE_LOOP_AFTER_RAM_CLEANUP */
         /* jump to reset vector of an app */
         "   bx      r0\n"
         :


### PR DESCRIPTION
Option to put execution in infinite loop.
Meant to be used for debug.