### PR TITLE
bootutil: boot_enc_set_key: error on set to valid context

### DIFF
--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -646,6 +646,13 @@ boot_enc_set_key(struct enc_key_data *enc_state, const uint8_t *key)
 {
     int rc;
 
+    /* This should not be in production code; there should be no path
+     * where we set the key twice, without dropping the context first.
+     */
+    if (enc_state->valid == 1) {
+        BOOT_LOG_DBG("boot_enc_set_key: key allready set (%p)", enc_state);
+        return -2;
+    }
     rc = bootutil_aes_ctr_set_key(&enc_state->aes_ctr, key);
     if (rc != 0) {
         boot_enc_drop(enc_state);


### PR DESCRIPTION
Enforce dropping context first, invalidating, before attempting to set it again.

Drafting this to find out how much stuff will break.