### PR TITLE
boot: bootutil: Fix extra . in logging output

### DIFF
--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -444,8 +444,8 @@ boot_swap_type_multi(int image_index)
     rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_SECONDARY(image_index),
                                     &secondary_slot);
     if (rc == BOOT_EFLASH) {
-        BOOT_LOG_INF("Secondary image of image pair (%d.) "
-                     "is unreachable. Treat it as empty", image_index);
+        BOOT_LOG_INF("Secondary image of image pair (%d) is unreachable. Treat it as empty",
+                     image_index);
         secondary_slot.magic = BOOT_MAGIC_UNSET;
         secondary_slot.swap_type = BOOT_SWAP_TYPE_NONE;
         secondary_slot.copy_done = BOOT_FLAG_UNSET;


### PR DESCRIPTION
Fixes a stray . being output in a log message