### PR TITLE
scripts: imgtool: Fix verification with public ed25519 key file

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -194,6 +194,7 @@ ALLOWED_KEY_SHA = {
     keys.RSAPublic          : ['256'],
     # This two are set to 256 for compatibility, the right would be 512
     keys.Ed25519            : ['256', '512'],
+    keys.Ed25519Public      : ['256', '512'],
     keys.X25519             : ['256', '512']
 }
 


### PR DESCRIPTION
Fixes an issue whereby ed25519 public keys were not supported for verifying images which would wrongly give an error about the key type not matching the TLV record

Fixes https://github.com/mcu-tools/mcuboot/issues/2562