### PR TITLE
boot: bootutil: loader: Add error codes to log messages

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -621,7 +621,7 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
                 &boot_img_hdr(state, BOOT_SLOT_SECONDARY)->ih_ver,
                 &boot_img_hdr(state, BOOT_SLOT_PRIMARY)->ih_ver);
         if (rc < 0 && !boot_check_header_erased(state, BOOT_SLOT_PRIMARY)) {
-            BOOT_LOG_ERR("insufficient version in secondary slot");
+            BOOT_LOG_ERR("Insufficient version in secondary slot");
             boot_scramble_slot(fap, slot);
             /* Image in the secondary slot does not satisfy version requirement.
              * Erase the image and continue booting from the primary slot.
@@ -1074,7 +1074,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
      */
     rc = boot_update_security_counter(state, BOOT_SLOT_PRIMARY, BOOT_SLOT_SECONDARY);
     if (rc != 0) {
-        BOOT_LOG_ERR("Security counter update failed after image upgrade.");
+        BOOT_LOG_ERR("Security counter update failed after image upgrade: %d", rc);
         return rc;
     }
 #endif /* MCUBOOT_HW_ROLLBACK_PROT */
@@ -1301,8 +1301,7 @@ boot_perform_update(struct boot_loader_state *state, struct boot_status *bs)
          */
         rc = boot_update_security_counter(state, BOOT_SLOT_PRIMARY, BOOT_SLOT_SECONDARY);
         if (rc != 0) {
-            BOOT_LOG_ERR("Security counter update failed after "
-                         "image upgrade.");
+            BOOT_LOG_ERR("Security counter update failed after image upgrade: %d", rc);
             BOOT_SWAP_TYPE(state) = BOOT_SWAP_TYPE_PANIC;
         }
     }
@@ -1635,16 +1634,16 @@ boot_update_hw_rollback_protection(struct boot_loader_state *state)
     if (swap_state.magic != BOOT_MAGIC_GOOD || swap_state.image_ok == BOOT_FLAG_SET) {
         rc = boot_update_security_counter(state, BOOT_SLOT_PRIMARY, BOOT_SLOT_PRIMARY);
         if (rc != 0) {
-            BOOT_LOG_ERR("Security counter update failed after image %d validation.",
-                         BOOT_CURR_IMG(state));
+            BOOT_LOG_ERR("Security counter update failed after image %d validation: %d",
+                         BOOT_CURR_IMG(state), rc);
             return rc;
         }
 
 #ifdef MCUBOOT_HW_ROLLBACK_PROT_LOCK
         rc = boot_nv_security_counter_lock(BOOT_CURR_IMG(state));
         if (rc != 0) {
-            BOOT_LOG_ERR("Security counter lock failed after image %d validation.",
-                         BOOT_CURR_IMG(state));
+            BOOT_LOG_ERR("Security counter lock failed after image %d validation: %d",
+                         BOOT_CURR_IMG(state). rc);
             return rc;
         }
 #endif /* MCUBOOT_HW_ROLLBACK_PROT_LOCK */
@@ -1765,8 +1764,8 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
         /* Determine the sector layout of the image slots and scratch area. */
         rc = boot_read_sectors(state, sectors);
         if (rc != 0) {
-            BOOT_LOG_WRN("Failed reading sectors; BOOT_MAX_IMG_SECTORS=%d"
-                          " - too small?", BOOT_MAX_IMG_SECTORS);
+            BOOT_LOG_WRN("Failed reading sectors; BOOT_MAX_IMG_SECTORS=%d - too small?",
+                         BOOT_MAX_IMG_SECTORS);
             BOOT_SWAP_TYPE(state) = BOOT_SWAP_TYPE_NONE;
         }
 
@@ -1938,7 +1937,7 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
          * the magic number on the image is OK.
          */
         if (BOOT_IMG(state, BOOT_SLOT_PRIMARY).hdr.ih_magic != IMAGE_MAGIC) {
-            BOOT_LOG_ERR("bad image magic 0x%lx; Image=%u", (unsigned long)
+            BOOT_LOG_ERR("Bad image magic 0x%lx; Image=%u", (unsigned long)
                          BOOT_IMG(state, BOOT_SLOT_PRIMARY).hdr.ih_magic,
                          BOOT_CURR_IMG(state));
             rc = BOOT_EBADIMAGE;
@@ -2092,10 +2091,8 @@ boot_get_slot_usage(struct boot_loader_state *state)
                 BOOT_LOG_IMAGE_INFO(slot, hdr);
             } else {
                 state->slot_usage[BOOT_CURR_IMG(state)].slot_available[slot] = false;
-                BOOT_LOG_INF("Image %d %s slot: Image not found",
-                             BOOT_CURR_IMG(state),
-                             (slot == BOOT_SLOT_PRIMARY)
-                             ? "Primary" : "Secondary");
+                BOOT_LOG_INF("Image %d %s slot: image not found", BOOT_CURR_IMG(state),
+                             (slot == BOOT_SLOT_PRIMARY) ? "primary" : "secondary");
             }
         }
 
@@ -2163,10 +2160,8 @@ print_loaded_images(struct boot_loader_state *state)
 #endif
         active_slot = state->slot_usage[BOOT_CURR_IMG(state)].active_slot;
 
-        BOOT_LOG_INF("Image %d loaded from the %s slot",
-                     BOOT_CURR_IMG(state),
-                     (active_slot == BOOT_SLOT_PRIMARY) ?
-                     "primary" : "secondary");
+        BOOT_LOG_INF("Image %d loaded from the %s slot", BOOT_CURR_IMG(state),
+                     (active_slot == BOOT_SLOT_PRIMARY) ? "primary" : "secondary");
     }
 }
 #endif
