### PR TITLE
bootutil: boot_enc_set_key does not need to know boot_status

### DIFF
--- a/boot/boot_serial/src/boot_serial_encryption.c
+++ b/boot/boot_serial/src/boot_serial_encryption.c
@@ -239,7 +239,8 @@ decrypt_image_inplace(const struct flash_area *fa_p,
         if (rc < 0) {
             FIH_RET(fih_rc);
         }
-        if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_PRIMARY, bs)) {
+        if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_PRIMARY,
+                                        bs->enckey[BOOT_SLOT_PRIMARY])) {
             FIH_RET(fih_rc);
         }
     }

--- a/boot/bootutil/include/bootutil/enc_key.h
+++ b/boot/bootutil/include/bootutil/enc_key.h
@@ -64,7 +64,7 @@ int boot_decrypt_key(const uint8_t *buf, uint8_t *enckey);
 int boot_enc_init(struct enc_key_data *enc_state, uint8_t slot);
 int boot_enc_drop(struct enc_key_data *enc_state, uint8_t slot);
 int boot_enc_set_key(struct enc_key_data *enc_state, uint8_t slot,
-                     const struct boot_status *bs);
+                     const uint8_t *key);
 int boot_enc_load(struct boot_loader_state *state, int slot,
                   const struct image_header *hdr, const struct flash_area *fap,
                   struct boot_status *bs);

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -643,11 +643,11 @@ boot_enc_drop(struct enc_key_data *enc_state, uint8_t slot)
 
 int
 boot_enc_set_key(struct enc_key_data *enc_state, uint8_t slot,
-        const struct boot_status *bs)
+        const uint8_t *key)
 {
     int rc;
 
-    rc = bootutil_aes_ctr_set_key(&enc_state[slot].aes_ctr, bs->enckey[slot]);
+    rc = bootutil_aes_ctr_set_key(&enc_state[slot].aes_ctr, key);
     if (rc != 0) {
         boot_enc_drop(enc_state, slot);
         return -1;

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -645,7 +645,8 @@ boot_image_check(struct boot_loader_state *state, struct image_header *hdr,
         if (rc < 0) {
             FIH_RET(fih_rc);
         }
-        if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_SECONDARY, bs)) {
+        if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_SECONDARY,
+                                        bs->enckey[BOOT_SLOT_SECONDARY])) {
             FIH_RET(fih_rc);
         }
     }
@@ -1496,7 +1497,8 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
         if (rc < 0) {
             return BOOT_EBADIMAGE;
         }
-        if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_SECONDARY, bs)) {
+        if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_SECONDARY,
+                                        bs->enckey[BOOT_SLOT_SECONDARY])) {
             return BOOT_EBADIMAGE;
         }
     }
@@ -1618,7 +1620,8 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
             assert(rc >= 0);
 
             if (rc == 0) {
-                rc = boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_PRIMARY, bs);
+                rc = boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_PRIMARY,
+                                      bs->enckey[BOOT_SLOT_PRIMARY]);
                 assert(rc == 0);
             } else {
                 rc = 0;
@@ -1642,7 +1645,8 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
             assert(rc >= 0);
 
             if (rc == 0) {
-                rc = boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_SECONDARY, bs);
+                rc = boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_SECONDARY,
+                                      bs->enckey[BOOT_SLOT_SECONDARY]);
                 assert(rc == 0);
             } else {
                 rc = 0;
@@ -1685,7 +1689,7 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
             }
 
             if (i != BOOT_ENC_KEY_SIZE) {
-                boot_enc_set_key(BOOT_CURR_ENC(state), slot, bs);
+                boot_enc_set_key(BOOT_CURR_ENC(state), slot, bs->enckey[slot]);
             }
         }
 #endif

--- a/boot/bootutil/src/ram_load.c
+++ b/boot/bootutil/src/ram_load.c
@@ -155,7 +155,7 @@ boot_decrypt_and_copy_image_to_sram(struct boot_loader_state *state,
     }
 
     /* if rc > 0 then the key has already been loaded */
-    if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC(state), slot, &bs)) {
+    if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC(state), slot, bs->enckey[slot])) {
         goto done;
     }
 


### PR DESCRIPTION
boot_enc_set_key now reads key to provided buffer, if that buffer is in boot_state, then caller is responsible to provide pointer.