### PR TITLE
iar: Avoid using double colons when defining labels

### DIFF
--- a/boot/bootutil/include/bootutil/fault_injection_hardening.h
+++ b/boot/bootutil/include/bootutil/fault_injection_hardening.h
@@ -277,7 +277,7 @@ void fih_cfi_decrement(void);
  * after compilation. Does not require debug symbols.
  */
 #if defined(__ICCARM__)
-#define FIH_LABEL(str, lin, cnt) __asm volatile ("FIH_LABEL_" str "_" #lin "_" #cnt "::" ::);
+#define FIH_LABEL(str, lin, cnt) __asm volatile ("FIH_LABEL_" str "_" #lin "_" #cnt ":" ::);
 #elif defined(__APPLE__)
 #define FIH_LABEL(str) do {} while (0)
 #else


### PR DESCRIPTION
Using double colons (::) creates global labels, which can lead to linker errors or symbol conflicts in certain cases. Switch to single colon (:) to keep labels local and prevent duplicate definitions.