### PR TITLE
boot: zephyr: boards: nrf54l15dk: Remove useless Kconfig setting

### DIFF
--- a/boot/zephyr/boards/nrf54l15dk_nrf54l05_cpuapp.conf
+++ b/boot/zephyr/boards/nrf54l15dk_nrf54l05_cpuapp.conf
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-CONFIG_BOOT_MAX_IMG_SECTORS=256
 
 # Ensure that the SPI NOR driver is disabled by default
 CONFIG_SPI_NOR=n

--- a/boot/zephyr/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/boot/zephyr/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-CONFIG_BOOT_MAX_IMG_SECTORS=256
 
 # Ensure that the SPI NOR driver is disabled by default
 CONFIG_SPI_NOR=n

--- a/boot/zephyr/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/boot/zephyr/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-CONFIG_BOOT_MAX_IMG_SECTORS=256
 
 # Ensure that the SPI NOR driver is disabled by default
 CONFIG_SPI_NOR=n


### PR DESCRIPTION
Removes setting a Kconfig which is ignored, because the value is automatically derived from dts configuration