### PR TITLE
boot: bootutil: feed watchdog during swap operations

### DIFF
--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -543,6 +543,7 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
             if (idx <= (last_idx - bs->idx + 1)) {
                 boot_move_sector_up(idx, sector_sz, state, bs, fap_pri, fap_sec);
             }
+            MCUBOOT_WATCHDOG_FEED();
             idx--;
         }
         bs->idx = BOOT_STATUS_IDX_0;
@@ -555,6 +556,7 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
         if (idx >= bs->idx) {
             boot_swap_sectors(idx, sector_sz, state, bs, fap_pri, fap_sec);
         }
+        MCUBOOT_WATCHDOG_FEED();
         idx++;
     }
 }

--- a/boot/bootutil/src/swap_offset.c
+++ b/boot/bootutil/src/swap_offset.c
@@ -682,6 +682,7 @@ void swap_run(struct boot_loader_state *state, struct boot_status *bs,
                                          (mirror_idx > used_sectors_sec ? true : false));
             }
 
+            MCUBOOT_WATCHDOG_FEED();
             idx++;
         }
 
@@ -702,6 +703,7 @@ void swap_run(struct boot_loader_state *state, struct boot_status *bs,
                                   (idx > used_sectors_sec ? true : false));
             }
 
+            MCUBOOT_WATCHDOG_FEED();
             idx++;
         }
     }

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -935,6 +935,7 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
             boot_swap_sectors(first_sector_idx, sz, state, bs);
         }
 
+        MCUBOOT_WATCHDOG_FEED();
         last_sector_idx = first_sector_idx - 1;
         swap_idx++;
     }


### PR DESCRIPTION
## Problem

Flash swap was exceeding 30 seconds on my device.  I had set mcuboot to have a watchdog set to 30 second reset (consistent with my app behavior).  Lack of watchdog feed during flash swap caused a watchdog reset to occur.  56d28f0c started this work with adding watchdog feed in serial recovery, adjusting flash swap to match. 

## Summary

- Add `MCUBOOT_WATCHDOG_FEED()` to swap loops in `swap_offset.c`, `swap_move.c`, and `swap_scratch.c`
- On devices with many flash sectors or slow flash, swap operations can exceed the watchdog timeout and reset the device mid-swap
- The existing `loader.c` copy loop already feeds the watchdog; this closes the gap in the swap implementations

## Test plan

- [x] Build with `CONFIG_BOOT_WATCHDOG_FEED=y` and verify swap completes without watchdog reset