### PR TITLE
boot: zephyr: boards: nrf54h20dk cpuapp add chosen code part

### DIFF
--- a/boot/zephyr/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/boot/zephyr/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};
+
 &gdpwr {
 	status = "disabled";
 };


### PR DESCRIPTION
Add the required zephyr,code-partition which is typically included by the common app.overlay to the nrf54h20dk_nrf54h20_cpuapp board overlay.