### PR TITLE
imgtool: add AES‑KW encryption support and tests

### DIFF
--- a/docs/encrypted_images.md
+++ b/docs/encrypted_images.md
@@ -176,7 +176,8 @@ To extract the public key in source file form, use
 format, use `imgtool getpub -k <input.pem> -e pem`.
 
 If using AES-KW, follow the steps in the next section to generate the
-required keys.
+required keys. The base64-encoded KEK can be passed to `imgtool sign`
+via the `--encrypt` option.
 
 ## [Creating your keys with Unix tooling](#creating-your-keys-with-unix-tooling)
 
@@ -187,6 +188,6 @@ required keys.
 * If using ECIES-X25519, generate a private key passing the option `-t x25519`
   to `imgtool keygen` command. To generate public key PEM file the following
   command can be used: `openssl pkey -in <generated-private-key.pem> -pubout`
-* If using AES-KW (`newt` only), the `kek` can be generated with a
+* If using AES-KW, the `kek` can be generated with a
   command like (change count to 32 for a 256 bit key)
   `dd if=/dev/urandom bs=1 count=16 | base64 > my_kek.b64`

--- a/docs/imgtool.md
+++ b/docs/imgtool.md
@@ -134,6 +134,8 @@ primary slot and adds a header and trailer that the bootloader is expecting:
       -E, --encrypt filename          Encrypt image using the provided public key.
                                       (Not supported in direct-xip or ram-load
                                       mode.)
+                                      For AES-KW, pass a base64-encoded KEK file
+                                      (16 bytes for 128-bit, 32 bytes for 256-bit).
       --save-enctlv                   When upgrading, save encrypted key TLVs
                                       instead of plain keys. Enable when
                                       BOOT_SWAP_SAVE_ENCTLV config option was set.

