### PR TITLE
boot: zephyr: get base addres from CONFIG_FLASH_BASE_ADDRESS

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -42,7 +42,7 @@ BOOT_LOG_MODULE_DECLARE(mcuboot);
 #elif (DT_NODE_HAS_STATUS_OKAY(DT_INST(0, nxp_imx_flexspi)) && DT_HAS_CHOSEN(zephyr_flash_controller))
 #define FLASH_DEVICE_ID SPI_FLASH_0_ID
 #define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash_controller)
-#define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_PARENT(FLASH_DEVICE_NODE), 1)
+#define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS
 
 #elif (!defined(CONFIG_XTENSA) && DT_HAS_CHOSEN(zephyr_flash_controller))
 #define FLASH_DEVICE_ID SOC_FLASH_0_ID


### PR DESCRIPTION
1. The base address of the flash has been obtained in kconfig, (https://github.com/zephyrproject-rtos/zephyr/blob/main/soc/nxp/common/Kconfig.flexspi_xip#L13) so there is no need to obtain it through DT.

2. Obtaining the base address by `#define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_PARENT(FLASH_DEVICE_NODE), 1)` will cause build issues in the MCXN series. (see https://github.com/zephyrproject-rtos/zephyr/issues/97021)