### PR TITLE
imgtool: Add sha512 to allowed configurations for ECDSA256P1

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -185,7 +185,7 @@ ALLOWED_KEY_SHA = {
     keys.ECDSA384P1         : ['384'],
     keys.ECDSA384P1Public   : ['384'],
     keys.ECDSA256P1         : ['256'],
-    keys.ECDSA256P1Public   : ['256'],
+    keys.ECDSA256P1Public   : ['256', '512'],
     keys.RSA                : ['256'],
     keys.RSAPublic          : ['256'],
     # This two are set to 256 for compatibility, the right would be 512


### PR DESCRIPTION
Added SHA512 to the list of supported algorithms for ECDSA256P1.