--- a/scripts/tests/test_encryption_kw.py
+++ b/scripts/tests/test_encryption_kw.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import struct
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from imgtool import image
+from imgtool.main import imgtool
+
+VERSION = '1.2.3'
+HEADER_SIZE = 32
+SLOT_SIZE = 4096
+
+
+@pytest.fixture
+def key_file():
+    return Path(__file__).parents[2] / 'root-ec-p256.pem'
+
+
+def parse_tlvs(data, endian="<"):
+    header = data[:image.IMAGE_HEADER_SIZE]
+    _, _, hdr_sz, _, img_sz, flags = struct.unpack(endian + "IIHHII", header[:20])
+    tlv_off = hdr_sz + img_sz
+
+    magic, tlv_tot = struct.unpack(endian + "HH", data[tlv_off:tlv_off + image.TLV_INFO_SIZE])
+    if magic == image.TLV_PROT_INFO_MAGIC:
+        tlv_off += tlv_tot
+        magic, tlv_tot = struct.unpack(endian + "HH", data[tlv_off:tlv_off + image.TLV_INFO_SIZE])
+
+    assert magic == image.TLV_INFO_MAGIC
+
+    tlv_end = tlv_off + tlv_tot
+    tlv_off += image.TLV_INFO_SIZE
+    tlvs = []
+    while tlv_off < tlv_end:
+        tlv_type, _, tlv_len = struct.unpack(endian + "BBH", data[tlv_off:tlv_off + image.TLV_SIZE])
+        tlv_off += image.TLV_SIZE
+        payload = data[tlv_off:tlv_off + tlv_len]
+        tlvs.append((tlv_type, payload))
+        tlv_off += tlv_len
+
+    return flags, tlvs
+
+
+@pytest.mark.parametrize(
+    "keylen, kek_bytes, expected_len, enc_flag",
+    [
+        (128, bytes(range(16)), 24, image.IMAGE_F["ENCRYPTED_AES128"]),
+        (256, bytes(range(32)), 40, image.IMAGE_F["ENCRYPTED_AES256"]),
+    ],
+)
+def test_encrypt_aes_kw(keylen, kek_bytes, expected_len, enc_flag, tmpdir):
+    runner = CliRunner()
+
+    infile = tmpdir / "in.bin"
+    outfile = tmpdir / "out.bin"
+    kekfile = tmpdir / "kek.b64"
+
+    with infile.open("wb") as f:
+        f.write(bytes([0x11]) * 256)
+    with kekfile.open("wb") as f:
+        f.write(base64.b64encode(kek_bytes))
+
+    result = runner.invoke(
+        imgtool,
+        [
+            "sign",
+            f"--header-size={HEADER_SIZE}",
+            f"--slot-size={SLOT_SIZE}",
+            f"--version={VERSION}",
+            "--pad-header",
+            f"--encrypt={kekfile}",
+            f"--encrypt-keylen={keylen}",
+            str(infile),
+            str(outfile),
+        ],
+    )
+    assert result.exit_code == 0
+    assert outfile.exists()
+
+    with outfile.open("rb") as f:
+        data = f.read()
+    flags, tlvs = parse_tlvs(data)
+    assert flags & enc_flag
+
+    enckw_tlvs = [payload for tlv_type, payload in tlvs if tlv_type == image.TLV_VALUES["ENCKW"]]
+    assert len(enckw_tlvs) == 1
+    assert len(enckw_tlvs[0]) == expected_len
+
+
+@pytest.mark.parametrize(
+    "keylen, kek_bytes",
+    [
+        (128, bytes(range(16))),
+        (256, bytes(range(32))),
+    ],
+)
+def test_encrypt_aes_kw_with_signing_key(keylen, kek_bytes, tmpdir, key_file):
+    runner = CliRunner()
+
+    infile = tmpdir / "in.bin"
+    outfile = tmpdir / "out.bin"
+    kekfile = tmpdir / "kek.b64"
+
+    with infile.open("wb") as f:
+        f.write(bytes([0x22]) * 256)
+    with kekfile.open("wb") as f:
+        f.write(base64.b64encode(kek_bytes))
+
+    result = runner.invoke(
+        imgtool,
+        [
+            "sign",
+            f"--header-size={HEADER_SIZE}",
+            f"--slot-size={SLOT_SIZE}",
+            f"--version={VERSION}",
+            "--pad-header",
+            f"--encrypt={kekfile}",
+            f"--encrypt-keylen={keylen}",
+            f"--key={key_file}",
+            str(infile),
+            str(outfile),
+        ],
+    )
+    assert result.exit_code == 0
+    assert outfile.exists()


### PR DESCRIPTION
 - Add AES‑KW KEK loading from base64 (16/32 bytes) and emit ENCKW TLVs in imgtool.
  - Allow AES‑KW encryption alongside any signing key.
  - Document AES‑KW usage in imgtool/encrypted images docs.
  - Add AES‑KW encryption tests, including sign+encrypt coverage.


Code is heavily codex-assisted. I'm new to mcuboot, so I can miss something.

Codex says that image works in simulator:

```
  # Build bootsim with KW support
  cargo build --release --features enc-kw
 
  # Create payload + unsigned images with imgtool
  dd if=/dev/urandom of=/tmp/app.bin bs=1024 count=64
  ./scripts/imgtool.py sign --align 4 -H 0x20 -v 1.2.2 --pad-header -S 0x20000 /tmp/app.bin /tmp/app-unsigned.bin
  ./scripts/imgtool.py sign --encrypt enc-aes128kw.b64 --align 4 -H 0x20 -v 1.2.3 --pad-header -S 0x20000 /tmp/app.bin /tmp/app-kw-unsigned.bin
 
  # Run sim with external images
  RUST_LOG=debug cargo run --release --features enc-kw --  run-image --device stm32f4 --image0 /tmp/app-unsigned.bin  --image1 /tmp/app-kw-unsigned.bin
 
  - boot_enc_load: ENCKW TLV found, decrypt key OK
  - bootutil_img_validate: hash TLV (SHA256) found and validated
  - swap started (scratch algorithm)
  - swap metadata written (swap_info/swap_size/enc_key/magic)
  - copy_done written in primary
  - run-image succeeded
 
 