### PR TITLE
Secure boot for EFR32

### DIFF
--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -206,7 +206,8 @@ bootutil_img_validate(struct boot_loader_state *state,
                       int seed_len, uint8_t *out_hash
                      )
 {
-#if (defined(EXPECTED_KEY_TLV) && defined(MCUBOOT_HW_KEY)) || defined(MCUBOOT_HW_ROLLBACK_PROT)
+/* Added MCUBOOT_BUILTIN_KEY support: image_index is required for builtin key lookup */
+#if (defined(EXPECTED_KEY_TLV) && defined(MCUBOOT_HW_KEY)) || defined(MCUBOOT_HW_ROLLBACK_PROT) || defined(MCUBOOT_BUILTIN_KEY) 
     int image_index = (state == NULL ? 0 : BOOT_CURR_IMG(state));
 #endif
     uint32_t off;

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -13,6 +13,12 @@ if(TEST_RUNTIME_SOURCE_HOOKS)
   set(EXTRA_ZEPHYR_MODULES "${CMAKE_SOURCE_DIR}/../../samples/runtime-source/zephyr/hooks")
 endif()
 
+# Parse prj.conf for Silicon Labs configuration before Zephyr processing
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/prj.conf")
+  file(READ "${CMAKE_CURRENT_SOURCE_DIR}/prj.conf" PRJ_CONF_CONTENT)
+  string(REGEX MATCH "(^|\n)# SILABS_APP_PROPERTIES_ENABLED" SILABS_APP_PROPERTIES_ENABLED "${PRJ_CONF_CONTENT}")
+endif()
+
 # find_package(Zephyr) in order to load application boilerplate:
 # http://docs.zephyrproject.org/application/application.html
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
@@ -727,4 +733,11 @@ if(SYSBUILD)
 
   set(mcuboot_image_footer_size ${required_size} CACHE INTERNAL "Estimated MCUboot image trailer size" FORCE)
   set(mcuboot_image_upgrade_footer_size ${required_upgrade_size} CACHE INTERNAL "Estimated MCUboot update image trailer size" FORCE)
+endif()
+
+# Include Silicon Labs application properties
+if(CONFIG_SOC_FAMILY_SILABS_S2 AND SILABS_APP_PROPERTIES_ENABLED)
+  target_sources(app PRIVATE silabs/application_properties.c)
+  target_include_directories(app PRIVATE silabs)
+  target_link_libraries(app PRIVATE "-Wl,--undefined=sl_app_properties")  
 endif()

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -513,4 +513,15 @@
     k_cpu_idle(); \
   }
 
+/*
+ * ================================================================
+ * SE Manager-Based Hardware Crypto + PSA SE Key Configuration
+ * ================================================================
+ */
+/* Enable PSA built-in key support for SE-stored keys */
+#if defined(CONFIG_PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256)
+#define MCUBOOT_BUILTIN_KEY
+#define MCUBOOT_BUILTIN_KEY_ID_OVERRIDE 0x7fff0001U  // SL_SE_BUILTIN_KEY_SECUREBOOT_ID
+#endif
+
 #endif /* __MCUBOOT_CONFIG_H__ */