@@ -2228,9 +2223,8 @@ boot_select_or_erase(struct boot_loader_state *state)
              */
             rc = boot_write_copy_done(fap);
             if (rc != 0) {
-                BOOT_LOG_WRN("Failed to set copy_done flag of the image in "
-                             "the %s slot.", (active_slot == BOOT_SLOT_PRIMARY) ?
-                             "primary" : "secondary");
+                BOOT_LOG_WRN("Failed to set copy_done flag of the image in the %s slot.",
+                             (active_slot == BOOT_SLOT_PRIMARY) ? "primary" : "secondary");
                 rc = 0;
             }
         }
@@ -2274,8 +2268,7 @@ boot_load_and_validate_images(struct boot_loader_state *state)
             }
 
             if (active_slot == BOOT_SLOT_NONE) {
-                BOOT_LOG_INF("No slot to load for image %d",
-                             BOOT_CURR_IMG(state));
+                BOOT_LOG_INF("No slot to load for image %d", BOOT_CURR_IMG(state));
                 FIH_RET(FIH_FAILURE);
             }
 
@@ -2371,16 +2364,16 @@ boot_update_hw_rollback_protection(struct boot_loader_state *state)
                                           state->slot_usage[BOOT_CURR_IMG(state)].active_slot,
                                           state->slot_usage[BOOT_CURR_IMG(state)].active_slot);
         if (rc != 0) {
-            BOOT_LOG_ERR("Security counter update failed after image %d validation.",
-                         BOOT_CURR_IMG(state));
+            BOOT_LOG_ERR("Security counter update failed after image %d validation: %d",
+                         BOOT_CURR_IMG(state), rc);
             return rc;
         }
 
 #ifdef MCUBOOT_HW_ROLLBACK_PROT_LOCK
         rc = boot_nv_security_counter_lock(BOOT_CURR_IMG(state));
         if (rc != 0) {
-            BOOT_LOG_ERR("Security counter lock failed after image %d validation.",
-                         BOOT_CURR_IMG(state));
+            BOOT_LOG_ERR("Security counter lock failed after image %d validation: %d",
+                         BOOT_CURR_IMG(state), rc);
             return rc;
         }
 #endif /* MCUBOOT_HW_ROLLBACK_PROT_LOCK */


### PR DESCRIPTION
Adds error codes to some messages, also formats others to fit more onto less lines for easier readability and searching using grep

Alternative to #2578