### PR TITLE
bootutil: Replace boot_write_enc_key with boot_write_enc_keys

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -407,23 +407,25 @@ boot_write_swap_size(const struct flash_area *fap, uint32_t swap_size)
 
 #ifdef MCUBOOT_ENC_IMAGES
 int
-boot_write_enc_key(const struct flash_area *fap, uint8_t slot,
-        const struct boot_status *bs)
+boot_write_enc_keys(const struct flash_area *fap, const struct boot_status *bs)
 {
-    uint32_t off;
-    int rc;
+    int slot;
 
-    off = boot_enc_key_off(fap, slot);
-    BOOT_LOG_DBG("writing enc_key; fa_id=%d off=0x%lx (0x%lx)",
-                 flash_area_get_id(fap), (unsigned long)off,
-                 (unsigned long)flash_area_get_off(fap) + off);
+    for (slot = 0; slot < BOOT_NUM_SLOTS; ++slot) {
+        uint32_t off = boot_enc_key_off(fap, slot);
+        int rc;
+
+        BOOT_LOG_DBG("writing enc_key; fa_id=%d off=0x%lx (0x%lx)",
+                     flash_area_get_id(fap), (unsigned long)off,
+                     (unsigned long)flash_area_get_off(fap) + off);
 #if MCUBOOT_SWAP_SAVE_ENCTLV
-    rc = flash_area_write(fap, off, bs->enctlv[slot], BOOT_ENC_TLV_ALIGN_SIZE);
+        rc = flash_area_write(fap, off, bs->enctlv[slot], BOOT_ENC_TLV_ALIGN_SIZE);
 #else
-    rc = flash_area_write(fap, off, bs->enckey[slot], BOOT_ENC_KEY_ALIGN_SIZE);
+        rc = flash_area_write(fap, off, bs->enckey[slot], BOOT_ENC_KEY_ALIGN_SIZE);
 #endif
-    if (rc != 0) {
-        return BOOT_EFLASH;
+        if (rc != 0) {
+            return BOOT_EFLASH;
+        }
     }
 
     return 0;

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -371,8 +371,7 @@ int boot_scramble_slot(const struct flash_area *fap, int slot);
 bool boot_status_is_reset(const struct boot_status *bs);
 
 #ifdef MCUBOOT_ENC_IMAGES
-int boot_write_enc_key(const struct flash_area *fap, uint8_t slot,
-                       const struct boot_status *bs);
+int boot_write_enc_keys(const struct flash_area *fap, const struct boot_status *bs);
 int boot_read_enc_key(const struct flash_area *fap, uint8_t slot,
                       struct boot_status *bs);
 #endif

--- a/boot/bootutil/src/swap_misc.c
+++ b/boot/bootutil/src/swap_misc.c
@@ -137,11 +137,7 @@ swap_status_init(const struct boot_loader_state *state,
     assert(rc == 0);
 
 #ifdef MCUBOOT_ENC_IMAGES
-    rc = boot_write_enc_key(fap, 0, bs);
-    assert(rc == 0);
-
-    rc = boot_write_enc_key(fap, 1, bs);
-    assert(rc == 0);
+    rc = boot_write_enc_keys(fap, bs);
 #endif
 
     rc = boot_write_magic(fap);

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -884,11 +884,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
             assert(rc == 0);
 
 #ifdef MCUBOOT_ENC_IMAGES
-            rc = boot_write_enc_key(fap_primary_slot, 0, bs);
-            assert(rc == 0);
-
-            rc = boot_write_enc_key(fap_primary_slot, 1, bs);
-            assert(rc == 0);
+            rc = boot_write_enc_keys(fap_primary_slot, bs);
 #endif
             rc = boot_write_magic(fap_primary_slot);
             assert(rc == 0);


### PR DESCRIPTION
All keys are written at once anyway.