### PR TITLE
boot: bootutil: fix image_index definition

### DIFF
--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -204,8 +204,10 @@ bootutil_img_validate(struct boot_loader_state *state,
                       int seed_len, uint8_t *out_hash
                      )
 {
-#if (defined(EXPECTED_KEY_TLV) && defined(MCUBOOT_HW_KEY)) || defined(MCUBOOT_HW_ROLLBACK_PROT) \
-    || defined(MCUBOOT_UUID_VID) || defined(MCUBOOT_UUID_CID)
+#if (defined(EXPECTED_KEY_TLV) && defined(MCUBOOT_HW_KEY)) || \
+    (defined(EXPECTED_SIG_TLV) && defined(MCUBOOT_BUILTIN_KEY)) || \
+    defined(MCUBOOT_HW_ROLLBACK_PROT) || \
+    defined(MCUBOOT_UUID_VID) || defined(MCUBOOT_UUID_CID)
     int image_index = (state == NULL ? 0 : BOOT_CURR_IMG(state));
 #endif
     uint32_t off;


### PR DESCRIPTION
`image_index` is used when when `MCUBOOT_BUILTIN_KEY` and `EXPECTED_SIG_TLV` are set, but in this case this variable is never defined.