### PR TITLE
boot: zephyr: cmake: Fix Zephyr version file define

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -108,6 +108,7 @@ if(CONFIG_MEASURED_BOOT OR CONFIG_BOOT_SHARE_DATA)
   # include file
   set_source_files_properties(
     ${BOOT_DIR}/bootutil/src/boot_record.c
+    TARGET_DIRECTORY zephyr
     PROPERTIES COMPILE_FLAGS -DZEPHYR_VER_INCLUDE=1
   )
 endif()


### PR DESCRIPTION
A regression was introduced when the zephyr library CMake functions were replaced with non-library equivalents, because the zephyr library is not in the same directory, this meant that the compilation define added tro boot_record.c stopped working, this fixes the issue by specifying that is applies to the zephyr target directory