### PR TITLE
bootutil: Add missing guards for helpers in bootutil_img_validate

### DIFF
--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -187,6 +187,7 @@ static const uint16_t allowed_unprot_tlvs[] = {
 };
 #endif
 
+#ifdef MCUBOOT_IMAGE_MULTI_SIG_SUPPORT
 static inline int get_boot_verified_key_id(int key_id)
 {
 #if defined(MCUBOOT_HW_KEY)
@@ -218,6 +219,7 @@ static inline void boot_collect_verified_key(int key_id,
         *count = n + 1;
     }
 }
+#endif
 
 /*
  * Verify the integrity of the image.


### PR DESCRIPTION
Add MCUBOOT_IMAGE_MULTI_SIG_SUPPORT guard for:
 - get_boot_verified_key_id
 - boot_collect_verified_key