### PR TITLE
docs: design: Fix TLV type size

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -87,8 +87,7 @@ struct image_tlv_info {
 
 /** Image trailer TLV format. All fields in little endian. */
 struct image_tlv {
-    uint8_t  it_type;   /* IMAGE_TLV_[...]. */
-    uint8_t  _pad;
+    uint16_t  it_type;  /* IMAGE_TLV_[...]. */
     uint16_t it_len;    /* Data length (not including TLV header). */
 };
 


### PR DESCRIPTION
Fixes an outdated comment suggesting that TLV type is 8-bit when it is actually 16-bit

Fixes #2438