### PR TITLE
zephyr: Add zephyr samples folder to list of samples

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -7,3 +7,5 @@ package-managers:
   pip:
     requirement-files:
       - zephyr/requirements.txt
+samples:
+  - boot/zephyr


### PR DESCRIPTION
Makes this sample path listed in the zephyr module file