### PR TITLE
zephyr: boards: nrf54h20dk: disable power domains

### DIFF
--- a/boot/zephyr/boards/nrf54h20dk_nrf54h20_cpuapp_iron.conf
+++ b/boot/zephyr/boards/nrf54h20dk_nrf54h20_cpuapp_iron.conf
@@ -7,3 +7,7 @@
 CONFIG_SPI_NOR=n
 
 CONFIG_BOOT_WATCHDOG_FEED=n
+
+# Power domains forced on by default on boot, no need
+# to manage them in bootloader.
+CONFIG_POWER_DOMAIN=n

--- a/boot/zephyr/boards/nrf54h20dk_nrf54h20_cpuapp_iron.overlay
+++ b/boot/zephyr/boards/nrf54h20dk_nrf54h20_cpuapp_iron.overlay
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&gdpwr {
+	status = "disabled";
+};
+
+&gdpwr_fast_active_0 {
+	status = "disabled";
+};
+
+&gdpwr_fast_active_1 {
+	status = "disabled";
+};
+
+&gdpwr_fast_main {
+	status = "disabled";
+};
+
+&gdpwr_slow_active {
+	status = "disabled";
+};
+
+&gdpwr_slow_main {
+	status = "disabled";
+};
+
+&gpio_pad_group0 {
+	status = "disabled";
+};
+
+&gpio_pad_group1 {
+	status = "disabled";
+};
+
+&gpio_pad_group2 {
+	status = "disabled";
+};
+
+&gpio_pad_group6 {
+	status = "disabled";
+};
+
+&gpio_pad_group7 {
+	status = "disabled";
+};
+
+&gpio_pad_group9 {
+	status = "disabled";
+};


### PR DESCRIPTION
The nrf54h20 power domains are forced on at boot, no need to enable them or their drivers unless they are to be managed further within the bootloader.

Aligns with https://github.com/zephyrproject-rtos/zephyr/pull/90754