--- a/boot/zephyr/silabs/app_properties_config.h
+++ b/boot/zephyr/silabs/app_properties_config.h
@@ -1,0 +1,66 @@
+/***************************************************************************//**
+ * @file
+ * @brief Application Properties Header File
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2021 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+#ifndef APP_PROPERTIES_CONFIG_H
+#define APP_PROPERTIES_CONFIG_H
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h>App Properties settings
+
+// Type of signature this application is signed with
+#if defined(CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256)
+#define SL_APPLICATION_SIGNATURE               (1UL << 0UL)
+#else
+#define SL_APPLICATION_SIGNATURE               (0UL)
+#endif
+
+// Location of the signature
+// Default: 0xFFFFFFFF
+#define SL_APPLICATION_SIGNATURE_LOCATION      0
+
+// Bitfield representing type of application
+#define SL_APPLICATION_TYPE                    (1UL << 6UL)
+
+// <o SL_APPLICATION_VERSION> Version number for this application
+// <0-4294967295:1>
+// <i> Default: 1 [0-4294967295]
+#define SL_APPLICATION_VERSION                 0x00010000
+
+// Capabilities of this application
+// Default: 0
+#define SL_APPLICATION_CAPABILITIES            0
+
+//Product ID of the device for which the application is built
+#define SL_APPLICATION_PRODUCT_ID             { 0 }
+
+// </h>
+
+#endif // APP_PROPERTIES_CONFIG_H

--- a/boot/zephyr/silabs/application_properties.c
+++ b/boot/zephyr/silabs/application_properties.c
@@ -1,0 +1,52 @@
+/***************************************************************************//**
+ * @file
+ * @brief Application Properties Source File
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2021 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+#include "application_properties.h"
+
+#ifdef APP_PROPERTIES_CONFIG_FILE
+#include APP_PROPERTIES_CONFIG_FILE
+#else
+#include "app_properties_config.h"
+#endif
+
+const ApplicationProperties_t sl_app_properties = {
+  .magic = APPLICATION_PROPERTIES_MAGIC,
+  .structVersion = APPLICATION_PROPERTIES_VERSION,
+  .signatureType = SL_APPLICATION_SIGNATURE,
+  .signatureLocation = SL_APPLICATION_SIGNATURE_LOCATION,
+  .app = {
+    .type = SL_APPLICATION_TYPE,
+    .version = SL_APPLICATION_VERSION,
+    .capabilities = SL_APPLICATION_CAPABILITIES,
+    .productId = SL_APPLICATION_PRODUCT_ID
+  },
+  .cert = 0,
+  .longTokenSectionAddress = 0,
+  .decryptKey = { 0 }
+};

--- a/boot/zephyr/silabs/application_properties.h
+++ b/boot/zephyr/silabs/application_properties.h
@@ -1,0 +1,168 @@
+/***************************************************************************//**
+ * @file
+ * @brief Representation of Application Properties
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2021 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * The licensor of this software is Silicon Laboratories Inc.  Your use of this
+ * software is governed by the terms of Silicon Labs Master Software License
+ * Agreement (MSLA) available at
+ * www.silabs.com/about-us/legal/master-software-license-agreement.  This
+ * software is distributed to you in Source Code format and is governed by the
+ * sections of the MSLA applicable to Source Code.
+ *
+ ******************************************************************************/
+#ifndef APPLICATION_PROPERTIES_H
+#define APPLICATION_PROPERTIES_H
+
+#include <stdint.h>
+
+/***************************************************************************//**
+ * @addtogroup Interface
+ * @{
+ * @addtogroup ApplicationProperties Application Properties
+ * @brief Properties of the application that can be accessed by the bootloader
+ * @details
+ *   Applications must contain an @ref ApplicationProperties_t struct declaring
+ *   the application version and capabilities, and so on. The metadata contained
+ *   in this struct will be extracted from the application by the Simplicity
+ *   Commander tool and placed in the GBL upgrade file. If this struct is not
+ *   in the application image, it will be added to the GBL file by the
+ *   Simplicity Commander.
+ *
+ *   The struct is also used to declare whether the application image is signed
+ *   and what type of signature is used. If no @ref ApplicationProperties_t
+ *   struct is present, the bootloader will assume that the application image
+ *   is signed using @ref APPLICATION_SIGNATURE_ECDSA_P256.
+ *
+ *   To ensure that the bootloader can easily locate the ApplicationProperties_t
+ *   struct, if not already done by the linker, Simplicity Commander will modify
+ *   word 13 of the application to insert a pointer to the
+ *   ApplicationProperties_t struct.
+ * @{
+ ******************************************************************************/
+
+/// Magic value declaring the existence of an ApplicationProperties_t struct
+#define APPLICATION_PROPERTIES_MAGIC     { \
+    0x13, 0xb7, 0x79, 0xfa,                \
+    0xc9, 0x25, 0xdd, 0xb7,                \
+    0xad, 0xf3, 0xcf, 0xe0,                \
+    0xf1, 0xb6, 0x14, 0xb8                 \
+}
+
+/// Byte-reversed version of ::APPLICATION_PROPERTIES_MAGIC
+#define APPLICATION_PROPERTIES_REVERSED  { \
+    0xb8, 0x14, 0xb6, 0xf1,                \
+    0xe0, 0xcf, 0xf3, 0xad,                \
+    0xb7, 0xdd, 0x25, 0xc9,                \
+    0xfa, 0x79, 0xb7, 0x13                 \
+}
+
+/// Major version number of the AppliationProperties_t struct
+#define APPLICATION_PROPERTIES_VERSION_MAJOR (1UL)
+/// Minor version number of the AppliationProperties_t struct
+#define APPLICATION_PROPERTIES_VERSION_MINOR (2UL)
+/// Version number of the ApplicationCertificate_t struct
+#define APPLICATION_CERTIFICATE_VERSION  (1UL)
+/// The application is not signed
+#define APPLICATION_SIGNATURE_NONE       (0UL)
+/// @brief The SHA-256 digest of the application is signed using ECDSA with the
+///        NIST P-256 curve.
+#define APPLICATION_SIGNATURE_ECDSA_P256 (1UL << 0UL)
+/// @brief The application is not signed, but has a CRC-32 checksum
+#define APPLICATION_SIGNATURE_CRC32      (1UL << 1UL)
+
+/// The application contains a Zigbee wireless stack
+#define APPLICATION_TYPE_ZIGBEE          (1UL << 0UL)
+/// The application contains a Thread wireless stack
+#define APPLICATION_TYPE_THREAD          (1UL << 1UL)
+/// The application contains a Flex wireless stack
+#define APPLICATION_TYPE_FLEX            (1UL << 2UL)
+/// The application contains a Bluetooth wireless stack
+#define APPLICATION_TYPE_BLUETOOTH       (1UL << 3UL)
+/// The application is an MCU application
+#define APPLICATION_TYPE_MCU             (1UL << 4UL)
+/// The application contains a Bluetooth application
+#define APPLICATION_TYPE_BLUETOOTH_APP   (1UL << 5UL)
+/// The application contains a bootloader
+#define APPLICATION_TYPE_BOOTLOADER      (1UL << 6UL)
+/// The application contains a Zwave wireless stack
+#define APPLICATION_TYPE_ZWAVE           (1UL << 7UL)
+
+/// Application Data
+typedef struct ApplicationData {
+  /// @brief Bitfield representing type of application, e.g.,
+  /// @ref APPLICATION_TYPE_ZIGBEE
+  uint32_t type;
+  /// Version number for this application
+  uint32_t version;
+  /// Capabilities of this application
+  uint32_t capabilities;
+  /// Unique ID (UUID or GUID) for the product this application is built for
+  uint8_t productId[16];
+} ApplicationData_t;
+
+/// Application Certificate
+typedef struct ApplicationCertificate {
+  /// Version of the certificate structure
+  uint8_t structVersion;
+  /// Reserved flags
+  uint8_t flags[3];
+  /// Public key
+  uint8_t key[64];
+  /// The version number of this certificate
+  uint32_t version;
+  /// Signature of the certificate
+  uint8_t signature[64];
+} ApplicationCertificate_t;
+
+/// Application Properties struct
+typedef struct {
+  /// @brief Magic value indicating this is an ApplicationProperties_t struct.
+  /// Must equal @ref APPLICATION_PROPERTIES_MAGIC
+  uint8_t magic[16];
+  /// Version number of this struct
+  uint32_t structVersion;
+  /// Type of signature this application is signed with
+  uint32_t signatureType;
+  /// Location of the signature. Typically points to the end of the application
+  uint32_t signatureLocation;
+  /// Information about the application
+  ApplicationData_t app;
+  /// Pointer to information about the certificate
+  ApplicationCertificate_t *cert;
+  /// Pointer to Long Token Data Section
+  uint8_t *longTokenSectionAddress;
+  /// Parser Decryption Key
+  const uint8_t decryptKey[16];
+} ApplicationProperties_t;
+
+/** @} (end addtogroup ApplicationProperties) */
+/** @} (end addtogroup Interface) */
+
+/// Application Properties major version shift value
+#define APPLICATION_PROPERTIES_VERSION_MAJOR_SHIFT (0U)
+/// Application Properties minor version shift value
+#define APPLICATION_PROPERTIES_VERSION_MINOR_SHIFT (8U)
+
+/// Application Properties major version mask
+#define APPLICATION_PROPERTIES_VERSION_MAJOR_MASK (0x000000FFU)
+/// Application Properties minor version mask
+#define APPLICATION_PROPERTIES_VERSION_MINOR_MASK (0xFFFFFF00U)
+
+/// Version number of the AppliationProperties_t struct
+#define APPLICATION_PROPERTIES_VERSION ((APPLICATION_PROPERTIES_VERSION_MINOR           \
+                                         << APPLICATION_PROPERTIES_VERSION_MINOR_SHIFT) \
+                                        | (APPLICATION_PROPERTIES_VERSION_MAJOR         \
+                                           << APPLICATION_PROPERTIES_VERSION_MAJOR_SHIFT))
+
+#if (APPLICATION_PROPERTIES_VERSION_MAJOR \
+     > (APPLICATION_PROPERTIES_VERSION_MAJOR_MASK >> APPLICATION_PROPERTIES_VERSION_MAJOR_SHIFT)) \
+|| (APPLICATION_PROPERTIES_VERSION_MINOR \
+    > (APPLICATION_PROPERTIES_VERSION_MINOR_MASK >> APPLICATION_PROPERTIES_VERSION_MINOR_SHIFT))
+#error "Invalid application properties version"
+#endif
+
+#endif // APPLICATION_PROPERTIES_H


### PR DESCRIPTION
PLATFORM_HYD-5622: Zephyr EFR32 Secure Boot PLT_security

- Modified `image_validate.c`
- Added Silabs application properties:
  - application_properties.c/h
  - application_properties.h
  - app_properties_config.h
- Updated Zephyr integration:
  - mcuboot_config.h
  - CMakeLists.txt

