### PR TITLE
boot: mbed: Add flash_area_get_sector

### DIFF
--- a/boot/mbed/include/flash_map_backend/flash_map_backend.h
+++ b/boot/mbed/include/flash_map_backend/flash_map_backend.h
@@ -175,6 +175,13 @@ int flash_area_id_from_multi_image_slot(int image_index, int slot);
  */
 int flash_area_id_to_multi_image_slot(int image_index, int area_id);
 
+/*
+ * Given flash area ID, return info about the sector a given offset
+ * belongs to.
+ */
+int flash_area_get_sector(const struct flash_area *fap, uint32_t off,
+  struct flash_sector *fs);
+
 #ifdef __cplusplus
 }
 #endif

--- a/boot/mbed/src/flash_map_backend.cpp
+++ b/boot/mbed/src/flash_map_backend.cpp
@@ -249,3 +249,15 @@ int flash_area_id_to_multi_image_slot(int image_index, int area_id)
     assert(image_index == 0);
     return area_id;
 }
+
+int flash_area_get_sector(const struct flash_area *fap, uint32_t off,
+  struct flash_sector *fs)
+{
+    mbed::BlockDevice* bd = flash_map_bd[fap->fa_id];
+    bd_size_t erase_size = bd->get_erase_size(off);
+
+    fs->fs_off = (off / erase_size) * erase_size;
+    fs->fs_size = erase_size;
+
+    return 0;
+}


### PR DESCRIPTION
This adds `flash_area_get_sector` to fix undefined reference symbol error.