### PR TITLE
boot: mbed: fix MCUBOOT_SWAP_SAVE_ENCTLV

### DIFF
--- a/boot/mbed/mbed_lib.json
+++ b/boot/mbed/mbed_lib.json
@@ -113,9 +113,9 @@
             "help": "Updateable image number (NOT TESTED)",
             "macro_name": "MCUBOOT_IMAGE_NUMBER"
         },
-        "MCUBOOT_SWAP_SAVE_ENCTLV": {
+        "mcuboot-swap-save-enctlv": {
             "help": "Swap save enctlv (NOT TESTED)",
-            "macro_name": "MCUBOOT_IMAGE_NUMBER",
+            "macro_name": "MCUBOOT_SWAP_SAVE_ENCTLV",
             "value": null
         },
         "encrypt-rsa": {


### PR DESCRIPTION
For Mbed platform, this fixes the `MCUBOOT_SWAP_SAVE_ENCTLV` configuration option:
- Change the name to be canonical, replacing underscores with hyphens and lowercasing
- Correct the macro name to replace with