### PR TITLE
boot: bootutil: Add missing swap offset file and fix RAM load

### DIFF
--- a/boot/bootutil/CMakeLists.txt
+++ b/boot/bootutil/CMakeLists.txt
@@ -35,12 +35,8 @@ target_sources(bootutil
         src/loader.c
         src/swap_misc.c
         src/swap_move.c
+        src/swap_offset.c
         src/swap_scratch.c
+        src/ram_load.c
         src/tlv.c
 )
-if(CONFIG_BOOT_RAM_LOAD)
-    target_sources(bootutil
-        PRIVATE
-            src/ram_load.c
-    )
-endif()

--- a/boot/bootutil/src/ram_load.c
+++ b/boot/bootutil/src/ram_load.c
@@ -41,6 +41,8 @@
 
 #include "mcuboot_config/mcuboot_config.h"
 
+#ifdef MCUBOOT_RAM_LOAD
+
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 #ifndef MULTIPLE_EXECUTABLE_RAM_REGIONS
@@ -433,3 +435,5 @@ int boot_load_image_from_flash_to_sram(struct boot_loader_state *state,
 
     return boot_load_image_to_sram(state);
 }
+
+#endif


### PR DESCRIPTION
The swap offset source file was missed from being added to the bootuil CMake file, in addition the RAM load one was wrongly using zephyr-specific Kconfigs to check if it should be included