### PR TITLE
boot: zephyr: sysbuild: fix CONFIG_MCUBOOT_UPDATE_FOOTER_SIZE leak

### DIFF
--- a/boot/zephyr/sysbuild/CMakeLists.txt
+++ b/boot/zephyr/sysbuild/CMakeLists.txt
@@ -33,10 +33,13 @@ function(${SYSBUILD_CURRENT_MODULE_NAME}_post_image_cmake)
       sysbuild_get(mcuboot_image_footer_size IMAGE mcuboot CACHE)
       sysbuild_get(mcuboot_image_upgrade_footer_size IMAGE mcuboot CACHE)
       math(EXPR mcuboot_image_footer_size "${mcuboot_image_footer_size}" OUTPUT_FORMAT HEXADECIMAL)
-      math(EXPR mcuboot_image_upgrade_footer_size "${mcuboot_image_upgrade_footer_size}" OUTPUT_FORMAT HEXADECIMAL)
-
+      
       set_property(TARGET ${image} APPEND_STRING PROPERTY CONFIG "CONFIG_ROM_END_OFFSET=${mcuboot_image_footer_size}\n")
-      set_property(TARGET ${image} APPEND_STRING PROPERTY CONFIG "CONFIG_MCUBOOT_UPDATE_FOOTER_SIZE=${mcuboot_image_upgrade_footer_size}\n")
+      
+      if(CONFIG_MCUBOOT_IMG_MANAGER)
+        math(EXPR mcuboot_image_upgrade_footer_size "${mcuboot_image_upgrade_footer_size}" OUTPUT_FORMAT HEXADECIMAL)
+        set_property(TARGET ${image} APPEND_STRING PROPERTY CONFIG "CONFIG_MCUBOOT_UPDATE_FOOTER_SIZE=${mcuboot_image_upgrade_footer_size}\n")
+      endif()
       return()
     endif()
   endforeach()


### PR DESCRIPTION
`CONFIG_MCUBOOT_UPDATE_FOOTER_SIZE` depends on `CONFIG_MCUBOOT_IMG_MANAGER` on Zephyr side, but we try to set it here always which results in the build warning:

"warning: MCUBOOT_UPDATE_FOOTER_SIZE (defined at subsys/dfu/Kconfig:55) was assigned the value '0x30' but got the value ''. Check these unsatisfied dependencies: MCUBOOT_IMG_MANAGER (=n), IMG_MANAGER (=n)"