### PR TITLE
Conditionally include mbedtls/ oid.h, asn1.h in ecdsa.h

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/ecdsa.h
+++ b/boot/bootutil/include/bootutil/crypto/ecdsa.h
@@ -65,11 +65,11 @@
 /* Universal defines */
 #define BOOTUTIL_CRYPTO_ECDSA_P256_HASH_SIZE (32)
 
-#include "mbedtls/oid.h"
-#include "mbedtls/asn1.h"
 #include "bootutil/sign_key.h"
 #if !defined(MCUBOOT_USE_PSA_CRYPTO)
 #include "bootutil/crypto/common.h"
+#include "mbedtls/asn1.h"
+#include "mbedtls/oid.h"
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
When MCUboot is built with the PSA Crypto backend these Mbed TLS headers are not required. Include them conditionally to avoid unnecessary build errors.