### PR TITLE
zephyr: nRF54L05 and L10 configuration with LTO enabled

### DIFF
--- a/boot/zephyr/socs/nrf54l05_cpuapp.conf
+++ b/boot/zephyr/socs/nrf54l05_cpuapp.conf
@@ -1,0 +1,3 @@
+# Link Time Optimizations
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+CONFIG_LTO=y

--- a/boot/zephyr/socs/nrf54l10_cpuapp.conf
+++ b/boot/zephyr/socs/nrf54l10_cpuapp.conf
@@ -1,0 +1,3 @@
+# Link Time Optimizations
+CONFIG_ISR_TABLES_LOCAL_DECLARATION=y
+CONFIG_LTO=y


### PR DESCRIPTION
Enable LTO to cut down the MCUboot size for nrf54l10 and nrf54l05.

Ref: https://github.com/mcu-tools/mcuboot/pull/2294