### PR TITLE
mynewt: Fix flash_area_sector_from_off

### DIFF
--- a/boot/mynewt/flash_map_backend/src/flash_map_extended.c
+++ b/boot/mynewt/flash_map_backend/src/flash_map_extended.c
@@ -70,7 +70,7 @@ int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
         if (start < fa->fa_off) {
             continue;
         }
-        if (off >= start - fa->fa_off && off <= (start - fa->fa_off) + size) {
+        if (off >= start - fa->fa_off && off < (start - fa->fa_off) + size) {
             sector->fs_off = start - fa->fa_off;
             sector->fs_size = size;
             rc = 0;


### PR DESCRIPTION
Function was incorrectly filling sector data when
offset was set to the beginning of the sector.
It returned previous sector instead of correct one.

Original error was introduced way back in #1570 which is in all releases starting from v.1.10.0
For some reason (maybe code was not used or used in other way) it was never triggered till #2275 was merged.

Fixes #2442 