### PR TITLE
imgtool: max alignment to 128 bytes for Renesas

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil_public.h
+++ b/boot/bootutil/include/bootutil/bootutil_public.h
@@ -79,7 +79,7 @@ extern "C" {
 #ifdef MCUBOOT_BOOT_MAX_ALIGN
 
 #if defined(MCUBOOT_SWAP_USING_MOVE) || defined(MCUBOOT_SWAP_USING_SCRATCH) || defined(MCUBOOT_SWAP_USING_OFFSET)
-_Static_assert(MCUBOOT_BOOT_MAX_ALIGN >= 8 && MCUBOOT_BOOT_MAX_ALIGN <= 32,
+_Static_assert(MCUBOOT_BOOT_MAX_ALIGN >= 8 && MCUBOOT_BOOT_MAX_ALIGN <= 128,
                "Unsupported value for MCUBOOT_BOOT_MAX_ALIGN for SWAP upgrade modes");
 #endif
 

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -798,7 +798,7 @@ class Image:
         if overwrite_only:
             return self.max_align * 2 + magic_align_size
         else:
-            if write_size not in set([1, 2, 4, 8, 16, 32]):
+            if write_size not in set([1, 2, 4, 8, 16, 32, 128]):
                 raise click.BadParameter("Invalid alignment: {}".format(
                     write_size))
             m = DEFAULT_MAX_SECTORS if max_sectors is None else max_sectors

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -436,11 +436,11 @@ class BasedIntParamType(click.ParamType):
               help='Specify the value of security counter. Use the `auto` '
               'keyword to automatically generate it from the image version.')
 @click.option('-v', '--version', callback=validate_version,  required=True)
-@click.option('--align', type=click.Choice(['1', '2', '4', '8', '16', '32']),
+@click.option('--align', type=click.Choice(['1', '2', '4', '8', '16', '32', '128']),
               default='1',
               required=False,
               help='Alignment used by swap update modes.')
-@click.option('--max-align', type=click.Choice(['8', '16', '32']),
+@click.option('--max-align', type=click.Choice(['8', '16', '32', '128']),
               required=False,
               help='Maximum flash alignment. Set if flash alignment of the '
               'primary and secondary slot differ and any of them is larger '


### PR DESCRIPTION
write-block-size is set to 128 bytes for the ra4, ra6, ra8's flash0 dtsi.

Fix error:
  Error: Invalid value for '--align': '128' is not one of '1', '2', '4', '8', '16', '32'.