### PR TITLE
imgtool: support producing images in test mode

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -283,8 +283,8 @@ def parse_uuid(namespace, value):
 class Image:
 
     def __init__(self, version=None, header_size=IMAGE_HEADER_SIZE,
-                 pad_header=False, pad=False, confirm=False, align=1,
-                 slot_size=0, max_sectors=DEFAULT_MAX_SECTORS,
+                 pad_header=False, pad=False, confirm=False, test=False,
+                 align=1, slot_size=0, max_sectors=DEFAULT_MAX_SECTORS,
                  overwrite_only=False, endian="little", load_addr=0,
                  rom_fixed=None, erased_val=None, save_enctlv=False,
                  security_counter=None, max_align=None,
@@ -301,6 +301,7 @@ class Image:
         self.pad_header = pad_header
         self.pad = pad
         self.confirm = confirm
+        self.test = test
         self.align = align
         self.slot_size = slot_size
         self.max_sectors = max_sectors
@@ -431,12 +432,14 @@ class Image:
                                                   self.save_enctlv,
                                                   self.enctlv_len)
                 trailer_addr = (self.base_addr + self.slot_size) - trailer_size
-                if self.confirm and not self.overwrite_only:
+                if (self.test or self.confirm) and not self.overwrite_only:
                     magic_align_size = align_up(len(self.boot_magic),
                                                 self.max_align)
                     image_ok_idx = -(magic_align_size + self.max_align)
+                    # If test is set, we leave image_ok at the erased value
                     flag = bytearray([self.erased_val] * self.max_align)
-                    flag[0] = 0x01  # image_ok = 0x01
+                    if self.confirm:
+                        flag[0] = 0x01  # image_ok = 0x01
                     h.puts(trailer_addr + trailer_size + image_ok_idx,
                            bytes(flag))
                 h.puts(trailer_addr + (trailer_size - len(self.boot_magic)),
@@ -877,11 +880,13 @@ class Image:
         pbytes = bytearray([self.erased_val] * padding)
         pbytes += bytearray([self.erased_val] * (tsize - len(self.boot_magic)))
         pbytes += self.boot_magic
-        if self.confirm and not self.overwrite_only:
+        if (self.test or self.confirm) and not self.overwrite_only:
             magic_size = 16
             magic_align_size = align_up(magic_size, self.max_align)
             image_ok_idx = -(magic_align_size + self.max_align)
-            pbytes[image_ok_idx] = 0x01  # image_ok = 0x01
+            # If test is set, set leave image_ok at the erased value
+            if self.confirm:
+                pbytes[image_ok_idx] = 0x01  # image_ok = 0x01
         self.payload += pbytes
 
     @staticmethod

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -416,6 +416,9 @@ class BasedIntParamType(click.ParamType):
 @click.option('--confirm', default=False, is_flag=True,
               help='When padding the image, mark it as confirmed (implies '
                    '--pad)')
+@click.option('--test', default=False, is_flag=True,
+              help='When padding the image, mark it for a test swap (implies '
+                   '--pad)')
 @click.option('--pad', default=False, is_flag=True,
               help='Pad image to --slot-size bytes, adding trailer magic')
 @click.option('-S', '--slot-size', type=BasedIntParamType(), required=True,
@@ -478,20 +481,20 @@ class BasedIntParamType(click.ParamType):
 @click.option('--cid', default=None, required=False,
               help='Unique image class identifier, format: (<raw_uuid>|<image_class_name>)')
 def sign(key, public_key_format, align, version, pad_sig, header_size,
-         pad_header, slot_size, pad, confirm, max_sectors, overwrite_only,
+         pad_header, slot_size, pad, confirm, test, max_sectors, overwrite_only,
          endian, encrypt_keylen, encrypt, compression, infile, outfile,
          dependencies, load_addr, hex_addr, erased_val, save_enctlv,
          security_counter, boot_record, custom_tlv, rom_fixed, max_align,
          clear, fix_sig, fix_sig_pubkey, sig_out, user_sha, hmac_sha, is_pure,
          vector_to_sign, non_bootable, vid, cid):
 
-    if confirm:
+    if confirm or test:
         # Confirmed but non-padded images don't make much sense, because
         # otherwise there's no trailer area for writing the confirmed status.
         pad = True
     img = image.Image(version=decode_version(version), header_size=header_size,
                       pad_header=pad_header, pad=pad, confirm=confirm,
-                      align=int(align), slot_size=slot_size,
+                      test=test, align=int(align), slot_size=slot_size,
                       max_sectors=max_sectors, overwrite_only=overwrite_only,
                       endian=endian, load_addr=load_addr, rom_fixed=rom_fixed,
                       erased_val=erased_val, save_enctlv=save_enctlv,


### PR DESCRIPTION
Add --test flag, which allows users to append a trailer that marks the image as ready for a test swap. This can be used for cases where the user wants to load an image to flash that MCUBoot will boot in test mode after system reset.