### PR TITLE
imgtool: Fix regression in verify TLV skipping

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -979,7 +979,7 @@ class Image:
 
         # If it's the protected-TLV block, skip it
         if magic == TLV_PROT_INFO_MAGIC:
-            tlv_off += TLV_INFO_SIZE + tlv_tot
+            tlv_off += tlv_tot
             tlv_info = b[tlv_off:tlv_off + TLV_INFO_SIZE]
             magic, tlv_tot = struct.unpack('HH', tlv_info)
 


### PR DESCRIPTION
A change in the multiple signatures commit broke the imgtool verify command. Revert the double addition of TLV_INFO_SIZE when skipping protected TLVs.

Fixes: f7f5c7a644610f9e0e33aecebcf6c37aa3b468b2

Change-Id: I62af45e12bb99c12f11c823ce604cebcd410e769