### PR TITLE
iar: Avoid using double colons when defining labels

### DIFF
--- a/boot/bootutil/include/bootutil/fault_injection_hardening.h
+++ b/boot/bootutil/include/bootutil/fault_injection_hardening.h
@@ -277,7 +277,7 @@ void fih_cfi_decrement(void);
  * after compilation. Does not require debug symbols.
  */
 #if defined(__ICCARM__)
-#define FIH_LABEL(str, lin, cnt) __asm volatile ("FIH_LABEL_" str "_" #lin "_" #cnt "::" ::);
+#define FIH_LABEL(str, lin, cnt) __asm volatile ("FIH_LABEL_" str "_" #lin "_" #cnt ":" ::);
 #elif defined(__APPLE__)
 #define FIH_LABEL(str) do {} while (0)
 #else


### PR DESCRIPTION
Cherry-picking https://github.com/mcu-tools/mcuboot/pull/2550

The target branch is a feature branch used by [TF-M project](https://www.trustedfirmware.org/projects/tf-m).
Changes verified by the Trusted Firmware Open CI: https://ci.trustedfirmware.org/view/TF-M/job/tf-m-static/2482/