### PR TITLE
boot: zephyr: get base addres from dts for flexspi devices

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -39,6 +39,11 @@ BOOT_LOG_MODULE_DECLARE(mcuboot);
 #error "FLASH_DEVICE_NODE could not be determined"
 #endif
 
+#elif (DT_NODE_HAS_STATUS_OKAY(DT_INST(0, nxp_imx_flexspi)) && DT_HAS_CHOSEN(zephyr_flash_controller))
+#define FLASH_DEVICE_ID SPI_FLASH_0_ID
+#define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash_controller)
+#define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_PARENT(FLASH_DEVICE_NODE), 1)
+
 #elif (!defined(CONFIG_XTENSA) && DT_HAS_CHOSEN(zephyr_flash_controller))
 #define FLASH_DEVICE_ID SOC_FLASH_0_ID
 #define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS


### PR DESCRIPTION
Flexspi devices have their AHB address available in the dts which value is now assigned to FLASH_DEVICE_BASE