### PR TITLE
boot: zephyr: Remove enable from beginning of prompts

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -565,7 +565,7 @@ config BOOT_FIRMWARE_LOADER
 endchoice
 
 config BOOT_DIRECT_XIP_REVERT
-	bool "Enable the revert mechanism in direct-xip mode"
+	bool "Revert mechanism in direct-xip mode"
 	depends on BOOT_DIRECT_XIP
 	help
 	  If y, enables the revert mechanism in direct-xip similar to the one in
@@ -576,7 +576,7 @@ config BOOT_DIRECT_XIP_REVERT
 	  (marked as confirmed in advance) just like in swap mode.
 
 config BOOT_RAM_LOAD_REVERT
-	bool "Enable the revert mechanism in ram-load mode"
+	bool "Revert mechanism in ram-load mode"
 	depends on BOOT_RAM_LOAD
 	help
 	  If y, enables the revert mechanism in ram-load similar to the one in
@@ -905,7 +905,7 @@ config BOOT_FIH_PROFILE_HIGH
 endchoice
 
 config BOOT_USE_BENCH
-        bool "Enable benchmark code"
+        bool "Benchmark code"
         help
           If y, adds support for simple benchmarking that can record
           time intervals between two calls.  The time printed depends
@@ -1105,7 +1105,7 @@ config BOOT_WATCHDOG_FEED_NRFX_WDT
 	imply NRFX_WDT010
 
 config BOOT_IMAGE_ACCESS_HOOKS
-	bool "Enable hooks for overriding MCUboot's native routines"
+	bool "Hooks for overriding MCUboot's native routines"
 	help
 	  Allow to provide procedures for override or extend native
 	  MCUboot's routines required for access the image data and the image
@@ -1113,21 +1113,21 @@ config BOOT_IMAGE_ACCESS_HOOKS
 	  files to the build.
 
 config BOOT_GO_HOOKS
-	bool "Enable hooks for overriding MCUBOOT's boot_go routine"
+	bool "Hooks for overriding MCUBOOT's boot_go routine"
 	help
 	  Allow to provide procedures for override or extend native
 	  MCUboot's boot_go routine. It is up to the project customization to
 	  add required source files to the build.
 
 config BOOT_FLASH_AREA_HOOKS
-	bool "Enable hooks for overriding MCUboot's flash area routines"
+	bool "Hooks for overriding MCUboot's flash area routines"
 	help
 	  Allow to provide procedures for override or extend native
 	  MCUboot's flash area routines. It is up to the project customization to
 	  add required source files to the build.
 
 config MCUBOOT_ACTION_HOOKS
-	bool "Enable hooks for responding to MCUboot status changes"
+	bool "Hooks for responding to MCUboot status changes"
 	help
 	  This will call a handler when the MCUboot status changes which allows
 	  for some level of user feedback, for instance to change LED status to
@@ -1137,7 +1137,7 @@ config MCUBOOT_ACTION_HOOKS
 	  boot/bootutil/include/bootutil/mcuboot_status.h
 
 config FIND_NEXT_SLOT_HOOKS
-	bool "Enable hooks for finding the next active slot"
+	bool "Hooks for finding the next active slot"
 	help
 	  Allow to provide procedures for override or extend the search policy
 	  for the best slot to boot in the Direct XIP mode.

--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -107,12 +107,12 @@ config BOOT_ERASE_PROGRESSIVELY
 	 times at the beginning of the DFU process.
 
 config BOOT_MGMT_ECHO
-	bool "Enable echo command"
+	bool "Echo command"
 	help
 	  if enabled, support for the mcumgr echo command is being added.
 
 menuconfig ENABLE_MGMT_PERUSER
-	bool "Enable system specific mcumgr commands"
+	bool "System specific mcumgr commands"
 	help
 	  The option enables processing of system specific mcumgr commands;
 	  system specific commands are within group MGMT_GROUP_ID_PERUSER (64)
@@ -123,7 +123,7 @@ menuconfig ENABLE_MGMT_PERUSER
 if ENABLE_MGMT_PERUSER
 
 config BOOT_MGMT_CUSTOM_STORAGE_ERASE
-	bool "Enable storage erase command"
+	bool "Storage erase command"
 	help
 	  The option enables mcumgr command that allows to erase storage
 	  partition.


### PR DESCRIPTION
Kconfigs should not start with "enable"