### PR TITLE
boot: zephyr: call LOG_PANIC before jumping to app to flush in flight logs

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -94,13 +94,14 @@ const struct boot_uart_funcs boot_funcs = {
 #include <arm_cleanup.h>
 #endif
 
-#if defined(CONFIG_LOG) && !defined(CONFIG_LOG_MODE_IMMEDIATE) && \
-    !defined(CONFIG_LOG_MODE_MINIMAL)
+#if defined(CONFIG_LOG)
+#include <zephyr/logging/log_ctrl.h>
+
+#if !defined(CONFIG_LOG_MODE_IMMEDIATE) && !defined(CONFIG_LOG_MODE_MINIMAL)
 #ifdef CONFIG_LOG_PROCESS_THREAD
 #warning "The log internal thread for log processing can't transfer the log"\
          "well for MCUBoot."
 #else
-#include <zephyr/logging/log_ctrl.h>
 
 #define BOOT_LOG_PROCESSING_INTERVAL K_MSEC(30) /* [ms] */
 
@@ -114,13 +115,13 @@ K_SEM_DEFINE(boot_log_sem, 0, 1);
 #define ZEPHYR_BOOT_LOG_START() zephyr_boot_log_start()
 #define ZEPHYR_BOOT_LOG_STOP() zephyr_boot_log_stop()
 #endif /* CONFIG_LOG_PROCESS_THREAD */
-#else
-/* synchronous log mode doesn't need to be initalized by the application */
+#endif /* !IMMEDIATE && !MINIMAL */
+#endif /* CONFIG_LOG */
+
+#if !defined(ZEPHYR_BOOT_LOG_START)
 #define ZEPHYR_BOOT_LOG_START() ((void)0)
 #define ZEPHYR_BOOT_LOG_STOP() ((void)0)
-#endif /* defined(CONFIG_LOG) && !defined(CONFIG_LOG_MODE_IMMEDIATE) && \
-        * !defined(CONFIG_LOG_MODE_MINIMAL)
-	*/
+#endif
 
 BOOT_LOG_MODULE_REGISTER(mcuboot);
 
@@ -478,6 +479,9 @@ void zephyr_boot_log_stop(void)
      * see https://github.com/zephyrproject-rtos/zephyr/issues/21500
      */
     (void)k_sem_take(&boot_log_sem, K_FOREVER);
+
+    /* Entice the log backends to flush their contents */
+    LOG_PANIC();
 }
 #endif /* defined(CONFIG_LOG) && !defined(CONFIG_LOG_MODE_IMMEDIATE) && \
         * !defined(CONFIG_LOG_PROCESS_THREAD) && !defined(CONFIG_LOG_MODE_MINIMAL)


### PR DESCRIPTION
## Problem

Pending log messages were lost when mcuboot jumped to the app.
`ZEPHYR_BOOT_LOG_STOP()` drains the software log buffers, but log
backends may still have data in flight that is discarded when the
app reinitializes the hardware.

Discovered because SWO logs were lost during the transition from
bootloader to app.

## Solution

Call `LOG_PANIC()` after `ZEPHYR_BOOT_LOG_STOP()`. This gives each
log backend the opportunity to finish transmitting before the jump.

SWO log fixes depend on zephyrproject-rtos/zephyr#104432 which adds
hardware drain logic to the SWO backend's panic handler.

## Test plan

- [x] Build with `CONFIG_LOG_BACKEND_SWO=y` — verify all MCUboot log
      output is captured before app starts
- [x] Tested on nRF5340 with J-Link SWO viewer