### PR TITLE
bootutil: Drop slot number and boot_state from most boot_enc functions

### DIFF
--- a/boot/boot_serial/src/boot_serial_encryption.c
+++ b/boot/boot_serial/src/boot_serial_encryption.c
@@ -35,7 +35,7 @@ boot_image_validate_encrypted(struct boot_loader_state *state,
         if (rc < 0) {
             FIH_RET(fih_rc);
         }
-        rc = boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_SECONDARY, bs);
+        rc = boot_enc_set_key(BOOT_CURR_ENC_SLOT(state, BOOT_SLOT_SECONDARY), bs->enckey[BOOT_SLOT_SECONDARY]);
         if (rc < 0) {
             FIH_RET(fih_rc);
         }
@@ -169,7 +169,7 @@ decrypt_region_inplace(struct boot_loader_state *state,
                     blk_sz = tlv_off - (off + bytes_copied);
                 }
             }
-            boot_enc_decrypt(BOOT_CURR_ENC(state), slot,
+            boot_enc_decrypt(BOOT_CURR_ENC_SLOT(state, slot),
                     (off + bytes_copied + idx) - hdr->ih_hdr_size, blk_sz,
                     blk_off, &buf[idx]);
         }
@@ -239,7 +239,7 @@ decrypt_image_inplace(const struct flash_area *fa_p,
         if (rc < 0) {
             FIH_RET(fih_rc);
         }
-        if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_PRIMARY, bs)) {
+        if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC_SLOT(state, BOOT_SLOT_PRIMARY), bs->enckey[BOOT_SLOT_PRIMARY])) {
             FIH_RET(fih_rc);
         }
     }

--- a/boot/bootutil/include/bootutil/enc_key.h
+++ b/boot/bootutil/include/bootutil/enc_key.h
@@ -61,18 +61,18 @@ struct boot_loader_state;
 /* Decrypt random, symmetric encryption key */
 int boot_decrypt_key(const uint8_t *buf, uint8_t *enckey);
 
-int boot_enc_init(struct enc_key_data *enc_state, uint8_t slot);
-int boot_enc_drop(struct enc_key_data *enc_state, uint8_t slot);
-int boot_enc_set_key(struct enc_key_data *enc_state, uint8_t slot,
-                     const struct boot_status *bs);
+int boot_enc_init(struct enc_key_data *enc_state);
+int boot_enc_drop(struct enc_key_data *enc_state);
+int boot_enc_set_key(struct enc_key_data *enc_state, const uint8_t *key);
 int boot_enc_load(struct boot_loader_state *state, int slot,
                   const struct image_header *hdr, const struct flash_area *fap,
                   struct boot_status *bs);
-bool boot_enc_valid(struct enc_key_data *enc_state, int slot);
-void boot_enc_encrypt(struct enc_key_data *enc_state, int slot,
+bool boot_enc_valid(const struct enc_key_data *enc_state);
+void boot_enc_encrypt(struct enc_key_data *enc_state,
         uint32_t off, uint32_t sz, uint32_t blk_off, uint8_t *buf);
-void boot_enc_decrypt(struct enc_key_data *enc_state, int slot,
+void boot_enc_decrypt(struct enc_key_data *enc_state,
         uint32_t off, uint32_t sz, uint32_t blk_off, uint8_t *buf);
+/* Note that boot_enc_zeorize takes BOOT_CURR_ENC, not BOOT_CURR_ENC_SLOT */
 void boot_enc_zeroize(struct enc_key_data *enc_state);
 
 #ifdef __cplusplus

--- a/boot/bootutil/src/bootutil_img_hash.c
+++ b/boot/bootutil/src/bootutil_img_hash.c
@@ -65,7 +65,6 @@ bootutil_img_hash(struct boot_loader_state *state,
     int fa_ret;
 #endif
 #if defined(MCUBOOT_ENC_IMAGES)
-    struct enc_key_data *enc_state;
     int image_index;
 #endif
 #if defined(MCUBOOT_SWAP_USING_OFFSET)
@@ -91,16 +90,14 @@ bootutil_img_hash(struct boot_loader_state *state,
 
 #ifdef MCUBOOT_ENC_IMAGES
     if (state == NULL) {
-        enc_state = NULL;
         image_index = 0;
     } else {
-        enc_state = BOOT_CURR_ENC(state);
         image_index = BOOT_CURR_IMG(state);
     }
 
     /* Encrypted images only exist in the secondary slot */
     if (MUST_DECRYPT(fap, image_index, hdr) &&
-            !boot_enc_valid(enc_state, 1)) {
+            !boot_enc_valid(BOOT_CURR_ENC_SLOT(state, BOOT_SLOT_SECONDARY))) {
         BOOT_LOG_DBG("bootutil_img_hash: error encrypted image found in primary slot");
         return -1;
     }
@@ -182,7 +179,7 @@ bootutil_img_hash(struct boot_loader_state *state,
 
             if (off >= hdr_size && off < tlv_off) {
                 blk_off = (off - hdr_size) & 0xf;
-                boot_enc_decrypt(enc_state, slot, off - hdr_size,
+                boot_enc_decrypt(BOOT_CURR_ENC_SLOT(state, slot), off - hdr_size,
                                  blk_sz, blk_off, tmp_buf);
             }
         }

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -483,8 +483,10 @@ static inline bool boot_u16_safe_add(uint16_t *dest, uint16_t a, uint16_t b)
 #endif
 #ifdef MCUBOOT_ENC_IMAGES
 #define BOOT_CURR_ENC(state) ((state)->enc[BOOT_CURR_IMG(state)])
+#define BOOT_CURR_ENC_SLOT(state, slot) (&((state)->enc[BOOT_CURR_IMG(state)][slot]))
 #else
 #define BOOT_CURR_ENC(state) NULL
+#define BOOT_CURR_ENC_SLOT(state, slot) NULL
 #endif
 #define BOOT_IMG(state, slot) ((state)->imgs[BOOT_CURR_IMG(state)][(slot)])
 #define BOOT_IMG_AREA(state, slot) (BOOT_IMG(state, slot).area)

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -645,7 +645,7 @@ boot_image_check(struct boot_loader_state *state, struct image_header *hdr,
         if (rc < 0) {
             FIH_RET(fih_rc);
         }
-        if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_SECONDARY, bs)) {
+        if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC_SLOT(state, BOOT_SLOT_SECONDARY), bs->enckey[BOOT_SLOT_SECONDARY])) {
             FIH_RET(fih_rc);
         }
     }
@@ -1378,11 +1378,11 @@ boot_copy_region(struct boot_loader_state *state,
                     }
                 }
                 if (source_slot == 0) {
-                    boot_enc_encrypt(BOOT_CURR_ENC(state), source_slot,
+                    boot_enc_encrypt(BOOT_CURR_ENC_SLOT(state, source_slot),
                             (abs_off + idx) - hdr->ih_hdr_size, blk_sz,
                             blk_off, &buf[idx]);
                 } else {
-                    boot_enc_decrypt(BOOT_CURR_ENC(state), source_slot,
+                    boot_enc_decrypt(BOOT_CURR_ENC_SLOT(state, source_slot),
                             (abs_off + idx) - hdr->ih_hdr_size, blk_sz,
                             blk_off, &buf[idx]);
                 }
@@ -1496,7 +1496,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
         if (rc < 0) {
             return BOOT_EBADIMAGE;
         }
-        if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_SECONDARY, bs)) {
+        if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC_SLOT(state, BOOT_SLOT_SECONDARY), bs->enckey[BOOT_SLOT_SECONDARY])) {
             return BOOT_EBADIMAGE;
         }
     }
