### PR TITLE
zephyr: Enable building ECDSA PSA variant

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -180,7 +180,10 @@ else()
 endif()
 
 if(CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256 OR CONFIG_BOOT_ENCRYPT_EC256)
-  if(MBEDTLS_ASN1_DIR)
+  # When ECDSA PSA is used, do not pull in additional ASN.1 include
+  # directories or sources, as it would cause incorrect header files
+  # to be included.
+  if(MBEDTLS_ASN1_DIR AND NOT CONFIG_BOOT_ECDSA_PSA)
     zephyr_library_include_directories(
       ${MBEDTLS_ASN1_DIR}/include
     )

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -113,6 +113,14 @@ config BOOT_X25519_PSA_DEPENDENCIES
 
 endif # BOOT_ENCRYPT_IMAGE
 
+config BOOT_ECDSA_PSA_DEPENDENCIES
+	bool
+	select PSA_WANT_ALG_ECDSA
+	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_IMPORT
+	select PSA_WANT_ECC_SECP_R1_256
+	help
+	  Dependencies for ECDSA signature
+
 if MBEDTLS_ENABLE_HEAP
 
 config MBEDTLS_HEAP_SIZE
@@ -282,6 +290,16 @@ config BOOT_ECDSA_CC310
 	select NRF_CC310_BL
 	select NRFXLIB_CRYPTO
 	select BOOT_USE_CC310
+
+config BOOT_ECDSA_PSA
+	bool "Use psa cryptoo"
+	select BOOT_USE_PSA_CRYPTO
+	select PSA_CRYPTO_CLIENT
+	select PSA_CRYPTO_C
+	select BOOT_IMG_HASH_ALG_SHA256_ALLOW
+	select BOOT_IMG_HASH_ALG_SHA512_ALLOW
+	select BOOT_ECDSA_PSA_DEPENDENCIES
+
 endchoice # Ecdsa implementation
 endif
 


### PR DESCRIPTION
Adds Kconfig option CONFIG_BOOT_ECDSA_PSA that allows to switch ECDSA to PSA backend.