### PR TITLE
boot: bootutil: Fix bootutil_find_key definition

### DIFF
--- a/boot/bootutil/src/bootutil_find_key.c
+++ b/boot/bootutil/src/bootutil_find_key.c
@@ -120,8 +120,7 @@ int bootutil_find_key(uint8_t image_index, uint8_t *key, uint16_t key_len)
 #endif /* !MCUBOOT_BUILTIN_KEY */
 
 #else /* !MCUBOOT_BYPASS_KEY_MATCH */
-static inline int
-bootutil_find_key(uint8_t image_index, uint8_t *key, uint16_t key_len)
+int bootutil_find_key(uint8_t image_index, uint8_t *key, uint16_t key_len)
 {
     (void)image_index;
     (void)key;


### PR DESCRIPTION
Fixes a wrong definition which creates a static inline function which does not match the prototype and also in a file where said function is not used at all