### PR TITLE
loader: Enforce version equality in slot deps

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -365,7 +365,7 @@ boot_verify_slot_dependency(struct boot_loader_state *state,
         /* Dependency satisfied. */
         rc = 0;
     }
-#else
+#elif !defined(MCUBOOT_VERSION_CMP_USE_SLOT_NUMBER)
   if (rc >= 0) {
         /* Dependency satisfied. */
         rc = 0;


### PR DESCRIPTION
In case of slotted dependency, interpret the version as a strict requirement, not just as a minimum compatible version.

This change fixes a problem of incorrect dependency resolution for fully dependent slots (a,s0 -> b,s0 and b,s0 -> a,s0), because the satisfaction of both of them will be checked in an image with lower index, which is required for the current algorithm to work correctly.