### PR TITLE
bootutil: boot_read_enc_key now returns boolean

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -240,7 +240,7 @@ boot_read_unprotected_tlv_sizes(const struct flash_area *fap, uint16_t *tlv_size
 #endif
 
 #ifdef MCUBOOT_ENC_IMAGES
-int
+bool
 boot_read_enc_key(const struct flash_area *fap, uint8_t slot, struct boot_status *bs)
 {
     uint32_t off;
@@ -274,7 +274,7 @@ boot_read_enc_key(const struct flash_area *fap, uint8_t slot, struct boot_status
 
         if (i == read_size) {
             BOOT_LOG_ERR("boot_read_enc_key: No key, read all 0xFF");
-            rc = 1;
+            return false;
         }
 #if MCUBOOT_SWAP_SAVE_ENCTLV
         else {
@@ -282,11 +282,15 @@ boot_read_enc_key(const struct flash_area *fap, uint8_t slot, struct boot_status
              * of the encrypted key.
              */
             rc = boot_decrypt_key(bs->enctlv[slot], bs->enckey[slot]);
+            if (rc != 0) {
+                return false;
+            }
         }
 #endif
+        return true;
     }
 
-    return rc;
+    return false;
 }
 #endif
 

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -339,8 +339,8 @@ bool boot_status_is_reset(const struct boot_status *bs);
 
 #ifdef MCUBOOT_ENC_IMAGES
 int boot_write_enc_keys(const struct flash_area *fap, const struct boot_status *bs);
-int boot_read_enc_key(const struct flash_area *fap, uint8_t slot,
-                      struct boot_status *bs);
+bool boot_read_enc_key(const struct flash_area *fap, uint8_t slot,
+                       struct boot_status *bs);
 #endif
 
 /**

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1191,8 +1191,7 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
 
             boot_enc_init(BOOT_CURR_ENC_SLOT(state, slot));
 
-            rc = boot_read_enc_key(fap, slot, bs);
-            if (rc) {
+            if (!boot_read_enc_key(fap, slot, bs)) {
                 BOOT_LOG_DBG("boot_swap_image: Failed loading key (%d, %d)",
                               image_index, slot);
             } else {


### PR DESCRIPTION
No need to return error code we can not do anything with.