### PR TITLE
boot: zephyr: Allow disabling default multiple RAM region file

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -550,7 +550,7 @@ if((CONFIG_BOOT_SWAP_USING_SCRATCH OR CONFIG_BOOT_SWAP_USING_MOVE OR CONFIG_BOOT
   zephyr_library_sources(flash_check.c)
 endif()
 
-if(CONFIG_BOOT_RAM_LOAD)
+if(CONFIG_MULTIPLE_EXECUTABLE_RAM_REGIONS_DEFAULT_FILE)
   zephyr_library_sources(ram_load.c)
 endif()
 

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -637,6 +637,16 @@ config MULTIPLE_EXECUTABLE_RAM_REGIONS
 	  When selected, boot_get_image_exec_ram_info() should be updated to provide
 	  the information about the areas.
 
+config MULTIPLE_EXECUTABLE_RAM_REGIONS_DEFAULT_FILE
+	bool "Default MCUboot multiple executable RAM region source file"
+	default y
+	depends on MULTIPLE_EXECUTABLE_RAM_REGIONS
+	help
+	  When enabled, will include the default MCUboot file that has the
+	  boot_get_image_exec_ram_info() implementation in it, for users with out-of-tree or
+	  custom configuration then this option can be disabled and a custom file can be added
+	  by a CMake module which defines the configuration for the intended board.
+
 config FLASH_RUNTIME_SOURCES
 	bool "Images are read from flash partitions defined at runtime"
 	depends on SINGLE_APPLICATION_SLOT

--- a/boot/zephyr/ram_load.c
+++ b/boot/zephyr/ram_load.c
@@ -19,12 +19,10 @@
 
 #include <zephyr/devicetree.h>
 
-#ifdef MULTIPLE_EXECUTABLE_RAM_REGIONS
 int boot_get_image_exec_ram_info(uint32_t image_id,
                                  uint32_t *exec_ram_start,
                                  uint32_t *exec_ram_size)
 {
-
 #ifdef CONFIG_SOC_SERIES_STM32N6X
     *exec_ram_start = DT_PROP_BY_IDX(DT_NODELABEL(axisram1), reg, 0);
     *exec_ram_size = DT_PROP_BY_IDX(DT_NODELABEL(axisram1), reg, 1);
@@ -32,4 +30,3 @@ int boot_get_image_exec_ram_info(uint32_t image_id,
 
     return 0;
 }
-#endif /* MULTIPLE_EXECUTABLE_RAM_REGIONS */


### PR DESCRIPTION
Allows disabling the default MCUboot Zephyr file specifying the multiple RAM regions, in order to allow users to supply their own versions