### PR TITLE
boot: zephyr: fix getting base address for certain boards

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -39,7 +39,8 @@ BOOT_LOG_MODULE_DECLARE(mcuboot);
 #error "FLASH_DEVICE_NODE could not be determined"
 #endif
 
-#elif (DT_NODE_HAS_STATUS_OKAY(DT_INST(0, nxp_imx_flexspi)) && DT_HAS_CHOSEN(zephyr_flash_controller))
+#elif (DT_NODE_HAS_COMPAT(DT_PARENT(DT_CHOSEN(zephyr_flash_controller)),       \
+			  nxp_imx_flexspi))
 #define FLASH_DEVICE_ID SPI_FLASH_0_ID
 #define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash_controller)
 #define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_PARENT(FLASH_DEVICE_NODE), 1)


### PR DESCRIPTION
This fixes the build for boards who have have a flexspi controller but having different controller assigned to zephyr,flash-controller in the DTS.

This solves this issue: zephyrproject-rtos/zephyr#97021