### PR TITLE
Fix HMAC-SHA512 for ECIES-X25519

### DIFF
--- a/boot/bootutil/src/encrypted_psa.c
+++ b/boot/bootutil/src/encrypted_psa.c
@@ -43,7 +43,11 @@ static const uint8_t ec_pubkey_oid[] = MBEDTLS_OID_ISO_IDENTIFIED_ORG \
 #define HKDF_AES_KEY_SIZE   (BOOT_ENC_KEY_SIZE)
 /* MAC feed */
 #define HKDF_MAC_FEED_INDEX (HKDF_AES_KEY_INDEX + HKDF_AES_KEY_SIZE)
-#define HKDF_MAC_FEED_SIZE  (32)    /* This is SHA independent */
+#if !defined(MCUBOOT_HMAC_SHA512)
+#define HKDF_MAC_FEED_SIZE  (32)
+#else
+#define HKDF_MAC_FEED_SIZE  (64)
+#endif
 /* Total size */
 #define HKDF_SIZE           (HKDF_AES_KEY_SIZE + HKDF_MAC_FEED_SIZE)
 

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -445,7 +445,7 @@ class Image:
             newpk = X25519PrivateKey.generate()
             shared = newpk.exchange(enckey._get_public())
         derived_key = HKDF(
-            algorithm=hmac_sha_alg, length=48, salt=None,
+            algorithm=hmac_sha_alg, length=16 + hmac_sha_alg.digest_size, salt=None,
             info=b'MCUBoot_ECIES_v1', backend=default_backend()).derive(shared)
         encryptor = Cipher(algorithms.AES(derived_key[:16]),
                            modes.CTR(bytes([0] * 16)),


### PR DESCRIPTION
HMAC-SHA512 used for MAC tagging encryption key has been incorrectly fed only 32 bytes for password.