### PR TITLE
boot: bootutil: declare fih_panic_loop() as noreturn

### DIFF
--- a/boot/bootutil/include/bootutil/fault_injection_hardening.h
+++ b/boot/bootutil/include/bootutil/fault_injection_hardening.h
@@ -137,7 +137,7 @@ extern fih_ret FIH_BOOT_HOOK_REGULAR;
 /* Global failure handler - more resistant to unlooping. noinline and used are
  * used to prevent optimization
  */
-__attribute__((noinline)) __attribute__((used))
+__attribute__((noinline)) __attribute__((used)) __attribute__((noreturn))
 void fih_panic_loop(void);
 #define FIH_PANIC fih_panic_loop()
 #else

--- a/boot/bootutil/src/fault_injection_hardening.c
+++ b/boot/bootutil/src/fault_injection_hardening.c
@@ -63,6 +63,7 @@ void fih_cfi_decrement(void)
  */
 __attribute__((used))
 __attribute__((noinline))
+__attribute__((noreturn))
 void fih_panic_loop(void)
 {
     __asm volatile ("b fih_panic_loop");
@@ -74,5 +75,10 @@ void fih_panic_loop(void)
     __asm volatile ("b fih_panic_loop");
     __asm volatile ("b fih_panic_loop");
     __asm volatile ("b fih_panic_loop");
+
+    /* An infinite loop to suppress compiler warnings
+     * about the return of a noreturn function
+     */
+    while (1) {}
 }
 #endif /* FIH_ENABLE_GLOBAL_FAIL */


### PR DESCRIPTION
Add `noreturn` attribute the `fih_panic_loop()` and add a terminal endless loop in the function to prevent build warnings like the below one found when build MCUBOOT in TF-M:
```
.../arm-none-eabi/include/assert.h: In function '__assert_func':
.../trusted-firmware-m/platform/ext/common/tfm_assert.c:22:1: warning: 'noreturn' function does return
   22 | }
      | ^
```