### PR TITLE
fix(bootutil): correct copy size when bootstrapping and swapping with…

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -990,6 +990,27 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
         size += this_size;
     }
 
+#if defined(MCUBOOT_SWAP_USING_MOVE)
+    /* When using MCUBOOT_SWAP_USING_MOVE, primary region is larger then the secondary region
+     * Optimal region configuration: # useful regions in primary region = # regions in secondary region + 1
+     * This means that we have to use the size of the secondary region (so without the swap sector)
+     */
+    sect_count = boot_img_num_sectors(state, BOOT_SLOT_SECONDARY);
+    for (sect = 0, size = 0; sect < sect_count; sect++) {
+        this_size = boot_img_sector_size(state, BOOT_SLOT_SECONDARY, sect);
+
+#if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
+        if ((size + this_size) >= src_size) {
+            size += src_size - size;
+            size += BOOT_WRITE_SZ(state) - (size % BOOT_WRITE_SZ(state));
+            break;
+        }
+#endif
+
+        size += this_size;
+    }
+#endif
+
 #if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
     trailer_sz = boot_trailer_sz(BOOT_WRITE_SZ(state));
     sector = boot_img_num_sectors(state, BOOT_SLOT_PRIMARY) - 1;

--- a/docs/release-notes.d/fix-copy-size-swap-move-bootstrapping.md
+++ b/docs/release-notes.d/fix-copy-size-swap-move-bootstrapping.md
@@ -1,0 +1,2 @@
+- Fix: Corrected the copy size calculation when bootstrapping and swapping using MCUBOOT_SWAP_USING_MOVE.
+  Previously, the primary region size was used, which could be larger than the secondary region, when using the optimal region sizes. Now, the size of the secondary region (excluding the swap sector and sectors needed for swapping) is used, ensuring only the valid image area is copied. This prevents potential over-copying and related issues during image upgrade or bootstrap operations.


### PR DESCRIPTION
… MOVE

Previously, the copy size was calculated using the primary region size, which could be larger than the secondary region. This fix ensures that the size of the secondary region (excluding the swap sector) is used, preventing over-copying and related issues during image upgrade or bootstrap operations.