### PR TITLE
boot: zephyr: boot_serial_extension: Remove include

### DIFF
--- a/boot/zephyr/boot_serial_extension_zephyr_basic.c
+++ b/boot/zephyr/boot_serial_extension_zephyr_basic.c
@@ -9,7 +9,6 @@
 #include <zephyr/drivers/flash.h>
 #include <zephyr/mgmt/mcumgr/mgmt/mgmt_defines.h>
 #include <zephyr/mgmt/mcumgr/grp/zephyr/zephyr_basic.h>
-#include <../subsys/mgmt/mcumgr/transport/include/mgmt/mcumgr/transport/smp_internal.h>
 
 #include <flash_map_backend/flash_map_backend.h>
 #include <sysflash/sysflash.h>


### PR DESCRIPTION
Removes an un-needed include file