### PR TITLE
zephyr: Remove duplicate zephyr module line

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -7,5 +7,3 @@ package-managers:
   pip:
     requirement-files:
       - zephyr/requirements.txt
-samples:
-  - boot/zephyr


### PR DESCRIPTION
Removes declaring samples twice