@@ -1618,7 +1618,7 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
             assert(rc >= 0);
 
             if (rc == 0) {
-                rc = boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_PRIMARY, bs);
+                rc = boot_enc_set_key(BOOT_CURR_ENC_SLOT(state, BOOT_SLOT_PRIMARY), bs->enckey[BOOT_SLOT_PRIMARY]);
                 assert(rc == 0);
             } else {
                 rc = 0;
@@ -1642,7 +1642,7 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
             assert(rc >= 0);
 
             if (rc == 0) {
-                rc = boot_enc_set_key(BOOT_CURR_ENC(state), BOOT_SLOT_SECONDARY, bs);
+                rc = boot_enc_set_key(BOOT_CURR_ENC_SLOT(state, BOOT_SLOT_SECONDARY), bs->enckey[BOOT_SLOT_SECONDARY]);
                 assert(rc == 0);
             } else {
                 rc = 0;
@@ -1673,7 +1673,7 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
 #ifdef MCUBOOT_ENC_IMAGES
         for (slot = 0; slot < BOOT_NUM_SLOTS; slot++) {
 
-            boot_enc_init(BOOT_CURR_ENC(state), slot);
+            boot_enc_init(BOOT_CURR_ENC_SLOT(state, slot));
 
             rc = boot_read_enc_key(fap, slot, bs);
             assert(rc == 0);
@@ -1685,7 +1685,7 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
             }
 
             if (i != BOOT_ENC_KEY_SIZE) {
-                boot_enc_set_key(BOOT_CURR_ENC(state), slot, bs);
+                boot_enc_set_key(BOOT_CURR_ENC_SLOT(state, slot), bs->enckey[slot]);
             }
         }
 #endif

--- a/boot/bootutil/src/ram_load.c
+++ b/boot/bootutil/src/ram_load.c
@@ -155,7 +155,7 @@ boot_decrypt_and_copy_image_to_sram(struct boot_loader_state *state,
     }
 
     /* if rc > 0 then the key has already been loaded */
-    if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC(state), slot, &bs)) {
+    if (rc == 0 && boot_enc_set_key(BOOT_CURR_ENC_SLOT(state, slot), bs.enckey[slot])) {
         goto done;
     }
 
@@ -176,7 +176,7 @@ boot_decrypt_and_copy_image_to_sram(struct boot_loader_state *state,
              * Part of the chunk is encrypted payload */
             blk_sz = tlv_off - (bytes_copied);
         }
-        boot_enc_decrypt(BOOT_CURR_ENC(state), slot,
+        boot_enc_decrypt(BOOT_CURR_ENC_SLOT(state, slot),
                 (bytes_copied + idx) - hdr->ih_hdr_size, blk_sz,
                 blk_off, cur_dst);
         bytes_copied += chunk_sz;


### PR DESCRIPTION
Step forward in reducing entanglement between internal APIs.