### PR TITLE
hooks: Use dedicated type for slot numbers

### DIFF
--- a/boot/bootutil/include/bootutil/boot_hooks.h
+++ b/boot/bootutil/include/bootutil/boot_hooks.h
@@ -282,6 +282,6 @@ int flash_area_get_device_id_hook(const struct flash_area *fa,
  * @return 0 if a slot was requested;
  *         BOOT_HOOK_REGULAR follow the normal execution path.
  */
-int boot_find_next_slot_hook(struct boot_loader_state *state, uint8_t image, uint32_t *active_slot);
+int boot_find_next_slot_hook(struct boot_loader_state *state, uint8_t image, enum boot_slot *active_slot);
 
 #endif /*H_BOOTUTIL_HOOKS*/

--- a/boot/zephyr/hooks_sample.c
+++ b/boot/zephyr/hooks_sample.c
@@ -94,7 +94,8 @@ int boot_img_install_stat_hook(int image_index, int slot, int *img_install_stat)
     return BOOT_HOOK_REGULAR;
 }
 
-int boot_find_next_slot_hook(struct boot_loader_state *state, uint8_t image, uint32_t *active_slot)
+int boot_find_next_slot_hook(struct boot_loader_state *state, uint8_t image,
+                             enum boot_slot *active_slot)
 {
     return BOOT_HOOK_REGULAR;
 }


### PR DESCRIPTION
Use the dedicated type to specify the slot number.