### PR TITLE
bootutil: Move primary/secondary slot definition to bootutil_public - enum

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -331,7 +331,7 @@ bs_list(struct boot_loader_state *state, char *buf, int len)
             }
 
 #ifdef MCUBOOT_SWAP_USING_OFFSET
-            if (slot == BOOT_SECONDARY_SLOT && swap_status != BOOT_SWAP_TYPE_REVERT) {
+            if (slot == BOOT_SLOT_SECONDARY && swap_status != BOOT_SWAP_TYPE_REVERT) {
                 start_off = boot_img_sector_size(state, slot, 0);
                 state->secondary_offset[image_index] = start_off;
             }
@@ -401,25 +401,25 @@ bs_list(struct boot_loader_state *state, char *buf, int len)
 
 #ifdef MCUBOOT_SERIAL_IMG_GRP_IMAGE_STATE
             if (swap_status == BOOT_SWAP_TYPE_NONE) {
-                if (slot == BOOT_PRIMARY_SLOT) {
+                if (slot == BOOT_SLOT_PRIMARY) {
                     confirmed = true;
                     active = true;
                 }
             } else if (swap_status == BOOT_SWAP_TYPE_TEST) {
-                if (slot == BOOT_PRIMARY_SLOT) {
+                if (slot == BOOT_SLOT_PRIMARY) {
                     confirmed = true;
                 } else {
                     pending = true;
                 }
             } else if (swap_status == BOOT_SWAP_TYPE_PERM) {
-                if (slot == BOOT_PRIMARY_SLOT) {
+                if (slot == BOOT_SLOT_PRIMARY) {
                     confirmed = true;
                 } else {
                     pending = true;
                     permanent = true;
                 }
             } else if (swap_status == BOOT_SWAP_TYPE_REVERT) {
-                if (slot == BOOT_PRIMARY_SLOT) {
+                if (slot == BOOT_SLOT_PRIMARY) {
                     active = true;
                 } else {
                     confirmed = true;
@@ -551,7 +551,7 @@ bs_set(struct boot_loader_state *state, char *buf, int len)
                 }
 
 #ifdef MCUBOOT_SWAP_USING_OFFSET
-                if (slot == BOOT_SECONDARY_SLOT && swap_status != BOOT_SWAP_TYPE_REVERT) {
+                if (slot == BOOT_SLOT_SECONDARY && swap_status != BOOT_SWAP_TYPE_REVERT) {
                     start_off = boot_img_sector_size(state, slot, 0);
                     state->secondary_offset[image_index] = start_off;
                 }

--- a/boot/bootutil/include/bootutil/bootutil_public.h
+++ b/boot/bootutil/include/bootutil/bootutil_public.h
@@ -129,6 +129,14 @@ _Static_assert(MCUBOOT_BOOT_MAX_ALIGN >= 8 && MCUBOOT_BOOT_MAX_ALIGN <= 32,
                                                     (swap_info) = (image) << 4 \
                                                                 | (type);      \
                                                     }
+
+enum boot_slot {
+    BOOT_SLOT_PRIMARY = 0,      /* Primary slot */
+    BOOT_SLOT_SECONDARY = 1,    /* Secondary slot */
+    BOOT_SLOT_COUNT = 2,        /* Number of slots */
+    BOOT_SLOT_NONE = UINT32_MAX /* special value representing no active slot */
+};
+
 #ifdef MCUBOOT_HAVE_ASSERT_H
 #include "mcuboot_config/mcuboot_assert.h"
 #else

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -209,7 +209,7 @@ int boot_header_scramble_off_sz(const struct flash_area *fa, int slot, size_t *o
     /* In case of swap offset, header of secondary slot image is positioned
      * in second sector of slot.
      */
-    if (slot == BOOT_SECONDARY_SLOT) {
+    if (slot == BOOT_SLOT_SECONDARY) {
         ret = flash_area_get_sector(fa, 0, &sector);
         if (ret < 0) {
             return ret;
@@ -316,7 +316,7 @@ boot_find_status(const struct boot_loader_state *state, int image_index)
 #if MCUBOOT_SWAP_USING_SCRATCH
         state->scratch.area,
 #endif
-        state->imgs[image_index][BOOT_PRIMARY_SLOT].area,
+        state->imgs[image_index][BOOT_SLOT_PRIMARY].area,
     };
     unsigned int i;
 
@@ -470,7 +470,7 @@ boot_read_image_size(struct boot_loader_state *state, int slot, uint32_t *size)
     uint32_t protect_tlv_size;
     int rc;
 
-    assert(slot == BOOT_PRIMARY_SLOT || slot == BOOT_SECONDARY_SLOT);
+    assert(slot == BOOT_SLOT_PRIMARY || slot == BOOT_SLOT_SECONDARY);
 
     fap = BOOT_IMG_AREA(state, slot);
     assert(fap != NULL);
@@ -636,12 +636,12 @@ boot_initialize_area(struct boot_loader_state *state, int flash_area)
     num_sectors = BOOT_MAX_IMG_SECTORS;
 
     if (flash_area == FLASH_AREA_IMAGE_PRIMARY(BOOT_CURR_IMG(state))) {
-        out_sectors = BOOT_IMG(state, BOOT_PRIMARY_SLOT).sectors;
-        out_num_sectors = &BOOT_IMG(state, BOOT_PRIMARY_SLOT).num_sectors;
+        out_sectors = BOOT_IMG(state, BOOT_SLOT_PRIMARY).sectors;
+        out_num_sectors = &BOOT_IMG(state, BOOT_SLOT_PRIMARY).num_sectors;
 #if BOOT_NUM_SLOTS > 1
     } else if (flash_area == FLASH_AREA_IMAGE_SECONDARY(BOOT_CURR_IMG(state))) {
-        out_sectors = BOOT_IMG(state, BOOT_SECONDARY_SLOT).sectors;
-        out_num_sectors = &BOOT_IMG(state, BOOT_SECONDARY_SLOT).num_sectors;
+        out_sectors = BOOT_IMG(state, BOOT_SLOT_SECONDARY).sectors;
+        out_num_sectors = &BOOT_IMG(state, BOOT_SLOT_SECONDARY).num_sectors;
 #if MCUBOOT_SWAP_USING_SCRATCH
     } else if (flash_area == FLASH_AREA_IMAGE_SCRATCH) {
         out_sectors = state->scratch.sectors;
@@ -677,7 +677,7 @@ boot_write_sz(struct boot_loader_state *state)
      * on what the minimum write size is for scratch area, active image slot.
      * We need to use the bigger of those 2 values.
      */
-    elem_sz = flash_area_align(BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT));
+    elem_sz = flash_area_align(BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY));
 #if MCUBOOT_SWAP_USING_SCRATCH
     align = flash_area_align(BOOT_SCRATCH_AREA(state));
     if (align > elem_sz) {
@@ -700,10 +700,10 @@ boot_read_sectors(struct boot_loader_state *state, struct boot_sector_buffer *se
 
     image_index = BOOT_CURR_IMG(state);
 
-    BOOT_IMG(state, BOOT_PRIMARY_SLOT).sectors =
+    BOOT_IMG(state, BOOT_SLOT_PRIMARY).sectors =
         sectors->primary[image_index];
 #if BOOT_NUM_SLOTS > 1
-    BOOT_IMG(state, BOOT_SECONDARY_SLOT).sectors =
+    BOOT_IMG(state, BOOT_SLOT_SECONDARY).sectors =
         sectors->secondary[image_index];
 #if MCUBOOT_SWAP_USING_SCRATCH
     state->scratch.sectors = sectors->scratch;
@@ -780,10 +780,10 @@ void boot_fetch_slot_state_sizes(void)
 
         image_index = BOOT_CURR_IMG(boot_get_loader_state());
 
-        BOOT_IMG(boot_get_loader_state(), BOOT_PRIMARY_SLOT).sectors =
+        BOOT_IMG(boot_get_loader_state(), BOOT_SLOT_PRIMARY).sectors =
             sector_buffers.primary[image_index];
 #if BOOT_NUM_SLOTS > 1
-        BOOT_IMG(boot_get_loader_state(), BOOT_SECONDARY_SLOT).sectors =
+        BOOT_IMG(boot_get_loader_state(), BOOT_SLOT_SECONDARY).sectors =
             sector_buffers.secondary[image_index];
 #if MCUBOOT_SWAP_USING_SCRATCH
         boot_get_loader_state()->scratch.sectors = sector_buffers.scratch;

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -51,8 +51,6 @@ struct flash_area;
 
 #define BOOT_TMPBUF_SZ  256
 
-#define NO_ACTIVE_SLOT UINT32_MAX
-
 /** Number of image slots in flash; currently limited to two. */
 #if defined(MCUBOOT_SINGLE_APPLICATION_SLOT) || defined(MCUBOOT_SINGLE_APPLICATION_SLOT_RAM_LOAD)
 #define BOOT_NUM_SLOTS                  1
@@ -202,7 +200,7 @@ _Static_assert(sizeof(boot_img_magic) == BOOT_MAGIC_SZ, "Invalid size for image 
 
 #define BOOT_LOG_IMAGE_INFO(slot, hdr)                                    \
     BOOT_LOG_INF("%-9s slot: version=%u.%u.%u+%u",                        \
-                 ((slot) == BOOT_PRIMARY_SLOT) ? "Primary" : "Secondary", \
+                 ((slot) == BOOT_SLOT_PRIMARY) ? "Primary" : "Secondary", \
                  (hdr)->ih_ver.iv_major,                                  \
                  (hdr)->ih_ver.iv_minor,                                  \
                  (hdr)->ih_ver.iv_revision,                               \
@@ -221,9 +219,6 @@ _Static_assert(sizeof(boot_img_magic) == BOOT_MAGIC_SZ, "Invalid size for image 
 
 /** Maximum number of image sectors supported by the bootloader. */
 #define BOOT_STATUS_MAX_ENTRIES         BOOT_MAX_IMG_SECTORS
-
-#define BOOT_PRIMARY_SLOT               0
-#define BOOT_SECONDARY_SLOT             1
 
 #define BOOT_STATUS_SOURCE_NONE         0
 #define BOOT_STATUS_SOURCE_SCRATCH      1

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -213,7 +213,7 @@ fill_rsp(struct boot_loader_state *state, struct boot_rsp *rsp)
 #if defined(MCUBOOT_DIRECT_XIP) || defined(MCUBOOT_RAM_LOAD)
     active_slot = state->slot_usage[BOOT_CURR_IMG(state)].active_slot;
 #else
-    active_slot = BOOT_PRIMARY_SLOT;
+    active_slot = BOOT_SLOT_PRIMARY;
 #endif
 
     rsp->br_flash_dev_id = flash_area_get_device_id(BOOT_IMG_AREA(state, active_slot));
@@ -315,18 +315,18 @@ boot_verify_slot_dependency(struct boot_loader_state *state,
      * the dependency and get it's version. */
 #if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)
     uint8_t swap_type = state->swap_type[dep->image_id];
-    dep_slot = BOOT_IS_UPGRADE(swap_type) ? BOOT_SECONDARY_SLOT
-                                          : BOOT_PRIMARY_SLOT;
+    dep_slot = BOOT_IS_UPGRADE(swap_type) ? BOOT_SLOT_SECONDARY
+                                          : BOOT_SLOT_PRIMARY;
 #elif defined(MCUBOOT_VERSION_CMP_USE_SLOT_NUMBER)
     switch(dep->slot) {
         case VERSION_DEP_SLOT_ACTIVE:
             dep_slot = state->slot_usage[dep->image_id].active_slot;
             break;
         case VERSION_DEP_SLOT_PRIMARY:
-            dep_slot = BOOT_PRIMARY_SLOT;
+            dep_slot = BOOT_SLOT_PRIMARY;
             break;
         case VERSION_DEP_SLOT_SECONDARY:
-            dep_slot = BOOT_SECONDARY_SLOT;
+            dep_slot = BOOT_SLOT_SECONDARY;
             break;
         default:
             return -1;
@@ -376,14 +376,14 @@ boot_verify_slot_dependency(struct boot_loader_state *state,
     if (rc == 0) {
         switch(dep->slot) {
             case VERSION_DEP_SLOT_PRIMARY:
-                state->slot_usage[dep->image_id].slot_available[BOOT_PRIMARY_SLOT] = true;
-                state->slot_usage[dep->image_id].slot_available[BOOT_SECONDARY_SLOT] = false;
-                state->slot_usage[dep->image_id].active_slot = BOOT_PRIMARY_SLOT;
+                state->slot_usage[dep->image_id].slot_available[BOOT_SLOT_PRIMARY] = true;
+                state->slot_usage[dep->image_id].slot_available[BOOT_SLOT_SECONDARY] = false;
+                state->slot_usage[dep->image_id].active_slot = BOOT_SLOT_PRIMARY;
                 break;
             case VERSION_DEP_SLOT_SECONDARY:
-                state->slot_usage[dep->image_id].slot_available[BOOT_PRIMARY_SLOT] = false;
-                state->slot_usage[dep->image_id].slot_available[BOOT_SECONDARY_SLOT] = true;
-                state->slot_usage[dep->image_id].active_slot = BOOT_SECONDARY_SLOT;
+                state->slot_usage[dep->image_id].slot_available[BOOT_SLOT_PRIMARY] = false;
+                state->slot_usage[dep->image_id].slot_available[BOOT_SLOT_SECONDARY] = true;
+                state->slot_usage[dep->image_id].active_slot = BOOT_SLOT_SECONDARY;
                 break;
             case VERSION_DEP_SLOT_ACTIVE:
             default:
@@ -414,9 +414,9 @@ boot_verify_dependencies(struct boot_loader_state *state)
         }
         if (BOOT_SWAP_TYPE(state) != BOOT_SWAP_TYPE_NONE &&
             BOOT_SWAP_TYPE(state) != BOOT_SWAP_TYPE_FAIL) {
-            slot = BOOT_SECONDARY_SLOT;
+            slot = BOOT_SLOT_SECONDARY;
         } else {
-            slot = BOOT_PRIMARY_SLOT;
+            slot = BOOT_SLOT_PRIMARY;
         }
 
         rc = boot_verify_slot_dependencies(state, slot);
@@ -467,7 +467,7 @@ boot_verify_dependencies(struct boot_loader_state *state)
 #endif /* MCUBOOT_RAM_LOAD */
 
             state->slot_usage[BOOT_CURR_IMG(state)].slot_available[active_slot] = false;
-            state->slot_usage[BOOT_CURR_IMG(state)].active_slot = NO_ACTIVE_SLOT;
+            state->slot_usage[BOOT_CURR_IMG(state)].active_slot = BOOT_SLOT_NONE;
 
             return rc;
         }
@@ -636,7 +636,7 @@ boot_write_status(const struct boot_loader_state *state, struct boot_status *bs)
     } else {
 #endif
         /* Write to the primary slot. */
-        fap = BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT);
+        fap = BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY);
 #if MCUBOOT_SWAP_USING_SCRATCH
     }
 #endif
@@ -912,13 +912,13 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
          * through mcumgr; so we just get rid of the trailer here, if the header
          * is erased.
          */
-        if (slot != BOOT_PRIMARY_SLOT) {
+        if (slot != BOOT_SLOT_PRIMARY) {
             swap_scramble_trailer_sectors(state, fap);
 
 #if defined(MCUBOOT_SWAP_USING_MOVE)
             if (bs->swap_type == BOOT_SWAP_TYPE_REVERT ||
                 boot_swap_type_multi(BOOT_CURR_IMG(state)) == BOOT_SWAP_TYPE_REVERT) {
-                const struct flash_area *fap_pri = BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT);
+                const struct flash_area *fap_pri = BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY);
 
                 assert(fap_pri != NULL);
 
@@ -937,7 +937,7 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
     }
 
 #if defined(MCUBOOT_SWAP_USING_OFFSET)
-    if (slot != BOOT_PRIMARY_SLOT && boot_status_is_reset(bs) &&
+    if (slot != BOOT_SLOT_PRIMARY && boot_status_is_reset(bs) &&
         (expected_swap_type == BOOT_SWAP_TYPE_TEST || expected_swap_type == BOOT_SWAP_TYPE_PERM)) {
         /* Check first sector to see if there is a magic header here, if so the update has likely
          * been loaded to the wrong sector and cannot be used
@@ -957,14 +957,14 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
 #endif
 
 #if defined(MCUBOOT_OVERWRITE_ONLY) && defined(MCUBOOT_DOWNGRADE_PREVENTION)
-    if (slot != BOOT_PRIMARY_SLOT) {
+    if (slot != BOOT_SLOT_PRIMARY) {
         int rc;
 
         /* Check if version of secondary slot is sufficient */
         rc = boot_version_cmp(
-                &boot_img_hdr(state, BOOT_SECONDARY_SLOT)->ih_ver,
-                &boot_img_hdr(state, BOOT_PRIMARY_SLOT)->ih_ver);
-        if (rc < 0 && boot_check_header_erased(state, BOOT_PRIMARY_SLOT)) {
+                &boot_img_hdr(state, BOOT_SLOT_SECONDARY)->ih_ver,
+                &boot_img_hdr(state, BOOT_SLOT_PRIMARY)->ih_ver);
+        if (rc < 0 && boot_check_header_erased(state, BOOT_SLOT_PRIMARY)) {
             BOOT_LOG_ERR("insufficient version in secondary slot");
             boot_scramble_slot(fap, slot);
             /* Image in the secondary slot does not satisfy version requirement.
@@ -988,7 +988,7 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
 check_validity:
 #endif
     if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
-        if ((slot != BOOT_PRIMARY_SLOT) || ARE_SLOTS_EQUIVALENT()) {
+        if ((slot != BOOT_SLOT_PRIMARY) || ARE_SLOTS_EQUIVALENT()) {
             boot_scramble_slot(fap, slot);
             /* Image is invalid, erase it to prevent further unnecessary
              * attempts to validate and boot it.
@@ -996,7 +996,7 @@ check_validity:
         }
 #if !defined(__BOOTSIM__)
         BOOT_LOG_ERR("Image in the %s slot is not valid!",
-                     (slot == BOOT_PRIMARY_SLOT) ? "primary" : "secondary");
+                     (slot == BOOT_SLOT_PRIMARY) ? "primary" : "secondary");
 #endif
         fih_rc = FIH_NO_BOOTABLE_IMAGE;
         goto out;
@@ -1008,8 +1008,8 @@ check_validity:
      * overwriting an application written to the incorrect slot.
      * This feature is only supported by ARM platforms.
      */
-    if (fap == BOOT_IMG_AREA(state, BOOT_SECONDARY_SLOT)) {
-        const struct flash_area *pri_fa = BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT);
+    if (fap == BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY)) {
+        const struct flash_area *pri_fa = BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY);
         struct image_header *secondary_hdr = boot_img_hdr(state, slot);
         uint32_t reset_value = 0;
         uint32_t reset_addr = secondary_hdr->ih_hdr_size + sizeof(reset_value);
@@ -1101,7 +1101,7 @@ boot_validated_swap_type(struct boot_loader_state *state,
         /* Boot loader wants to switch to the secondary slot.
          * Ensure image is valid.
          */
-        FIH_CALL(boot_validate_slot, fih_rc, state, BOOT_SECONDARY_SLOT, bs, swap_type);
+        FIH_CALL(boot_validate_slot, fih_rc, state, BOOT_SLOT_SECONDARY, bs, swap_type);
         if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
             if (FIH_EQ(fih_rc, FIH_NO_BOOTABLE_IMAGE)) {
                 swap_type = BOOT_SWAP_TYPE_NONE;
@@ -1338,11 +1338,11 @@ boot_copy_region(struct boot_loader_state *state,
     if (encrypted_src != encrypted_dst) {
         if (encrypted_dst) {
             /* Need encryption, metadata from the primary slot */
-            hdr = boot_img_hdr(state, BOOT_PRIMARY_SLOT);
+            hdr = boot_img_hdr(state, BOOT_SLOT_PRIMARY);
             source_slot = 0;
         } else {
             /* Need decryption, metadata from the secondary slot */
-            hdr = boot_img_hdr(state, BOOT_SECONDARY_SLOT);
+            hdr = boot_img_hdr(state, BOOT_SLOT_SECONDARY);
             source_slot = 1;
         }
     } else {
@@ -1467,7 +1467,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
 
 #if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
     uint32_t src_size = 0;
-    rc = boot_read_image_size(state, BOOT_SECONDARY_SLOT, &src_size);
+    rc = boot_read_image_size(state, BOOT_SLOT_SECONDARY, &src_size);
     assert(rc == 0);
 #endif
 
@@ -1476,15 +1476,15 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
     BOOT_LOG_INF("Image %d upgrade secondary slot -> primary slot", image_index);
     BOOT_LOG_INF("Erasing the primary slot");
 
-    fap_primary_slot = BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT);
+    fap_primary_slot = BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY);
     assert(fap_primary_slot != NULL);
 
-    fap_secondary_slot = BOOT_IMG_AREA(state, BOOT_SECONDARY_SLOT);
+    fap_secondary_slot = BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY);
     assert(fap_secondary_slot != NULL);
 
-    sect_count = boot_img_num_sectors(state, BOOT_PRIMARY_SLOT);
+    sect_count = boot_img_num_sectors(state, BOOT_SLOT_PRIMARY);
     for (sect = 0, size = 0; sect < sect_count; sect++) {
-        this_size = boot_img_sector_size(state, BOOT_PRIMARY_SLOT, sect);
+        this_size = boot_img_sector_size(state, BOOT_SLOT_PRIMARY, sect);
         rc = boot_erase_region(fap_primary_slot, size, this_size, false);
         assert(rc == 0);
 
@@ -1501,11 +1501,11 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
 
 #if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
     trailer_sz = boot_trailer_sz(BOOT_WRITE_SZ(state));
-    sector = boot_img_num_sectors(state, BOOT_PRIMARY_SLOT) - 1;
+    sector = boot_img_num_sectors(state, BOOT_SLOT_PRIMARY) - 1;
     sz = 0;
     do {
-        sz += boot_img_sector_size(state, BOOT_PRIMARY_SLOT, sector);
-        off = boot_img_sector_off(state, BOOT_PRIMARY_SLOT, sector);
+        sz += boot_img_sector_size(state, BOOT_SLOT_PRIMARY, sector);
+        off = boot_img_sector_off(state, BOOT_SLOT_PRIMARY, sector);
         sector--;
     } while (sz < trailer_sz);
 
@@ -1514,9 +1514,9 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
 #endif
 
 #ifdef MCUBOOT_ENC_IMAGES
-    if (IS_ENCRYPTED(boot_img_hdr(state, BOOT_SECONDARY_SLOT))) {
-        rc = boot_enc_load(state, BOOT_SECONDARY_SLOT,
-                boot_img_hdr(state, BOOT_SECONDARY_SLOT),
+    if (IS_ENCRYPTED(boot_img_hdr(state, BOOT_SLOT_SECONDARY))) {
+        rc = boot_enc_load(state, BOOT_SLOT_SECONDARY,
+                boot_img_hdr(state, BOOT_SLOT_SECONDARY),
                 fap_secondary_slot, bs);
 
         if (rc < 0) {
@@ -1532,7 +1532,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
                  image_index, size);
 #if defined(MCUBOOT_SWAP_USING_OFFSET)
     rc = BOOT_COPY_REGION(state, fap_secondary_slot, fap_primary_slot,
-                          boot_img_sector_size(state, BOOT_SECONDARY_SLOT, 0), 0, size, 0);
+                          boot_img_sector_size(state, BOOT_SLOT_SECONDARY, 0), 0, size, 0);
 #else
     rc = boot_copy_region(state, fap_secondary_slot, fap_primary_slot, 0, 0, size);
 #endif
@@ -1548,7 +1548,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
 #endif
 
     rc = BOOT_HOOK_CALL(boot_copy_region_post_hook, 0, BOOT_CURR_IMG(state),
-                        BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT), size);
+                        BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY), size);
     if (rc != 0) {
         return rc;
     }
@@ -1559,7 +1559,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
      * slot's image header must be passed since the image headers in the
      * boot_data structure have not been updated yet.
      */
-    rc = boot_update_security_counter(state, BOOT_PRIMARY_SLOT, BOOT_SECONDARY_SLOT);
+    rc = boot_update_security_counter(state, BOOT_SLOT_PRIMARY, BOOT_SLOT_SECONDARY);
     if (rc != 0) {
         BOOT_LOG_ERR("Security counter update failed after image upgrade.");
         return rc;
@@ -1574,17 +1574,17 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
      */
     BOOT_LOG_DBG("erasing secondary header");
     rc = boot_scramble_region(fap_secondary_slot,
-                              boot_img_sector_off(state, BOOT_SECONDARY_SLOT, 0),
-                              boot_img_sector_size(state, BOOT_SECONDARY_SLOT, 0), false);
+                              boot_img_sector_off(state, BOOT_SLOT_SECONDARY, 0),
+                              boot_img_sector_size(state, BOOT_SLOT_SECONDARY, 0), false);
     assert(rc == 0);
 #endif
 
-    last_sector = boot_img_num_sectors(state, BOOT_SECONDARY_SLOT) - 1;
+    last_sector = boot_img_num_sectors(state, BOOT_SLOT_SECONDARY) - 1;
     BOOT_LOG_DBG("erasing secondary trailer");
     rc = boot_scramble_region(fap_secondary_slot,
-                              boot_img_sector_off(state, BOOT_SECONDARY_SLOT,
+                              boot_img_sector_off(state, BOOT_SLOT_SECONDARY,
                                     last_sector),
-                              boot_img_sector_size(state, BOOT_SECONDARY_SLOT,
+                              boot_img_sector_size(state, BOOT_SLOT_SECONDARY,
                                     last_sector), false);
     assert(rc == 0);
 
@@ -1631,15 +1631,15 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
          * No swap ever happened, so need to find the largest image which
          * will be used to determine the amount of sectors to swap.
          */
-        hdr = boot_img_hdr(state, BOOT_PRIMARY_SLOT);
+        hdr = boot_img_hdr(state, BOOT_SLOT_PRIMARY);
         if (hdr->ih_magic == IMAGE_MAGIC) {
-            rc = boot_read_image_size(state, BOOT_PRIMARY_SLOT, &copy_size);
+            rc = boot_read_image_size(state, BOOT_SLOT_PRIMARY, &copy_size);
             assert(rc == 0);
         }
 
 #ifdef MCUBOOT_ENC_IMAGES
         if (IS_ENCRYPTED(hdr)) {
-            fap = BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT);
+            fap = BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY);
             rc = boot_enc_load(state, 0, hdr, fap, bs);
             assert(rc >= 0);
 
@@ -1654,16 +1654,16 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
         }
 #endif
 
-        hdr = boot_img_hdr(state, BOOT_SECONDARY_SLOT);
+        hdr = boot_img_hdr(state, BOOT_SLOT_SECONDARY);
         if (hdr->ih_magic == IMAGE_MAGIC) {
-            rc = boot_read_image_size(state, BOOT_SECONDARY_SLOT, &size);
+            rc = boot_read_image_size(state, BOOT_SLOT_SECONDARY, &size);
             assert(rc == 0);
         }
 
 #ifdef MCUBOOT_ENC_IMAGES
-        hdr = boot_img_hdr(state, BOOT_SECONDARY_SLOT);
+        hdr = boot_img_hdr(state, BOOT_SLOT_SECONDARY);
         if (IS_ENCRYPTED(hdr)) {
-            fap = BOOT_IMG_AREA(state, BOOT_SECONDARY_SLOT);
+            fap = BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY);
             rc = boot_enc_load(state, 1, hdr, fap, bs);
             assert(rc >= 0);
 
@@ -1727,7 +1727,7 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
     }
 #endif
     rc = BOOT_HOOK_CALL(boot_copy_region_post_hook, 0, BOOT_CURR_IMG(state),
-                        BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT), size);
+                        BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY), size);
 
     return 0;
 }
@@ -1757,8 +1757,8 @@ boot_perform_update(struct boot_loader_state *state, struct boot_status *bs)
      * already been checked).
      */
     FIH_DECLARE(fih_rc, FIH_FAILURE);
-    rc = boot_check_header_erased(state, BOOT_PRIMARY_SLOT);
-    FIH_CALL(boot_validate_slot, fih_rc, state, BOOT_PRIMARY_SLOT, bs, 0);
+    rc = boot_check_header_erased(state, BOOT_SLOT_PRIMARY);
+    FIH_CALL(boot_validate_slot, fih_rc, state, BOOT_SLOT_PRIMARY, bs, 0);
     if (rc == 0 || FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
         rc = boot_copy_image(state, bs);
     } else {
@@ -1793,7 +1793,7 @@ boot_perform_update(struct boot_loader_state *state, struct boot_status *bs)
          * revert the images on the next reboot. Therefore, the security
          * counter must be increased right after the image upgrade.
          */
-        rc = boot_update_security_counter(state, BOOT_PRIMARY_SLOT, BOOT_SECONDARY_SLOT);
+        rc = boot_update_security_counter(state, BOOT_SLOT_PRIMARY, BOOT_SLOT_SECONDARY);
         if (rc != 0) {
             BOOT_LOG_ERR("Security counter update failed after "
                          "image upgrade.");
@@ -1989,7 +1989,7 @@ boot_prepare_image_for_update(struct boot_loader_state *state,
         rc = boot_read_image_headers(state, !boot_status_is_reset(bs), bs);
 #ifdef MCUBOOT_BOOTSTRAP
         /* When bootstrapping it's OK to not have image magic in the primary slot */
-        if (rc != 0 && boot_check_header_erased(state, BOOT_PRIMARY_SLOT) != 0) {
+        if (rc != 0 && boot_check_header_erased(state, BOOT_SLOT_PRIMARY) != 0) {
 #else
         if (rc != 0) {
 #endif
@@ -2048,7 +2048,7 @@ boot_prepare_image_for_update(struct boot_loader_state *state,
                 BOOT_SWAP_TYPE(state) = boot_validated_swap_type(state, bs);
             } else {
                 FIH_CALL(boot_validate_slot, fih_rc,
-                         state, BOOT_SECONDARY_SLOT, bs, 0);
+                         state, BOOT_SLOT_SECONDARY, bs, 0);
                 if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
                     BOOT_SWAP_TYPE(state) = BOOT_SWAP_TYPE_FAIL;
                 } else {
@@ -2068,15 +2068,15 @@ boot_prepare_image_for_update(struct boot_loader_state *state,
                  * magic, so also run validation on the primary slot to be
                  * sure it's not OK.
                  */
-                rc = boot_check_header_erased(state, BOOT_PRIMARY_SLOT);
+                rc = boot_check_header_erased(state, BOOT_SLOT_PRIMARY);
                 FIH_CALL(boot_validate_slot, fih_rc,
-                         state, BOOT_PRIMARY_SLOT, bs, 0);
+                         state, BOOT_SLOT_PRIMARY, bs, 0);
 
                 if (rc == 0 || FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
 
-                    rc = (boot_img_hdr(state, BOOT_SECONDARY_SLOT)->ih_magic == IMAGE_MAGIC) ? 1: 0;
+                    rc = (boot_img_hdr(state, BOOT_SLOT_SECONDARY)->ih_magic == IMAGE_MAGIC) ? 1: 0;
                     FIH_CALL(boot_validate_slot, fih_rc,
-                             state, BOOT_SECONDARY_SLOT, bs, 0);
+                             state, BOOT_SLOT_SECONDARY, bs, 0);
 
                     if (rc == 1 && FIH_EQ(fih_rc, FIH_SUCCESS)) {
                         /* Set swap type to REVERT to overwrite the primary
@@ -2128,7 +2128,7 @@ boot_update_hw_rollback_protection(struct boot_loader_state *state)
      * can be performed when it's necessary.
      */
     if (swap_state.magic != BOOT_MAGIC_GOOD || swap_state.image_ok == BOOT_FLAG_SET) {
-        rc = boot_update_security_counter(state, BOOT_PRIMARY_SLOT, BOOT_PRIMARY_SLOT);
+        rc = boot_update_security_counter(state, BOOT_SLOT_PRIMARY, BOOT_SLOT_PRIMARY);
         if (rc != 0) {
             BOOT_LOG_ERR("Security counter update failed after image "
                             "validation.");
@@ -2165,7 +2165,7 @@ check_downgrade_prevention(struct boot_loader_state *state)
 
     if (MCUBOOT_DOWNGRADE_PREVENTION_SECURITY_COUNTER) {
         /* If there was security no counter in slot 0, allow swap */
-        rc = bootutil_get_img_security_cnt(state, BOOT_PRIMARY_SLOT,
+        rc = bootutil_get_img_security_cnt(state, BOOT_SLOT_PRIMARY,
                                            BOOT_IMG_AREA(state, 0),
                                            &security_counter[0]);
         if (rc != 0) {
@@ -2173,7 +2173,7 @@ check_downgrade_prevention(struct boot_loader_state *state)
         }
         /* If there is no security counter in slot 1, or it's lower than
          * that of slot 0, prevent downgrade */
-        rc = bootutil_get_img_security_cnt(state, BOOT_SECONDARY_SLOT,
+        rc = bootutil_get_img_security_cnt(state, BOOT_SLOT_SECONDARY,
                                            BOOT_IMG_AREA(state, 1),
                                            &security_counter[1]);
         if (rc != 0 || security_counter[0] > security_counter[1]) {
@@ -2181,13 +2181,13 @@ check_downgrade_prevention(struct boot_loader_state *state)
         }
     }
     else {
-        rc = boot_version_cmp(&boot_img_hdr(state, BOOT_SECONDARY_SLOT)->ih_ver,
-                              &boot_img_hdr(state, BOOT_PRIMARY_SLOT)->ih_ver);
+        rc = boot_version_cmp(&boot_img_hdr(state, BOOT_SLOT_SECONDARY)->ih_ver,
+                              &boot_img_hdr(state, BOOT_SLOT_PRIMARY)->ih_ver);
     }
     if (rc < 0) {
         /* Image in slot 0 prevents downgrade, delete image in slot 1 */
         BOOT_LOG_INF("Image %d in slot 1 erased due to downgrade prevention", BOOT_CURR_IMG(state));
-        boot_scramble_slot(BOOT_IMG_AREA(state, 1), BOOT_SECONDARY_SLOT);
+        boot_scramble_slot(BOOT_IMG_AREA(state, 1), BOOT_SLOT_SECONDARY);
     } else {
         rc = 0;
     }
@@ -2333,7 +2333,7 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
         case BOOT_SWAP_TYPE_REVERT:
             rc = BOOT_HOOK_CALL(boot_perform_update_hook, BOOT_HOOK_REGULAR,
                                 BOOT_CURR_IMG(state), &(BOOT_IMG(state, 1).hdr),
-                                BOOT_IMG_AREA(state, BOOT_SECONDARY_SLOT));
+                                BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY));
             if (rc == BOOT_HOOK_REGULAR)
             {
                 rc = boot_perform_update(state, &bs);
@@ -2407,7 +2407,7 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
         }
 
 #ifdef MCUBOOT_VALIDATE_PRIMARY_SLOT
-        FIH_CALL(boot_validate_slot, fih_rc, state, BOOT_PRIMARY_SLOT, NULL, 0);
+        FIH_CALL(boot_validate_slot, fih_rc, state, BOOT_SLOT_PRIMARY, NULL, 0);
         /* Check for all possible values is redundant in normal operation it
          * is meant to prevent FI attack.
          */
@@ -2422,9 +2422,9 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
          * onto an empty flash chip. At least do a basic sanity check that
          * the magic number on the image is OK.
          */
-        if (BOOT_IMG(state, BOOT_PRIMARY_SLOT).hdr.ih_magic != IMAGE_MAGIC) {
+        if (BOOT_IMG(state, BOOT_SLOT_PRIMARY).hdr.ih_magic != IMAGE_MAGIC) {
             BOOT_LOG_ERR("bad image magic 0x%lx; Image=%u", (unsigned long)
-                         BOOT_IMG(state, BOOT_PRIMARY_SLOT).hdr.ih_magic,
+                         BOOT_IMG(state, BOOT_SLOT_PRIMARY).hdr.ih_magic,
                          BOOT_CURR_IMG(state));
             rc = BOOT_EBADIMAGE;
             FIH_SET(fih_rc, FIH_FAILURE);
@@ -2438,7 +2438,7 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
             goto out;
         }
 
-        rc = boot_add_shared_data(state, BOOT_PRIMARY_SLOT);
+        rc = boot_add_shared_data(state, BOOT_SLOT_PRIMARY);
         if (rc != 0) {
             FIH_SET(fih_rc, FIH_FAILURE);
             goto out;
@@ -2579,12 +2579,12 @@ boot_get_slot_usage(struct boot_loader_state *state)
                 state->slot_usage[BOOT_CURR_IMG(state)].slot_available[slot] = false;
                 BOOT_LOG_INF("Image %d %s slot: Image not found",
                              BOOT_CURR_IMG(state),
-                             (slot == BOOT_PRIMARY_SLOT)
+                             (slot == BOOT_SLOT_PRIMARY)
                              ? "Primary" : "Secondary");
             }
         }
 
-        state->slot_usage[BOOT_CURR_IMG(state)].active_slot = NO_ACTIVE_SLOT;
+        state->slot_usage[BOOT_CURR_IMG(state)].active_slot = BOOT_SLOT_NONE;
     }
 
     return 0;
@@ -2596,19 +2596,19 @@ boot_get_slot_usage(struct boot_loader_state *state)
  *
  * @param  state        Boot loader status information.
  *
- * @return              NO_ACTIVE_SLOT if no available slot found, number of
+ * @return              BOOT_SLOT_NONE if no available slot found, number of
  *                      the found slot otherwise.
  */
 static uint32_t
 find_slot_with_highest_version(struct boot_loader_state *state)
 {
     uint32_t slot;
-    uint32_t candidate_slot = NO_ACTIVE_SLOT;
+    uint32_t candidate_slot = BOOT_SLOT_NONE;
     int rc;
 
     for (slot = 0; slot < BOOT_NUM_SLOTS; slot++) {
         if (state->slot_usage[BOOT_CURR_IMG(state)].slot_available[slot]) {
-            if (candidate_slot == NO_ACTIVE_SLOT) {
+            if (candidate_slot == BOOT_SLOT_NONE) {
                 candidate_slot = slot;
             } else {
                 rc = boot_version_cmp(
@@ -2650,7 +2650,7 @@ print_loaded_images(struct boot_loader_state *state)
 
         BOOT_LOG_INF("Image %d loaded from the %s slot",
                      BOOT_CURR_IMG(state),
-                     (active_slot == BOOT_PRIMARY_SLOT) ?
+                     (active_slot == BOOT_SLOT_PRIMARY) ?
                      "primary" : "secondary");
     }
 }
@@ -2695,7 +2695,7 @@ boot_select_or_erase(struct boot_loader_state *state)
          * to prevent it from being selected again on the next reboot.
          */
         BOOT_LOG_DBG("Erasing faulty image in the %s slot.",
-                     (active_slot == BOOT_PRIMARY_SLOT) ? "primary" : "secondary");
+                     (active_slot == BOOT_SLOT_PRIMARY) ? "primary" : "secondary");
         rc = boot_scramble_region(fap, 0, flash_area_get_size(fap), false);
         assert(rc == 0);
         rc = -1;
@@ -2714,7 +2714,7 @@ boot_select_or_erase(struct boot_loader_state *state)
             rc = boot_write_copy_done(fap);
             if (rc != 0) {
                 BOOT_LOG_WRN("Failed to set copy_done flag of the image in "
-                             "the %s slot.", (active_slot == BOOT_PRIMARY_SLOT) ?
+                             "the %s slot.", (active_slot == BOOT_SLOT_PRIMARY) ?
                              "primary" : "secondary");
                 rc = 0;
             }
@@ -2758,7 +2758,7 @@ boot_load_and_validate_images(struct boot_loader_state *state)
             if (rc != 0) {
                 /* The image is placed in an unsuitable slot. */
                 state->slot_usage[BOOT_CURR_IMG(state)].slot_available[slot] = false;
-                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = NO_ACTIVE_SLOT;
+                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = BOOT_SLOT_NONE;
                 continue;
             }
 
@@ -2767,7 +2767,7 @@ boot_load_and_validate_images(struct boot_loader_state *state)
             if (rc != 0) {
                 /* The selected image slot has been erased. */
                 state->slot_usage[BOOT_CURR_IMG(state)].slot_available[slot] = false;
-                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = NO_ACTIVE_SLOT;
+                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = BOOT_SLOT_NONE;
                 continue;
             }
 #endif /* MCUBOOT_DIRECT_XIP_REVERT */
@@ -2784,7 +2784,7 @@ boot_load_and_validate_images(struct boot_loader_state *state)
                 /* Image cannot be ramloaded. */
                 boot_remove_image_from_flash(state, slot);
                 state->slot_usage[BOOT_CURR_IMG(state)].slot_available[slot] = false;
-                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = NO_ACTIVE_SLOT;
+                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = BOOT_SLOT_NONE;
                 continue;
             }
 #endif /* MCUBOOT_RAM_LOAD */
@@ -2796,12 +2796,12 @@ boot_load_and_validate_images(struct boot_loader_state *state)
                 boot_remove_image_from_sram(state);
 #endif /* MCUBOOT_RAM_LOAD */
                 state->slot_usage[BOOT_CURR_IMG(state)].slot_available[slot] = false;
-                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = NO_ACTIVE_SLOT;
+                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = BOOT_SLOT_NONE;
                 continue;
             }
 
             /* Valid image loaded from a slot, go to the next slot. */
-            state->slot_usage[BOOT_CURR_IMG(state)].active_slot = NO_ACTIVE_SLOT;
+            state->slot_usage[BOOT_CURR_IMG(state)].active_slot = BOOT_SLOT_NONE;
         }
     }
 
@@ -2813,7 +2813,7 @@ boot_load_and_validate_images(struct boot_loader_state *state)
         while (true) {
             /* Go over all the slots and try to load one */
             active_slot = state->slot_usage[BOOT_CURR_IMG(state)].active_slot;
-            if (active_slot != NO_ACTIVE_SLOT){
+            if (active_slot != BOOT_SLOT_NONE){
                 /* A slot is already active, go to next image. */
                 break;
             }
@@ -2824,7 +2824,7 @@ boot_load_and_validate_images(struct boot_loader_state *state)
                 active_slot = find_slot_with_highest_version(state);
             }
 
-            if (active_slot == NO_ACTIVE_SLOT) {
+            if (active_slot == BOOT_SLOT_NONE) {
                 BOOT_LOG_INF("No slot to load for image %d",
                              BOOT_CURR_IMG(state));
                 FIH_RET(FIH_FAILURE);
@@ -2865,7 +2865,7 @@ boot_load_and_validate_images(struct boot_loader_state *state)
         while (true) {
             /* Go over all the slots and try to load one */
             active_slot = state->slot_usage[BOOT_CURR_IMG(state)].active_slot;
-            if (active_slot != NO_ACTIVE_SLOT){
+            if (active_slot != BOOT_SLOT_NONE){
                 /* A slot is already active, go to next image. */
                 break;
             }
@@ -2876,7 +2876,7 @@ boot_load_and_validate_images(struct boot_loader_state *state)
                 active_slot = find_slot_with_highest_version(state);
             }
 
-            if (active_slot == NO_ACTIVE_SLOT) {
+            if (active_slot == BOOT_SLOT_NONE) {
                 BOOT_LOG_INF("No slot to load for image %d",
                              BOOT_CURR_IMG(state));
                 FIH_RET(FIH_FAILURE);
@@ -2896,7 +2896,7 @@ boot_load_and_validate_images(struct boot_loader_state *state)
             if (rc != 0) {
                 /* The image is placed in an unsuitable slot. */
                 state->slot_usage[BOOT_CURR_IMG(state)].slot_available[active_slot] = false;
-                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = NO_ACTIVE_SLOT;
+                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = BOOT_SLOT_NONE;
                 continue;
             }
 #endif /* MCUBOOT_DIRECT_XIP */
@@ -2906,7 +2906,7 @@ boot_load_and_validate_images(struct boot_loader_state *state)
             if (rc != 0) {
                 /* The selected image slot has been erased. */
                 state->slot_usage[BOOT_CURR_IMG(state)].slot_available[active_slot] = false;
-                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = NO_ACTIVE_SLOT;
+                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = BOOT_SLOT_NONE;
                 continue;
             }
 #endif /* MCUBOOT_DIRECT_XIP_REVERT || MCUBOOT_RAM_LOAD_REVERT */
@@ -2922,7 +2922,7 @@ boot_load_and_validate_images(struct boot_loader_state *state)
                 /* Image cannot be ramloaded. */
                 boot_remove_image_from_flash(state, active_slot);
                 state->slot_usage[BOOT_CURR_IMG(state)].slot_available[active_slot] = false;
-                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = NO_ACTIVE_SLOT;
+                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = BOOT_SLOT_NONE;
                 continue;
             }
 #endif /* MCUBOOT_RAM_LOAD */
@@ -2934,7 +2934,7 @@ boot_load_and_validate_images(struct boot_loader_state *state)
                 boot_remove_image_from_sram(state);
 #endif /* MCUBOOT_RAM_LOAD */
                 state->slot_usage[BOOT_CURR_IMG(state)].slot_available[active_slot] = false;
-                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = NO_ACTIVE_SLOT;
+                state->slot_usage[BOOT_CURR_IMG(state)].active_slot = BOOT_SLOT_NONE;
                 continue;
             }
 
@@ -3218,7 +3218,7 @@ const struct image_max_size *boot_get_max_app_size(void)
 uint32_t boot_get_state_secondary_offset(struct boot_loader_state *state,
                                          const struct flash_area *fap)
 {
-    if (state != NULL && BOOT_IMG_AREA(state, BOOT_SECONDARY_SLOT) == fap) {
+    if (state != NULL && BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY) == fap) {
         return state->secondary_offset[BOOT_CURR_IMG(state)];
     }
 

--- a/boot/bootutil/src/ram_load.c
+++ b/boot/bootutil/src/ram_load.c
@@ -274,7 +274,7 @@ boot_check_ram_load_overlapping(struct boot_loader_state *state)
     end_a = start_a + state->slot_usage[image_id_to_check].img_sz;
 
     for (i = 0; i < BOOT_IMAGE_NUMBER; i++) {
-        if (state->slot_usage[i].active_slot == NO_ACTIVE_SLOT
+        if (state->slot_usage[i].active_slot == BOOT_SLOT_NONE
             || i == image_id_to_check) {
             continue;
         }

--- a/boot/bootutil/src/swap_misc.c
+++ b/boot/bootutil/src/swap_misc.c
@@ -41,7 +41,7 @@ swap_erase_trailer_sectors(const struct boot_loader_state *state,
      * erase, there is nothing to do here.
      */
     if (device_requires_erase(fap)) {
-        uint8_t slot = BOOT_PRIMARY_SLOT;
+        uint8_t slot = BOOT_SLOT_PRIMARY;
         uint32_t sector;
         uint32_t trailer_sz;
         uint32_t total_sz;
@@ -49,8 +49,8 @@ swap_erase_trailer_sectors(const struct boot_loader_state *state,
         BOOT_LOG_DBG("Erasing trailer; fa_id=%d", flash_area_get_id(fap));
 
         /* By default it is assumed that slot is primary */
-        if (fap == BOOT_IMG_AREA(state, BOOT_SECONDARY_SLOT)) {
-            slot = BOOT_SECONDARY_SLOT;
+        if (fap == BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY)) {
+            slot = BOOT_SLOT_SECONDARY;
         }
 
         /* Delete starting from last sector and moving to beginning */
@@ -119,7 +119,7 @@ swap_status_init(const struct boot_loader_state *state,
 
     BOOT_LOG_DBG("initializing status; fa_id=%d", flash_area_get_id(fap));
 
-    rc = boot_read_swap_state(state->imgs[image_index][BOOT_SECONDARY_SLOT].area,
+    rc = boot_read_swap_state(state->imgs[image_index][BOOT_SLOT_SECONDARY].area,
                               &swap_state);
     assert(rc == 0);
 
@@ -170,7 +170,7 @@ swap_read_status(struct boot_loader_state *state, struct boot_status *bs)
 #endif
 
     case BOOT_STATUS_SOURCE_PRIMARY_SLOT:
-        fap = BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT);
+        fap = BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY);
         break;
 
     default:

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -110,9 +110,9 @@ static size_t app_max_size_adjust_to_trailer(struct boot_loader_state *state, si
 
 
     size_t trailer_sector_primary_end_off =
-        get_first_trailer_sector_end_off(state, BOOT_PRIMARY_SLOT, slot_trailer_sz);
+        get_first_trailer_sector_end_off(state, BOOT_SLOT_PRIMARY, slot_trailer_sz);
     size_t trailer_sector_secondary_end_off =
-        get_first_trailer_sector_end_off(state, BOOT_SECONDARY_SLOT, slot_trailer_sz);
+        get_first_trailer_sector_end_off(state, BOOT_SLOT_SECONDARY, slot_trailer_sz);
 
     /* If slots have sectors of different sizes, we need to find the "common" sector
      * boundary (slot compatibility checks ensure that the larger sector contains a multiple
@@ -281,8 +281,8 @@ boot_slots_compatible(struct boot_loader_state *state)
     size_t i, j;
     int8_t smaller;
 
-    num_sectors_primary = boot_img_num_sectors(state, BOOT_PRIMARY_SLOT);
-    num_sectors_secondary = boot_img_num_sectors(state, BOOT_SECONDARY_SLOT);
+    num_sectors_primary = boot_img_num_sectors(state, BOOT_SLOT_PRIMARY);
+    num_sectors_secondary = boot_img_num_sectors(state, BOOT_SLOT_SECONDARY);
     if ((num_sectors_primary > BOOT_MAX_IMG_SECTORS) ||
         (num_sectors_secondary > BOOT_MAX_IMG_SECTORS)) {
         BOOT_LOG_WRN("Cannot upgrade: more sectors than allowed");
@@ -305,12 +305,12 @@ boot_slots_compatible(struct boot_loader_state *state)
     smaller = 0;
     while (i < num_sectors_primary || j < num_sectors_secondary) {
         if (sz0 == sz1) {
-            sz0 += boot_img_sector_size(state, BOOT_PRIMARY_SLOT, i);
-            sz1 += boot_img_sector_size(state, BOOT_SECONDARY_SLOT, j);
+            sz0 += boot_img_sector_size(state, BOOT_SLOT_PRIMARY, i);
+            sz1 += boot_img_sector_size(state, BOOT_SLOT_SECONDARY, j);
             i++;
             j++;
         } else if (sz0 < sz1) {
-            sz0 += boot_img_sector_size(state, BOOT_PRIMARY_SLOT, i);
+            sz0 += boot_img_sector_size(state, BOOT_SLOT_PRIMARY, i);
             /* Guarantee that multiple sectors of the secondary slot
              * fit into the primary slot.
              */
@@ -321,7 +321,7 @@ boot_slots_compatible(struct boot_loader_state *state)
             smaller = 1;
             i++;
         } else {
-            size_t sector_size = boot_img_sector_size(state, BOOT_SECONDARY_SLOT, j);
+            size_t sector_size = boot_img_sector_size(state, BOOT_SLOT_SECONDARY, j);
 
 #ifdef MCUBOOT_DECOMPRESS_IMAGES
             if (sector_size == 0) {
@@ -486,7 +486,7 @@ swap_status_source(struct boot_loader_state *state)
 #endif
 
     image_index = BOOT_CURR_IMG(state);
-    rc = boot_read_swap_state(state->imgs[image_index][BOOT_PRIMARY_SLOT].area,
+    rc = boot_read_swap_state(state->imgs[image_index][BOOT_SLOT_PRIMARY].area,
                               &state_primary_slot);
     assert(rc == 0);
 
@@ -564,7 +564,7 @@ boot_copy_sz(const struct boot_loader_state *state, int last_sector_idx,
 
     scratch_sz = boot_scratch_area_size(state);
     for (i = last_sector_idx; i >= 0; i--) {
-        new_sz = sz + boot_img_sector_size(state, BOOT_PRIMARY_SLOT, i);
+        new_sz = sz + boot_img_sector_size(state, BOOT_SLOT_PRIMARY, i);
         /*
          * The secondary slot is not being checked here, because
          * `boot_slots_compatible` already provides assurance that the copy size
@@ -614,14 +614,14 @@ find_last_sector_idx(const struct boot_loader_state *state, uint32_t copy_size)
         if ((primary_slot_size < copy_size) ||
             (primary_slot_size < secondary_slot_size)) {
            primary_slot_size += boot_img_sector_size(state,
-                                                     BOOT_PRIMARY_SLOT,
+                                                     BOOT_SLOT_PRIMARY,
                                                      last_sector_idx_primary);
             ++last_sector_idx_primary;
         }
         if ((secondary_slot_size < copy_size) ||
             (secondary_slot_size < primary_slot_size)) {
            secondary_slot_size += boot_img_sector_size(state,
-                                                       BOOT_SECONDARY_SLOT,
+                                                       BOOT_SLOT_SECONDARY,
                                                        last_sector_idx_secondary);
             ++last_sector_idx_secondary;
         }
@@ -694,17 +694,17 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
 
     image_index = BOOT_CURR_IMG(state);
 
-    fap_primary_slot = BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT);
+    fap_primary_slot = BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY);
     assert(fap_primary_slot != NULL);
 
-    fap_secondary_slot = BOOT_IMG_AREA(state, BOOT_SECONDARY_SLOT);
+    fap_secondary_slot = BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY);
     assert(fap_secondary_slot != NULL);
 
     fap_scratch = state->scratch.area;
     assert(fap_scratch != NULL);
 
     /* Calculate offset from start of image area. */
-    img_off = boot_img_sector_off(state, BOOT_PRIMARY_SLOT, idx);
+    img_off = boot_img_sector_off(state, BOOT_SLOT_PRIMARY, idx);
 
     copy_sz = sz;
     trailer_sz = boot_trailer_sz(BOOT_WRITE_SZ(state));
@@ -723,11 +723,11 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
      * controls if special handling is needed (swapping the first trailer sector).
      */
     first_trailer_sector_primary =
-        boot_get_first_trailer_sector(state, BOOT_PRIMARY_SLOT, trailer_sz);
+        boot_get_first_trailer_sector(state, BOOT_SLOT_PRIMARY, trailer_sz);
 
     /* Check if the currently swapped sector(s) contain the trailer or part of it */
     if ((img_off + sz) >
-        boot_img_sector_off(state, BOOT_PRIMARY_SLOT, first_trailer_sector_primary)) {
+        boot_img_sector_off(state, BOOT_SLOT_PRIMARY, first_trailer_sector_primary)) {
         copy_sz = flash_area_get_size(fap_primary_slot) - img_off - trailer_sz;
 
         /* Check if the computed copy size would cause the beginning of the trailer in the scratch
@@ -803,10 +803,10 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
                  * sector(s) containing the beginning of the trailer won't be erased again.
                  */
                 size_t trailer_sector_secondary =
-                    boot_get_first_trailer_sector(state, BOOT_SECONDARY_SLOT, trailer_sz);
+                    boot_get_first_trailer_sector(state, BOOT_SLOT_SECONDARY, trailer_sz);
 
                 uint32_t trailer_sector_offset =
-                    boot_img_sector_off(state, BOOT_SECONDARY_SLOT, trailer_sector_secondary);
+                    boot_img_sector_off(state, BOOT_SLOT_SECONDARY, trailer_sector_secondary);
 
                 erase_sz = trailer_sector_offset - img_off;
             }
@@ -840,7 +840,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
 
             /* Ensure the sector(s) containing the beginning of the trailer won't be erased twice */
             uint32_t trailer_sector_off =
-                boot_img_sector_off(state, BOOT_PRIMARY_SLOT, first_trailer_sector_primary);
+                boot_img_sector_off(state, BOOT_SLOT_PRIMARY, first_trailer_sector_primary);
 
             erase_sz = trailer_sector_off - img_off;
         }
@@ -958,8 +958,8 @@ int app_max_size(struct boot_loader_state *state)
     size_t i, j;
     int8_t smaller;
 
-    num_sectors_primary = boot_img_num_sectors(state, BOOT_PRIMARY_SLOT);
-    num_sectors_secondary = boot_img_num_sectors(state, BOOT_SECONDARY_SLOT);
+    num_sectors_primary = boot_img_num_sectors(state, BOOT_SLOT_PRIMARY);
+    num_sectors_secondary = boot_img_num_sectors(state, BOOT_SLOT_SECONDARY);
 
 #ifndef MCUBOOT_OVERWRITE_ONLY
     scratch_sz = boot_scratch_area_size(state);
@@ -980,12 +980,12 @@ int app_max_size(struct boot_loader_state *state)
     smaller = 0;
     while (i < num_sectors_primary || j < num_sectors_secondary) {
         if (sz0 == sz1) {
-            sz0 += boot_img_sector_size(state, BOOT_PRIMARY_SLOT, i);
-            sz1 += boot_img_sector_size(state, BOOT_SECONDARY_SLOT, j);
+            sz0 += boot_img_sector_size(state, BOOT_SLOT_PRIMARY, i);
+            sz1 += boot_img_sector_size(state, BOOT_SLOT_SECONDARY, j);
             i++;
             j++;
         } else if (sz0 < sz1) {
-            sz0 += boot_img_sector_size(state, BOOT_PRIMARY_SLOT, i);
+            sz0 += boot_img_sector_size(state, BOOT_SLOT_PRIMARY, i);
             /* Guarantee that multiple sectors of the secondary slot
              * fit into the primary slot.
              */
@@ -996,7 +996,7 @@ int app_max_size(struct boot_loader_state *state)
             smaller = 1;
             i++;
         } else {
-            sz1 += boot_img_sector_size(state, BOOT_SECONDARY_SLOT, j);
+            sz1 += boot_img_sector_size(state, BOOT_SLOT_SECONDARY, j);
             /* Guarantee that multiple sectors of the primary slot
              * fit into the secondary slot.
              */
@@ -1043,10 +1043,10 @@ int app_max_size(struct boot_loader_state *state)
     assert(fap != NULL);
     primary_sz = flash_area_get_size(fap);
 
-    if (active_slot == BOOT_PRIMARY_SLOT) {
-        active_slot = BOOT_SECONDARY_SLOT;
+    if (active_slot == BOOT_SLOT_PRIMARY) {
+        active_slot = BOOT_SLOT_SECONDARY;
     } else {
-        active_slot = BOOT_PRIMARY_SLOT;
+        active_slot = BOOT_SLOT_PRIMARY;
     }
 
     fap = BOOT_IMG_AREA(state, active_slot);
@@ -1104,22 +1104,22 @@ boot_read_image_header(struct boot_loader_state *state, int slot,
 
         if (bs->idx - BOOT_STATUS_IDX_0 >= swap_count) {
             /* If all segments have been swapped, the header is located in the other slot */
-            hdr_slot = (slot == BOOT_PRIMARY_SLOT) ? BOOT_SECONDARY_SLOT : BOOT_PRIMARY_SLOT;
+            hdr_slot = (slot == BOOT_SLOT_PRIMARY) ? BOOT_SLOT_SECONDARY : BOOT_SLOT_PRIMARY;
         } else if (bs->idx - BOOT_STATUS_IDX_0 == swap_count - 1) {
             /* If the last swap operation is in progress, the headers are currently being swapped
              * since the first segment of each slot is the last to be processed.
              */
 
-            if (slot == BOOT_SECONDARY_SLOT && bs->state >= BOOT_STATUS_STATE_1) {
+            if (slot == BOOT_SLOT_SECONDARY && bs->state >= BOOT_STATUS_STATE_1) {
                 /* After BOOT_STATUS_STATE_1, the secondary image's header has been moved to the
                  * scratch area.
                  */
                 hdr_slot = BOOT_NUM_SLOTS;
-            } else if (slot == BOOT_PRIMARY_SLOT && bs->state >= BOOT_STATUS_STATE_2) {
+            } else if (slot == BOOT_SLOT_PRIMARY && bs->state >= BOOT_STATUS_STATE_2) {
                 /* After BOOT_STATUS_STATE_2, the primary image's header has been moved to the
                  * secondary slot.
                  */
-                hdr_slot = BOOT_SECONDARY_SLOT;
+                hdr_slot = BOOT_SLOT_SECONDARY;
             }
         }
     }

--- a/boot/zephyr/flash_check.c
+++ b/boot/zephyr/flash_check.c
@@ -27,7 +27,7 @@ bool swap_write_block_size_check(struct boot_loader_state *state)
 
 #ifdef MCUBOOT_SLOT0_EXPECTED_WRITE_SIZE
     flash_write_block_size_pri = flash_get_write_block_size(
-                                              state->imgs[0][BOOT_PRIMARY_SLOT].area->fa_dev);
+                                              state->imgs[0][BOOT_SLOT_PRIMARY].area->fa_dev);
 
     if (flash_write_block_size_pri != MCUBOOT_SLOT0_EXPECTED_WRITE_SIZE) {
         BOOT_LOG_DBG("Discrepancy, slot0 expected write block size: %d, actual: %d",
@@ -37,7 +37,7 @@ bool swap_write_block_size_check(struct boot_loader_state *state)
 
 #ifdef MCUBOOT_SLOT1_EXPECTED_WRITE_SIZE
     flash_write_block_size_sec = flash_get_write_block_size(
-                                              state->imgs[0][BOOT_SECONDARY_SLOT].area->fa_dev);
+                                              state->imgs[0][BOOT_SLOT_SECONDARY].area->fa_dev);
 
     if (flash_write_block_size_sec != MCUBOOT_SLOT1_EXPECTED_WRITE_SIZE) {
         BOOT_LOG_DBG("Discrepancy, slot1 expected write block size: %d, actual: %d",

--- a/boot/zephyr/single_loader.c
+++ b/boot/zephyr/single_loader.c
@@ -116,7 +116,7 @@ boot_open_all_flash_areas(struct boot_loader_state *state)
 {
     int rc;
 
-    rc = flash_area_open(FLASH_AREA_IMAGE_PRIMARY(0), &BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT));
+    rc = flash_area_open(FLASH_AREA_IMAGE_PRIMARY(0), &BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY));
     assert(rc == 0);
 
     return rc;
@@ -125,7 +125,7 @@ boot_open_all_flash_areas(struct boot_loader_state *state)
 void
 boot_close_all_flash_areas(struct boot_loader_state *state)
 {
-    flash_area_close(BOOT_IMG_AREA(state, BOOT_PRIMARY_SLOT));
+    flash_area_close(BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY));
 }
 
 #if defined(MCUBOOT_SERIAL_IMG_GRP_SLOT_INFO)
@@ -136,7 +136,7 @@ static int app_max_sectors(struct boot_loader_state *state)
     uint32_t trailer_sz;
     uint32_t trailer_sectors = 0;
 
-    sector_sz = boot_img_sector_size(state, BOOT_PRIMARY_SLOT, 0);
+    sector_sz = boot_img_sector_size(state, BOOT_SLOT_PRIMARY, 0);
     trailer_sz = boot_trailer_sz(BOOT_WRITE_SZ(state));
 
     while (1) {
@@ -148,14 +148,14 @@ static int app_max_sectors(struct boot_loader_state *state)
         }
     }
 
-    return boot_img_num_sectors(state, BOOT_PRIMARY_SLOT) - trailer_sectors;
+    return boot_img_num_sectors(state, BOOT_SLOT_PRIMARY) - trailer_sectors;
 }
 
 int app_max_size(struct boot_loader_state *state)
 {
     uint32_t sector_sz;
 
-    sector_sz = boot_img_sector_size(state, BOOT_PRIMARY_SLOT, 0);
+    sector_sz = boot_img_sector_size(state, BOOT_SLOT_PRIMARY, 0);
 
     return app_max_sectors(state) * sector_sz;
 }
@@ -191,7 +191,7 @@ boot_go(struct boot_rsp *rsp)
 
     rc = boot_open_all_flash_areas(&state);
 
-    rc = boot_image_load_header(BOOT_IMG_AREA(&state, BOOT_PRIMARY_SLOT), &_hdr);
+    rc = boot_image_load_header(BOOT_IMG_AREA(&state, BOOT_SLOT_PRIMARY), &_hdr);
     if (rc != 0)
         goto out;
 
@@ -204,7 +204,7 @@ boot_go(struct boot_rsp *rsp)
 #endif
 
 #ifdef MCUBOOT_VALIDATE_PRIMARY_SLOT
-    FIH_CALL(boot_image_validate, fih_rc, BOOT_IMG_AREA(&state, BOOT_PRIMARY_SLOT), &_hdr);
+    FIH_CALL(boot_image_validate, fih_rc, BOOT_IMG_AREA(&state, BOOT_SLOT_PRIMARY), &_hdr);
     if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
 #ifdef MCUBOOT_RAM_LOAD
         boot_remove_image_from_sram(&state);
@@ -212,7 +212,7 @@ boot_go(struct boot_rsp *rsp)
         goto out;
     }
 #elif defined(MCUBOOT_VALIDATE_PRIMARY_SLOT_ONCE)
-    FIH_CALL(boot_image_validate_once, fih_rc, BOOT_IMG_AREA(&state, BOOT_PRIMARY_SLOT), &_hdr);
+    FIH_CALL(boot_image_validate_once, fih_rc, BOOT_IMG_AREA(&state, BOOT_SLOT_PRIMARY), &_hdr);
     if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
 #ifdef MCUBOOT_RAM_LOAD
         boot_remove_image_from_sram(&state);
@@ -224,7 +224,7 @@ boot_go(struct boot_rsp *rsp)
 #endif /* MCUBOOT_VALIDATE_PRIMARY_SLOT */
 
 #ifdef MCUBOOT_MEASURED_BOOT
-    rc = boot_save_boot_status(0, &_hdr, BOOT_IMG_AREA(&state, BOOT_PRIMARY_SLOT));
+    rc = boot_save_boot_status(0, &_hdr, BOOT_IMG_AREA(&state, BOOT_SLOT_PRIMARY));
     if (rc != 0) {
         BOOT_LOG_ERR("Failed to add image data to shared area");
         return rc;
@@ -232,15 +232,15 @@ boot_go(struct boot_rsp *rsp)
 #endif /* MCUBOOT_MEASURED_BOOT */
 
 #ifdef MCUBOOT_DATA_SHARING
-    rc = boot_save_shared_data(&_hdr, BOOT_IMG_AREA(&state, BOOT_PRIMARY_SLOT), 0, NULL);
+    rc = boot_save_shared_data(&_hdr, BOOT_IMG_AREA(&state, BOOT_SLOT_PRIMARY), 0, NULL);
     if (rc != 0) {
         BOOT_LOG_ERR("Failed to add data to shared memory area.");
         return rc;
     }
 #endif /* MCUBOOT_DATA_SHARING */
 
-    rsp->br_flash_dev_id = flash_area_get_device_id(BOOT_IMG_AREA(&state, BOOT_PRIMARY_SLOT));
-    rsp->br_image_off = flash_area_get_off(BOOT_IMG_AREA(&state, BOOT_PRIMARY_SLOT));
+    rsp->br_flash_dev_id = flash_area_get_device_id(BOOT_IMG_AREA(&state, BOOT_SLOT_PRIMARY));
+    rsp->br_image_off = flash_area_get_off(BOOT_IMG_AREA(&state, BOOT_SLOT_PRIMARY));
     rsp->br_hdr = &_hdr;
 
 out:


### PR DESCRIPTION
The slots definitions (BOOT_PRIMARY_SLOT, BOOT_SECONDARY_SLOT) were defined in bootutil_priv.h, which made them unusable for bootloader requests. This commit moves them to bootutil_public.h