### PR TITLE
boot: zephyr: board: nrf54h20: Enable PM by default

### DIFF
--- a/boot/zephyr/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/boot/zephyr/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -11,3 +11,6 @@ CONFIG_BOOT_WATCHDOG_FEED=n
 # Power domains forced on by default on boot, no need
 # to manage them in bootloader.
 CONFIG_POWER_DOMAIN=n
+
+# Enable PM to support booting images that have suspend to RAM enabled
+CONFIG_PM=y


### PR DESCRIPTION
Enables PM to support booting images with the suspend to RAM feature enabled
    
