### PR TITLE
boot: zephyr: boards: delete frdm_mcxa156 configuration

### DIFF
--- a/boot/zephyr/boards/frdm_mcxa156.conf
+++ b/boot/zephyr/boards/frdm_mcxa156.conf
@@ -1,5 +1,0 @@
-# Copyright 2024 NXP
-# SPDX-License-Identifier: Apache-2.0
-
-#MCXA156 does not support the MCUBoot swap mode.
-CONFIG_BOOT_UPGRADE_ONLY=y


### PR DESCRIPTION
Deletes configuration for the FRDM-MCXA156 board.
It's not required after MCXA156 flash write-program-size was reduced from 128 to 16 bytes.