### PR TITLE
boot: zephyr: adjust sample.yaml to pass USB deprecation process

### DIFF
--- a/boot/zephyr/sample.yaml
+++ b/boot/zephyr/sample.yaml
@@ -49,19 +49,20 @@ tests:
     tags: bootloader_mcuboot
   sample.bootloader.mcuboot.usb_cdc_acm_recovery:
     tags: bootloader_mcuboot
-    platform_allow:  nrf52840dongle/nrf52840
+    platform_allow: nrf52840dongle/nrf52840
     extra_args:
       - EXTRA_CONF_FILE=./usb_cdc_acm_recovery.conf
       - DTC_OVERLAY_FILE="./usb_cdc_acm.overlay;app.overlay"
-    integration_platforms:
-      - nrf52840dongle/nrf52840
+    extra_configs:
+      - CONFIG_DEPRECATION_TEST=y
   sample.bootloader.mcuboot.usb_cdc_acm_recovery_log:
-    extra_args: EXTRA_CONF_FILE=./usb_cdc_acm_log_recovery.conf
-      DTC_OVERLAY_FILE="./boards/nrf52840_big.overlay;app.overlay"
-    platform_allow:  nrf52840dk/nrf52840
-    integration_platforms:
-      - nrf52840dk/nrf52840
     tags: bootloader_mcuboot
+    platform_allow: nrf52840dk/nrf52840
+    extra_args:
+      - EXTRA_CONF_FILE=./usb_cdc_acm_log_recovery.conf
+      - DTC_OVERLAY_FILE="./boards/nrf52840_big.overlay;app.overlay"
+    extra_configs:
+      - CONFIG_DEPRECATION_TEST=y
   sample.bootloader.mcuboot.single_slot:
     extra_args: EXTRA_CONF_FILE=./single_slot.conf
       DTC_OVERLAY_FILE="./boards/nrf52840_single_slot.overlay;app.overlay"


### PR DESCRIPTION
The legacy USB device stack is in the process of being deprecated. In order to pass CI in the Zephyr Project, we need to adjust the test case settings in sample.yaml. Clean up both test cases and add a Kconfig option that allows them to pass Twitter runs despite deprecation warnings and flash overflows.

Exact as https://github.com/zephyrproject-rtos/mcuboot/pull/131