### PR TITLE
bootutil: Fix some debug log format specifiers

### DIFF
--- a/boot/bootutil/src/bootutil_area.c
+++ b/boot/bootutil/src/bootutil_area.c
@@ -205,7 +205,8 @@ boot_erase_region(const struct flash_area *fa, uint32_t off, uint32_t size, bool
 {
     int rc = 0;
 
-    BOOT_LOG_DBG("boot_erase_region: flash_area %p, offset %d, size %d, backwards == %d",
+    BOOT_LOG_DBG("boot_erase_region: flash_area %p, offset %" PRIu32 ""
+                 ", size %" PRIu32 ", backwards == %" PRIu8,
                  fa, off, size, (int)backwards);
 
     if (off >= flash_area_get_size(fa) || (flash_area_get_size(fa) - off) < size) {
@@ -303,7 +304,8 @@ boot_scramble_region(const struct flash_area *fa, uint32_t off, uint32_t size, b
 {
     int rc = 0;
 
-    BOOT_LOG_DBG("boot_scramble_region: %p %d %d %d", fa, off, size, (int)backwards);
+    BOOT_LOG_DBG("boot_scramble_region: %p %" PRIu32 " %" PRIu32 " %d",
+                 fa, off, size, (int)backwards);
 
     if (size == 0) {
         goto done;
@@ -329,13 +331,15 @@ boot_scramble_region(const struct flash_area *fa, uint32_t off, uint32_t size, b
         } else {
             end_offset = ALIGN_DOWN((off + size), write_block);
         }
-        BOOT_LOG_DBG("boot_scramble_region: start offset %u, end offset %u", off, end_offset);
+        BOOT_LOG_DBG("boot_scramble_region: start offset %" PRIu32 ", "
+                     "end offset %" PRIu32, off, end_offset);
 
         while (off != end_offset) {
             /* Write over the area to scramble data that is there */
             rc = flash_area_write(fa, off, buf, write_block);
             if (rc != 0) {
-                BOOT_LOG_DBG("boot_scramble_region: error %d for %p %d %u",
+                BOOT_LOG_DBG("boot_scramble_region: error %d for %p "
+                             "%" PRIu32 " %u",
                              rc, fa, off, (unsigned int)write_block);
                 break;
             }

--- a/boot/bootutil/src/bootutil_img_hash.c
+++ b/boot/bootutil/src/bootutil_img_hash.c
@@ -27,6 +27,7 @@
  */
 
 #include <stdint.h>
+#include <inttypes.h>
 #include <flash_map_backend/flash_map_backend.h>
 
 #include "bootutil/crypto/sha.h"
@@ -167,7 +168,8 @@ bootutil_img_hash(struct boot_loader_state *state,
 #endif
         if (rc) {
             bootutil_sha_drop(&sha_ctx);
-            BOOT_LOG_DBG("bootutil_img_validate Error %d reading data chunk %p %u %u",
+            BOOT_LOG_DBG("bootutil_img_validate Error %d reading data chunk "
+                         "%p %" PRIu32 " %" PRIu32,
                          rc, fap, off, blk_sz);
             return rc;
         }

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -350,7 +350,7 @@ boot_write_trailer(const struct flash_area *fap, uint32_t off,
     uint32_t align;
     int rc;
 
-    BOOT_LOG_DBG("boot_write_trailer: for %p at %d, size = %d",
+    BOOT_LOG_DBG("boot_write_trailer: for %p at %" PRIu32 ", size = %d",
                  fap, off, inlen);
 
     align = flash_area_align(fap);

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -294,7 +294,8 @@ bootutil_img_validate(struct boot_loader_state *state,
 #else
     img_sz = it.tlv_end;
 #endif
-    BOOT_LOG_DBG("bootutil_img_validate: TLV off %u, end %u", it.tlv_off, it.tlv_end);
+    BOOT_LOG_DBG("bootutil_img_validate: TLV off %" PRIu32 ", end %" PRIu32,
+                 it.tlv_off, it.tlv_end);
 
     if (img_sz > bootutil_max_image_size(state, fap)) {
         rc = -1;

--- a/boot/bootutil/src/tlv.c
+++ b/boot/bootutil/src/tlv.c
@@ -19,6 +19,7 @@
  */
 
 #include <stddef.h>
+#include <inttypes.h>
 
 #include "bootutil/bootutil.h"
 #include "bootutil/bootutil_log.h"
@@ -113,7 +114,8 @@ bootutil_tlv_iter_next(struct image_tlv_iter *it, uint32_t *off, uint16_t *len,
         return -1;
     }
 
-    BOOT_LOG_DBG("bootutil_tlv_iter_next: searching for %d (%d is any) starting at %d ending at %d",
+    BOOT_LOG_DBG("bootutil_tlv_iter_next: searching for %d (%d is any) "
+                 "starting at %" PRIu32 " ending at %" PRIu32,
                  it->type, IMAGE_TLV_ANY, it->tlv_off, it->tlv_end);
 
     while (it->tlv_off < it->tlv_end) {
@@ -123,7 +125,8 @@ bootutil_tlv_iter_next(struct image_tlv_iter *it, uint32_t *off, uint16_t *len,
 
         rc = LOAD_IMAGE_DATA(it->hdr, it->fap, it->tlv_off, &tlv, sizeof tlv);
         if (rc) {
-            BOOT_LOG_DBG("bootutil_tlv_iter_next: load failed with %d for %p %d",
+            BOOT_LOG_DBG("bootutil_tlv_iter_next: load failed with %d for %p "
+                         "%" PRIu32,
                          rc, it->fap, it->tlv_off);
             return -1;
         }
@@ -141,7 +144,8 @@ bootutil_tlv_iter_next(struct image_tlv_iter *it, uint32_t *off, uint16_t *len,
             *off = it->tlv_off + sizeof(tlv);
             *len = tlv.it_len;
             it->tlv_off += sizeof(tlv) + tlv.it_len;
-            BOOT_LOG_DBG("bootutil_tlv_iter_next: TLV %d found at %d (size %d)",
+            BOOT_LOG_DBG("bootutil_tlv_iter_next: TLV %d found at %" PRIu32
+                         " (size %d)",
                          tlv.it_type, *off, *len);
             return 0;
         }


### PR DESCRIPTION
Uses format specifiers from inttype.h to remove warnings during build.
