### PR TITLE
boot: zephyr: Fix including asn1 when ed25519 is used

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -281,8 +281,13 @@ elseif(CONFIG_BOOT_SIGNATURE_TYPE_ED25519 OR CONFIG_BOOT_ENCRYPT_X25519)
       ${FIAT_DIR}/src/curve25519.c
     )
   else()
+    if(MBEDTLS_ASN1_DIR)
+      zephyr_library_sources(
+        ${MBEDTLS_ASN1_DIR}/src/asn1parse.c
+      )
+    endif()
+
     zephyr_library_sources(
-      ${MBEDTLS_ASN1_DIR}/src/asn1parse.c
       ${BOOT_DIR}/bootutil/src/ed25519_psa.c
     )
   endif()


### PR DESCRIPTION
Fixes wrongly including the asn1 MBEDTLS file when the Kconfig is set to not include it