### PR TITLE
workflows: zephyr: Fix zephyr builds

### DIFF
--- a/.github/workflows/zephyr_build.yaml
+++ b/.github/workflows/zephyr_build.yaml
@@ -75,7 +75,7 @@ jobs:
           base-path: repos/zephyr
           toolchains: arm-zephyr-eabi
           sdk-version: 0.17.4
-          west-project-filter: -.*,+cmsis,+cmsis_6,+hal_nordic,+hal_nxp,+hal_stm32,+libmetal,+littlefs,+mbedtls,+mcuboot,+open-amp,+tinycrypt,+trusted-firmware-m,+zcbor
+          west-project-filter: -.*,+cmsis,+cmsis_6,+hal_nordic,+hal_nxp,+hal_stm32,+hal_ti,+libmetal,+littlefs,+mbedtls,+mcuboot,+open-amp,+tinycrypt,+trusted-firmware-m,+zcbor
           ccache-max-size: 768MB
 
       - name: Checkout MCUBoot


### PR DESCRIPTION
Fixes zephyr builds by adding the TI hal module to the allow list