### PR TITLE
Fix logging errors

### DIFF
--- a/boot/bootutil/src/tlv.c
+++ b/boot/bootutil/src/tlv.c
@@ -142,7 +142,7 @@ bootutil_tlv_iter_next(struct image_tlv_iter *it, uint32_t *off, uint16_t *len,
             *len = tlv.it_len;
             it->tlv_off += sizeof(tlv) + tlv.it_len;
             BOOT_LOG_DBG("bootutil_tlv_iter_next: TLV %d found at %d (size %d)",
-                         *type, *off, *len);
+                         tlv.it_type, *off, *len);
             return 0;
         }
 

--- a/boot/zephyr/firmware_loader.c
+++ b/boot/zephyr/firmware_loader.c
@@ -73,7 +73,7 @@ boot_image_validate_once(const struct flash_area *fa_p,
     int rc;
     FIH_DECLARE(fih_rc, FIH_FAILURE);
 
-    BOOT_LOG_DBG("boot_image_validate_once: flash area %p", fap_p);
+    BOOT_LOG_DBG("boot_image_validate_once: flash area %p", fa_p);
 
     memset(&state, 0, sizeof(struct boot_swap_state));
     rc = boot_read_swap_state(fa_p, &state);

--- a/boot/zephyr/single_loader.c
+++ b/boot/zephyr/single_loader.c
@@ -85,7 +85,7 @@ boot_image_validate_once(const struct flash_area *fa_p,
     int rc;
     FIH_DECLARE(fih_rc, FIH_FAILURE);
 
-    BOOT_LOG_DBG("boot_image_validate_once: flash area %p", fap_p);
+    BOOT_LOG_DBG("boot_image_validate_once: flash area %p", fa_p);
 
     memset(&state, 0, sizeof(struct boot_swap_state));
     rc = boot_read_swap_state(fa_p, &state);


### PR DESCRIPTION
Fixes two issues introduced in https://github.com/mcu-tools/mcuboot/pull/2308:

1. `bootutil_tlv_iter_next()` may be called with `type == NULL`.
2. Both static `boot_image_validate_once()` functions in the Zephyr application have a flash area parameter named `fa_p`, not `fap_p`. This presumably went unnoticed because these functions are only compiled when `MCUBOOT_VALIDATE_PRIMARY_SLOT_ONCE` is defined.