### PR TITLE
boot: zephyr: Cleanup RAM by default

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -424,6 +424,7 @@ config MCUBOOT_CLEANUP_ARM_CORE
 config MCUBOOT_CLEANUP_RAM
 	bool "Perform RAM cleanup"
 	depends on CPU_CORTEX_M4 || CPU_CORTEX_M33
+	default y
 	help
 	  Sets contents of memory to 0 before jumping to application.
 


### PR DESCRIPTION
Enable the CONFIG_MCUBOOT_CLEANUP_RAM by deafult to improve security of the default configuration.