### PR TITLE
samples: zephyr: hello-world: Fix twister load yaml

### DIFF
--- a/samples/zephyr/hello-world/sample.yaml
+++ b/samples/zephyr/hello-world/sample.yaml
@@ -6,5 +6,7 @@ common:
 tests:
   mcuboot.samples.zephyr.hello_world.sysbuild:
     build_only: true
-    tags: samples tests
+    tags:
+      - samples
+      - tests
     min_ram: 16


### PR DESCRIPTION
Fixes 2 issues related to twister. When trying to run it in the folder twister can not load the yaml data due to invalid schema attributes.

```
$ west twister -T ../bootloader/mcuboot
INFO    - Using Ninja..
INFO    - Zephyr version: v4.3.0-2765-g5a58989daddd
INFO    - Using 'zephyr' toolchain.
ERROR   - /workspace/zephyr/bootloader/mcuboot/samples/zephyr/hello-world: can't load (skipping): SchemaError(msg='Schema validation failed:
 - Key 'platforms' was not defined. Path: '/sample'.
 - Value '[{'test': {'build_only': True, 'tags': 'samples tests', 'min_ram': 16}}]' is not a dict. Value path: '/tests'.')
```

```
$ west twister -T ../bootloader/mcuboot
INFO    - Using Ninja..
INFO    - Zephyr version: v4.3.0-2765-g5a58989daddd
INFO    - Using 'zephyr' toolchain.
ERROR   - /workspace/zephyr/bootloader/mcuboot/samples/zephyr/hello-world: can't load (skipping): SchemaError(msg='Schema validation failed:
 - Value '[{'test': {'build_only': True, 'tags': 'samples tests', 'min_ram': 16}}]' is not a dict. Value path: '/tests'.')

```

This patch fixes those issues and allow twister to run.
