### PR TITLE
boot:crypto Add custom crypto support

### DIFF
--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -48,6 +48,8 @@ jobs:
         - "sig-ecdsa-psa enc-ec256 max-align-16, sig-ecdsa-psa enc-ec256 swap-offset validate-primary-slot max-align-16"
         - "ram-load enc-aes256-kw multiimage"
         - "ram-load enc-aes256-kw sig-ecdsa-mbedtls multiimage"
+        - "custom-crypto,custom-crypto overwrite-only,custom-crypto validate-primary-slot,custom-crypto swap-offset"
+        - "custom-enc-crypto,custom-enc-crypto validate-primary-slot,custom-enc-crypto swap-offset validate-primary-slot max-align-32"
     runs-on: ubuntu-latest
     env:
       MULTI_FEATURES: ${{ matrix.features }}

--- a/boot/bootutil/include/bootutil/crypto/aes_ctr.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_ctr.h
@@ -2,9 +2,10 @@
  * This module provides a thin abstraction over some of the crypto
  * primitives to make it easier to swap out the used crypto library.
  *
- * At this point, there are two choices: MCUBOOT_USE_MBED_TLS, or
- * MCUBOOT_USE_TINYCRYPT.  It is a compile error there is not exactly
- * one of these defined.
+ * At this point, there are four choices: MCUBOOT_USE_MBED_TLS,
+ * MCUBOOT_USE_TINYCRYPT, MCUBOOT_USE_PSA_CRYPTO, or
+ * MCUBOOT_USE_CUSTOM_CRYPTO.  It is a compile error if there is not
+ * exactly one of these defined.
  */
 
 #ifndef __BOOTUTIL_CRYPTO_AES_CTR_H_
@@ -13,8 +14,10 @@
 #include "mcuboot_config/mcuboot_config.h"
 
 #if (defined(MCUBOOT_USE_MBED_TLS) + \
-     defined(MCUBOOT_USE_TINYCRYPT) + defined(MCUBOOT_USE_PSA_CRYPTO)) != 1
-    #error "One crypto backend must be defined: either MBED_TLS or TINYCRYPT or PSA"
+     defined(MCUBOOT_USE_TINYCRYPT) + \
+     defined(MCUBOOT_USE_PSA_CRYPTO) + \
+     defined(MCUBOOT_USE_CUSTOM_CRYPTO)) != 1
+    #error "One crypto backend must be defined: either MBED_TLS or TINYCRYPT or PSA or CUSTOM_CRYPTO"
 #endif
 
 #if defined(MCUBOOT_USE_MBED_TLS)
@@ -27,6 +30,6 @@
 
 #if defined(MCUBOOT_USE_PSA_CRYPTO)
     #include "bootutil/crypto/aes_ctr_psa.h"
-#endif
+#endif /* MCUBOOT_USE_PSA_CRYPTO */
 
 #endif /* __BOOTUTIL_CRYPTO_AES_CTR_H_ */

--- a/boot/bootutil/include/bootutil/crypto/ecdh_p256.h
+++ b/boot/bootutil/include/bootutil/crypto/ecdh_p256.h
@@ -2,9 +2,9 @@
  * This module provides a thin abstraction over some of the crypto
  * primitives to make it easier to swap out the used crypto library.
  *
- * At this point, there are two choices: MCUBOOT_USE_MBED_TLS, or
- * MCUBOOT_USE_TINYCRYPT.  It is a compile error there is not exactly
- * one of these defined.
+ * At this point, there are three choices: MCUBOOT_USE_MBED_TLS,
+ * MCUBOOT_USE_TINYCRYPT, or MCUBOOT_USE_CUSTOM_CRYPTO.  It is a compile
+ * error if there is not exactly one of these defined.
  */
 
 #ifndef __BOOTUTIL_CRYPTO_ECDH_P256_H_
@@ -13,8 +13,9 @@
 #include "mcuboot_config/mcuboot_config.h"
 
 #if (defined(MCUBOOT_USE_MBED_TLS) + \
-     defined(MCUBOOT_USE_TINYCRYPT)) != 1
-    #error "One crypto backend must be defined: either MBED_TLS or TINYCRYPT"
+     defined(MCUBOOT_USE_TINYCRYPT) + \
+     defined(MCUBOOT_USE_CUSTOM_CRYPTO)) != 1
+    #error "One crypto backend must be defined: either MBED_TLS or TINYCRYPT or CUSTOM_CRYPTO"
 #endif
 
 #if defined(MCUBOOT_USE_MBED_TLS)

--- a/boot/bootutil/include/bootutil/crypto/ecdsa.h
+++ b/boot/bootutil/include/bootutil/crypto/ecdsa.h
@@ -9,12 +9,13 @@
  * primitives to make it easier to swap out the used crypto library.
  *
  * At this point, the choices are: MCUBOOT_USE_TINYCRYPT, MCUBOOT_USE_CC310,
- * MCUBOOT_USE_MBED_TLS, MCUBOOT_USE_PSA_CRYPTO. Note that support for
- * MCUBOOT_USE_PSA_CRYPTO is still experimental and it might not support all
- * the crypto abstractions that MCUBOOT_USE_MBED_TLS supports. For this
- * reason, it's allowed to have both of them defined, and for crypto modules
- * that support both abstractions, the MCUBOOT_USE_PSA_CRYPTO will take
- * precedence.
+ * MCUBOOT_USE_MBED_TLS, MCUBOOT_USE_PSA_CRYPTO, MCUBOOT_USE_CUSTOM_CRYPTO.
+ * Note that support for MCUBOOT_USE_PSA_CRYPTO is still experimental and it
+ * might not support all the crypto abstractions that MCUBOOT_USE_MBED_TLS
+ * supports. For this reason, it's allowed to have both of them defined, and
+ * for crypto modules that support both abstractions, the MCUBOOT_USE_PSA_CRYPTO
+ * will take precedence. MCUBOOT_USE_CUSTOM_CRYPTO delegates all operations to
+ * a platform-supplied <mcuboot_custom_crypto.h> resolved via the include path.
  */
 
 #ifndef __BOOTUTIL_CRYPTO_ECDSA_H_
@@ -27,15 +28,21 @@
 #define MCUBOOT_USE_PSA_OR_MBED_TLS
 #endif /* MCUBOOT_USE_PSA_CRYPTO || MCUBOOT_USE_MBED_TLS */
 
+#if defined(MCUBOOT_USE_CUSTOM_CRYPTO) && defined(MCUBOOT_USE_PSA_OR_MBED_TLS)
+    #error "MCUBOOT_USE_CUSTOM_CRYPTO is mutually exclusive with MCUBOOT_USE_PSA_CRYPTO and MCUBOOT_USE_MBED_TLS"
+#endif
+
 #if defined(MCUBOOT_SIGN_EC384) && \
-    !defined(MCUBOOT_USE_PSA_CRYPTO)
-    #error "P384 requires PSA_CRYPTO to be defined"
+    !defined(MCUBOOT_USE_PSA_CRYPTO) && \
+    !defined(MCUBOOT_USE_CUSTOM_CRYPTO)
+    #error "P384 requires PSA_CRYPTO or CUSTOM_CRYPTO to be defined"
 #endif
 
 #if (defined(MCUBOOT_USE_TINYCRYPT) + \
      defined(MCUBOOT_USE_CC310) + \
-     defined(MCUBOOT_USE_PSA_OR_MBED_TLS)) != 1
-    #error "One crypto backend must be defined: either CC310/TINYCRYPT/MBED_TLS/PSA_CRYPTO"
+     defined(MCUBOOT_USE_PSA_OR_MBED_TLS) + \
+     defined(MCUBOOT_USE_CUSTOM_CRYPTO)) != 1
+    #error "One crypto backend must be defined: either CC310/TINYCRYPT/MBED_TLS/PSA_CRYPTO/CUSTOM_CRYPTO"
 #endif
 
 #if defined(MCUBOOT_USE_TINYCRYPT)
@@ -66,7 +73,7 @@
 #define BOOTUTIL_CRYPTO_ECDSA_P256_HASH_SIZE (32)
 
 #include "bootutil/sign_key.h"
-#if !defined(MCUBOOT_USE_PSA_CRYPTO)
+#if !defined(MCUBOOT_USE_PSA_CRYPTO) && !defined(MCUBOOT_USE_CUSTOM_CRYPTO)
 #include "bootutil/crypto/common.h"
 #include "mbedtls/asn1.h"
 #include "mbedtls/oid.h"

--- a/boot/bootutil/include/bootutil/crypto/hmac_sha256.h
+++ b/boot/bootutil/include/bootutil/crypto/hmac_sha256.h
@@ -2,9 +2,9 @@
  * This module provides a thin abstraction over some of the crypto
  * primitives to make it easier to swap out the used crypto library.
  *
- * At this point, there are two choices: MCUBOOT_USE_MBED_TLS, or
- * MCUBOOT_USE_TINYCRYPT.  It is a compile error there is not exactly
- * one of these defined.
+ * At this point, there are three choices: MCUBOOT_USE_MBED_TLS,
+ * MCUBOOT_USE_TINYCRYPT, or MCUBOOT_USE_CUSTOM_CRYPTO.  It is a compile
+ * error if there is not exactly one of these defined.
  */
 
 #ifndef __BOOTUTIL_CRYPTO_HMAC_SHA256_H_
@@ -13,8 +13,9 @@
 #include "mcuboot_config/mcuboot_config.h"
 
 #if (defined(MCUBOOT_USE_MBED_TLS) + \
-     defined(MCUBOOT_USE_TINYCRYPT)) != 1
-    #error "One crypto backend must be defined: either MBED_TLS or TINYCRYPT"
+     defined(MCUBOOT_USE_TINYCRYPT) + \
+     defined(MCUBOOT_USE_CUSTOM_CRYPTO)) != 1
+    #error "One crypto backend must be defined: MBED_TLS, TINYCRYPT, or CUSTOM_CRYPTO"
 #endif
 
 #if defined(MCUBOOT_USE_MBED_TLS)
@@ -119,10 +120,13 @@ static inline int bootutil_hmac_sha256_update(bootutil_hmac_sha256_context *ctx,
 
 static inline int bootutil_hmac_sha256_finish(bootutil_hmac_sha256_context *ctx, uint8_t *tag, unsigned int taglen)
 {
-    (void)taglen;
     /*
-     * HMAC the key and check that our received MAC matches the generated tag
+     * Finalize the HMAC computation and output the tag.
+     * mbedtls_md_hmac_finish() always outputs the full 32-byte SHA-256 digest
+     * and does not support truncation. taglen is ignored; caller must provide
+     * a 32-byte buffer.
      */
+    (void)taglen;
     return mbedtls_md_hmac_finish(ctx, tag);
 }
 #endif /* MCUBOOT_USE_MBED_TLS */

--- a/boot/bootutil/include/bootutil/crypto/sha.h
+++ b/boot/bootutil/include/bootutil/crypto/sha.h
@@ -11,11 +11,13 @@
  * primitives to make it easier to swap out the used crypto library.
  *
  * At this point, the choices are: MCUBOOT_USE_MBED_TLS, MCUBOOT_USE_TINYCRYPT,
- * MCUBOOT_USE_PSA_CRYPTO, MCUBOOT_USE_CC310. Note that support for MCUBOOT_USE_PSA_CRYPTO
- * is still experimental and it might not support all the crypto abstractions
- * that MCUBOOT_USE_MBED_TLS supports. For this reason, it's allowed to have
- * both of them defined, and for crypto modules that support both abstractions,
- * the MCUBOOT_USE_PSA_CRYPTO will take precedence.
+ * MCUBOOT_USE_PSA_CRYPTO, MCUBOOT_USE_CC310, MCUBOOT_USE_CUSTOM_CRYPTO. Note
+ * that support for MCUBOOT_USE_PSA_CRYPTO is still experimental and it might
+ * not support all the crypto abstractions that MCUBOOT_USE_MBED_TLS supports.
+ * For this reason, it's allowed to have both of them defined, and for crypto
+ * modules that support both abstractions, the MCUBOOT_USE_PSA_CRYPTO will take
+ * precedence. MCUBOOT_USE_CUSTOM_CRYPTO delegates all operations to a
+ * platform-supplied <mcuboot_custom_crypto.h> resolved via the include path.
  */
 
 #ifndef __BOOTUTIL_CRYPTO_SHA_H_
@@ -28,10 +30,15 @@
 #define MCUBOOT_USE_PSA_OR_MBED_TLS
 #endif /* MCUBOOT_USE_PSA_CRYPTO || MCUBOOT_USE_MBED_TLS */
 
+#if defined(MCUBOOT_USE_CUSTOM_CRYPTO) && defined(MCUBOOT_USE_PSA_OR_MBED_TLS)
+    #error "MCUBOOT_USE_CUSTOM_CRYPTO is mutually exclusive with MCUBOOT_USE_PSA_CRYPTO and MCUBOOT_USE_MBED_TLS"
+#endif
+
 #if (defined(MCUBOOT_USE_PSA_OR_MBED_TLS) + \
      defined(MCUBOOT_USE_TINYCRYPT) + \
-     defined(MCUBOOT_USE_CC310)) != 1
-    #error "One crypto backend must be defined: either CC310/MBED_TLS/TINYCRYPT/PSA_CRYPTO"
+     defined(MCUBOOT_USE_CC310) + \
+     defined(MCUBOOT_USE_CUSTOM_CRYPTO)) != 1
+    #error "One crypto backend must be defined: either CC310/MBED_TLS/TINYCRYPT/PSA_CRYPTO/CUSTOM_CRYPTO"
 #endif
 
 #if defined(MCUBOOT_SHA512)

--- a/boot/bootutil/src/encrypted_psa.c
+++ b/boot/bootutil/src/encrypted_psa.c
@@ -6,6 +6,8 @@
 
 #include "mcuboot_config/mcuboot_config.h"
 
+#if defined(MCUBOOT_USE_PSA_CRYPTO)
+
 #include <stddef.h>
 #include <inttypes.h>
 #include <string.h>
@@ -536,3 +538,5 @@ gone:
     return ret;
 }
 #endif /* defined(MCUBOOT_ENC_IMAGES) */
+
+#endif /* defined(MCUBOOT_USE_PSA_CRYPTO) */

--- a/docs/custom_crypto.md
+++ b/docs/custom_crypto.md
@@ -1,0 +1,223 @@
+<!--
+  - SPDX-License-Identifier: Apache-2.0
+-->
+
+# Custom Crypto Backend
+
+MCUboot's crypto abstraction layer supports several open source backends like
+`MCUBOOT_USE_MBED_TLS`, `MCUBOOT_USE_TINYCRYPT`, etc. The
+`MCUBOOT_USE_CUSTOM_CRYPTO` option allows to implement a custom backend that
+lets users plug in any crypto library —
+hardware accelerator, proprietary SDK, or another software implementation —
+without modifying MCUboot's own source.
+
+## How it works
+
+When `MCUBOOT_USE_CUSTOM_CRYPTO` is defined, the crypto abstraction headers
+(`sha.h`, `ecdsa.h`, `hmac_sha256.h`, `aes_ctr.h`, `ecdh_p256.h`) do not
+define any types or functions for the custom crypto path. Instead, you must
+provide them via your platform's custom crypto header.
+
+Your custom header must be included **before** any bootutil crypto headers.
+The simplest approach is to add your header's directory to the compiler include
+path and have every translation unit include your custom header first (e.g.,
+via a force-include compiler flag or by including it at the top of
+`mcuboot_config.h`).
+
+## Enabling the custom backend
+
+Define exactly one crypto backend macro in your `mcuboot_config.h` (or via a
+compiler flag):
+
+```c
+#define MCUBOOT_USE_CUSTOM_CRYPTO
+```
+
+Do **not** define any other `MCUBOOT_USE_*` crypto backend at the same time —
+that is a compile-time error.
+
+## Implementing `mcuboot_custom_crypto.h`
+
+Your custom crypto header must define the context types and functions before
+any bootutil crypto headers are included. The sections below cover the symbols
+required by each MCUboot feature; if a required symbol is missing, the
+compiler will fail at the first use.
+
+### Required always: image hash
+
+MCUboot uses the `bootutil_sha_*` interface for image hashing. Your custom
+implementation must match the hash algorithm selected by your MCUboot
+configuration.
+
+```c
+/* Context type */
+typedef <your_sha_ctx_type> bootutil_sha_context;
+
+static inline int bootutil_sha_init(bootutil_sha_context *ctx);
+static inline int bootutil_sha_drop(bootutil_sha_context *ctx);
+static inline int bootutil_sha_update(bootutil_sha_context *ctx,
+                                      const void *data, uint32_t data_len);
+static inline int bootutil_sha_finish(bootutil_sha_context *ctx,
+                                      uint8_t *output);
+```
+
+### Required for signature verification: ECDSA
+
+Your custom ECDSA implementation must match the curve selected by your
+MCUboot signing configuration. For `MCUBOOT_SIGN_EC256`, implement P-256.
+For `MCUBOOT_SIGN_EC384`, implement P-384, including parsing `secp384r1`
+public keys and verifying signatures against the selected hash.
+
+```c
+/* Context type */
+typedef <your_ecdsa_ctx_type> bootutil_ecdsa_context;
+
+static inline void bootutil_ecdsa_init(bootutil_ecdsa_context *ctx);
+static inline void bootutil_ecdsa_drop(bootutil_ecdsa_context *ctx);
+
+/* Parse the SubjectPublicKeyInfo blob; advance *cp past the wrapper. */
+static inline int bootutil_ecdsa_parse_public_key(bootutil_ecdsa_context *ctx,
+                                                  uint8_t **cp, uint8_t *end);
+
+/* Verify a signature over hash[0..hash_len). Returns 0 on success. */
+static inline int bootutil_ecdsa_verify(bootutil_ecdsa_context *ctx,
+                                        uint8_t *pk, size_t pk_len,
+                                        uint8_t *hash, size_t hash_len,
+                                        uint8_t *sig, size_t sig_len);
+```
+
+The helper interfaces below are not direct MCUboot entry points. They are only
+needed if your custom encrypted-image implementation reuses the same helper
+abstractions as MCUboot's stock `boot/bootutil/src/encrypted.c` logic.
+
+### Helpers used by the stock image encryption implementation: HMAC-SHA256
+
+```c
+typedef <your_hmac_ctx_type> bootutil_hmac_sha256_context;
+
+static inline void bootutil_hmac_sha256_init(
+        bootutil_hmac_sha256_context *ctx);
+static inline void bootutil_hmac_sha256_drop(
+        bootutil_hmac_sha256_context *ctx);
+static inline int  bootutil_hmac_sha256_set_key(
+        bootutil_hmac_sha256_context *ctx,
+        const uint8_t *key, uint32_t key_len);
+static inline int  bootutil_hmac_sha256_update(
+        bootutil_hmac_sha256_context *ctx,
+        const void *data, uint32_t data_len);
+static inline int  bootutil_hmac_sha256_finish(
+        bootutil_hmac_sha256_context *ctx,
+        uint8_t *output, uint32_t output_len);
+```
+
+### Helpers used by the stock image encryption implementation: AES-CTR
+
+```c
+typedef <your_aes_ctx_type> bootutil_aes_ctr_context;
+
+#define BOOT_ENC_BLOCK_SIZE  16  /* must equal 16 */
+
+static inline void bootutil_aes_ctr_init(bootutil_aes_ctr_context *ctx);
+static inline void bootutil_aes_ctr_drop(bootutil_aes_ctr_context *ctx);
+static inline int  bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx,
+                                             const uint8_t *key);
+static inline int  bootutil_aes_ctr_encrypt(bootutil_aes_ctr_context *ctx,
+                                             uint8_t *counter,
+                                             const uint8_t *m, uint32_t mlen,
+                                             size_t blk_off, uint8_t *output);
+static inline int  bootutil_aes_ctr_decrypt(bootutil_aes_ctr_context *ctx,
+                                             uint8_t *counter,
+                                             const uint8_t *c, uint32_t clen,
+                                             size_t blk_off, uint8_t *output);
+```
+
+### Helpers used by the stock image encryption implementation: ECDH-P256
+
+```c
+typedef <your_ecdh_ctx_type> bootutil_ecdh_p256_context;
+typedef bootutil_ecdh_p256_context bootutil_key_exchange_ctx;
+
+static inline void bootutil_ecdh_p256_init(bootutil_ecdh_p256_context *ctx);
+static inline void bootutil_ecdh_p256_drop(bootutil_ecdh_p256_context *ctx);
+
+/* Compute the shared secret z = ECDH(sk, pk). Returns 0 on success. */
+static inline int bootutil_ecdh_p256_shared_secret(
+        bootutil_ecdh_p256_context *ctx,
+        const uint8_t *pk,  /* 65 bytes, uncompressed */
+        const uint8_t *sk,  /* 32 bytes */
+        uint8_t *z);        /* 32 bytes out */
+```
+
+### Image encryption entry points
+
+When `MCUBOOT_ENC_IMAGES` is defined and you supply a custom backend, you are
+also responsible for providing the `boot_enc_*` symbols and
+`boot_decrypt_key()` that MCUboot normally gets from
+`boot/bootutil/src/encrypted.c`. That file guards its entire body with
+`#if !defined(MCUBOOT_USE_CUSTOM_CRYPTO)` so it will not be compiled, and no
+manual exclusion from the build is required. Your translation unit must
+export:
+
+```c
+int  boot_decrypt_key(const uint8_t *buf, uint8_t *enckey);
+int  boot_enc_init(struct enc_key_data *enc_state);
+int  boot_enc_drop(struct enc_key_data *enc_state);
+int  boot_enc_set_key(struct enc_key_data *enc_state, const uint8_t *key);
+int  boot_enc_load(struct boot_loader_state *state, int slot,
+                   const struct image_header *hdr,
+                   const struct flash_area *fap,
+                   struct boot_status *bs);
+bool boot_enc_valid(const struct enc_key_data *enc_state);
+void boot_enc_encrypt(struct enc_key_data *enc_state,
+                      uint32_t off, uint32_t sz, uint32_t blk_off,
+                      uint8_t *buf);
+void boot_enc_decrypt(struct enc_key_data *enc_state,
+                      uint32_t off, uint32_t sz, uint32_t blk_off,
+                      uint8_t *buf);
+void boot_enc_zeroize(struct enc_key_data *enc_state);
+```
+
+## Build requirements
+
+| Step | Action |
+|------|--------|
+| 1. Compiler define | `-DMCUBOOT_USE_CUSTOM_CRYPTO` |
+| 2. Include order | Ensure your custom header is included before `bootutil/crypto/*.h` |
+| 3. Source files | Compile `.c` files that back your custom implementations |
+| 4. Link | Link any required libraries from your crypto SDK |
+
+**Note:** The simplest way to ensure correct include order is to use a
+force-include compiler flag (e.g., `-include mcuboot_custom_crypto.h` with GCC)
+or include your custom header at the top of `mcuboot_config.h`.
+
+## Minimal example structure
+
+```
+my_board/
+  crypto/
+    mcuboot_custom_crypto.h   ← dispatcher — includes the headers below
+    my_sha.h                  ← SHA-256 context + functions
+    my_ecdsa.h                ← ECDSA-P256 context + functions
+    my_enc.c                  ← boot_enc_* symbols (if MCUBOOT_ENC_IMAGES)
+```
+
+`mcuboot_custom_crypto.h`:
+
+```c
+#ifndef MCUBOOT_CUSTOM_CRYPTO_H
+#define MCUBOOT_CUSTOM_CRYPTO_H
+
+#include "my_sha.h"
+#include "my_ecdsa.h"
+#if defined(MCUBOOT_ENC_IMAGES)
+#include "my_hmac_sha256.h"
+#include "my_aes_ctr.h"
+#include "my_ecdh_p256.h"
+#endif
+
+#endif /* MCUBOOT_CUSTOM_CRYPTO_H */
+```
+
+Add `my_board/crypto/` to the include path and compile `my_enc.c` when
+`MCUBOOT_ENC_IMAGES` is enabled.  MCUboot will resolve all crypto calls
+through the types and functions you define.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ The MCUboot documentation is composed of the following pages:
 - [Encrypted images](encrypted_images.md)
 - [imgtool](imgtool.md) - image signing and key management
 - [ECDSA](ecdsa.md) - information about ECDSA signature formats
+- [Custom crypto backend](custom_crypto.md) - plugging in a custom crypto library
 - [Serial Recovery](serial_recovery.md) - MCUmgr as the serial recovery protocol
 - Usage instructions:
   - [Zephyr](readme-zephyr.md)

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -36,6 +36,8 @@ max-align-16 = ["mcuboot-sys/max-align-16"]
 max-align-32 = ["mcuboot-sys/max-align-32"]
 hw-rollback-protection = ["mcuboot-sys/hw-rollback-protection"]
 check-load-addr = ["mcuboot-sys/check-load-addr"]
+custom-crypto = ["mcuboot-sys/custom-crypto"]
+custom-enc-crypto = ["mcuboot-sys/custom-enc-crypto"]
 
 [dependencies]
 byteorder = "1.4"

--- a/sim/mcuboot-sys/Cargo.toml
+++ b/sim/mcuboot-sys/Cargo.toml
@@ -105,6 +105,20 @@ psa-crypto-api = []
 # Test for ih_load_addr in upgrade/next boot slot
 check-load-addr = []
 
+# Verify ECDSA-P256 signatures via MCUBOOT_USE_CUSTOM_CRYPTO using portable
+# mbedTLS-backed stubs contained entirely in csupport/custom_crypto/.
+# No hardware-specific code is compiled or linked.
+# Supports encryption when combined with enc-ec256-mbedtls, enc-aes256-ec256,
+# or the convenience feature custom-enc-crypto.
+custom-crypto = []
+
+# ECIES-P256 image encryption via the MCUBOOT_USE_CUSTOM_CRYPTO path.
+# Implies custom-crypto.  Activates sim_custom_encrypted.c for boot_enc_*
+# symbols backed by the portable mbedTLS stubs in csupport/custom_crypto/.
+# Use instead of the enc-ec256-mbedtls + custom-crypto combination when
+# the intent is clearly a fully-custom-crypto build.
+custom-enc-crypto = ["custom-crypto"]
+
 [build-dependencies]
 cc = "1.0.25"
 

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -41,6 +41,8 @@ fn main() {
     let max_align_32 = env::var("CARGO_FEATURE_MAX_ALIGN_32").is_ok();
     let hw_rollback_protection = env::var("CARGO_FEATURE_HW_ROLLBACK_PROTECTION").is_ok();
     let check_load_addr = env::var("CARGO_FEATURE_CHECK_LOAD_ADDR").is_ok();
+    let custom_crypto = env::var("CARGO_FEATURE_CUSTOM_CRYPTO").is_ok();
+    let custom_enc_crypto = env::var("CARGO_FEATURE_CUSTOM_ENC_CRYPTO").is_ok();
 
     let mut conf = CachedBuild::new();
     conf.conf.define("__BOOTSIM__", None);
@@ -97,6 +99,20 @@ fn main() {
     if vec![sig_rsa, sig_rsa3072, sig_ecdsa, sig_ed25519].iter()
         .fold(0, |sum, &v| sum + v as i32) > 1 {
         panic!("mcuboot does not support more than one sig type at the same time");
+    }
+
+    // custom-crypto selects MCUBOOT_USE_CUSTOM_CRYPTO and therefore
+    // conflicts with features that also set a backend macro.
+    if custom_crypto && (sig_rsa || sig_rsa3072 || sig_ecdsa ||
+                         sig_ecdsa_mbedtls || sig_ecdsa_psa || sig_ed25519) {
+        panic!("custom-crypto cannot be combined with sig-* features");
+    }
+
+    // custom-crypto encryption currently supports only ECIES-P256 via the
+    // mbedTLS-backed stubs (enc-ec256-mbedtls / enc-aes256-ec256 / custom-enc-crypto).
+    if custom_crypto && (enc_rsa || enc_aes256_rsa || enc_kw || enc_aes256_kw ||
+                         enc_ec256 || enc_x25519 || enc_aes256_x25519) {
+        panic!("custom-crypto encryption only supports enc-ec256-mbedtls, enc-aes256-ec256, and custom-enc-crypto");
     }
 
     if psa_crypto_api {
@@ -258,6 +274,43 @@ fn main() {
         conf.file("../../ext/fiat/src/curve25519.c");
         conf.file("../../ext/mbedtls/library/platform_util.c");
         conf.file("../../ext/mbedtls/library/asn1parse.c");
+    } else if custom_crypto {
+        // MCUBOOT_USE_CUSTOM_CRYPTO with mbedTLS stubs from csupport/custom_crypto/.
+        // mcuboot_config.h includes mcuboot_custom_crypto.h when MCUBOOT_USE_CUSTOM_CRYPTO
+        // is defined, ensuring types are available before bootutil/crypto headers.
+        conf.conf.define("MCUBOOT_USE_CUSTOM_CRYPTO", None);
+        conf.conf.define("MCUBOOT_SIGN_EC256", None);
+        conf.conf.include("csupport/custom_crypto");
+        conf.conf.include("../../ext/mbedtls/include");
+        conf.conf.include("../../ext/mbedtls/library");
+        conf.file("csupport/keys.c");
+        conf.file("../../ext/mbedtls/library/aes.c");
+        conf.file("../../ext/mbedtls/library/sha256.c");
+        conf.file("../../ext/mbedtls/library/asn1parse.c");
+        conf.file("../../ext/mbedtls/library/bignum.c");
+        conf.file("../../ext/mbedtls/library/bignum_core.c");
+        conf.file("../../ext/mbedtls/library/constant_time.c");
+        conf.file("../../ext/mbedtls/library/ecdsa.c");
+        conf.file("../../ext/mbedtls/library/ecp.c");
+        conf.file("../../ext/mbedtls/library/ecp_curves.c");
+        conf.file("../../ext/mbedtls/library/ecdh.c");
+        conf.file("../../ext/mbedtls/library/md.c");
+        conf.file("../../ext/mbedtls/library/platform.c");
+        conf.file("../../ext/mbedtls/library/platform_util.c");
+
+        // Encryption support: ECIES-P256 via sim_custom_encrypted.c which
+        // provides all boot_enc_* symbols using the custom crypto stubs.
+        // custom-enc-crypto is a convenience alias for this path.
+        if enc_ec256_mbedtls || enc_aes256_ec256 || custom_enc_crypto {
+            if enc_aes256_ec256 {
+                conf.conf.define("MCUBOOT_AES_256", None);
+            }
+            conf.conf.define("MCUBOOT_ENCRYPT_EC256", None);
+            conf.conf.define("MCUBOOT_ENC_IMAGES", None);
+            conf.conf.define("MCUBOOT_SWAP_SAVE_ENCTLV", None);
+            conf.conf.include("../../boot/bootutil/src");
+            conf.file("csupport/custom_crypto/sim_custom_encrypted.c");
+        }
     } else if !enc_ec256 && !enc_x25519 {
         // No signature type, only sha256 validation. The default
         // configuration file bundled with mbedTLS is sufficient.
@@ -379,7 +432,7 @@ fn main() {
         conf.file("../../ext/tinycrypt/lib/source/ctr_mode.c");
         conf.file("../../ext/tinycrypt/lib/source/hmac.c");
         conf.file("../../ext/tinycrypt/lib/source/ecc_dh.c");
-    } else if enc_ec256_mbedtls || enc_aes256_ec256 {
+    } else if (enc_ec256_mbedtls || enc_aes256_ec256) && !custom_crypto {
         if enc_aes256_ec256 {
             conf.conf.define("MCUBOOT_AES_256", None);
         }
@@ -459,7 +512,7 @@ fn main() {
         conf.conf.define("MBEDTLS_CONFIG_FILE", Some("<config-rsa-kw.h>"));
     } else if sig_rsa || sig_rsa3072 || enc_rsa || enc_aes256_rsa {
         conf.conf.define("MBEDTLS_CONFIG_FILE", Some("<config-rsa.h>"));
-    } else if sig_ecdsa_mbedtls || enc_ec256_mbedtls || enc_aes256_ec256 {
+    } else if sig_ecdsa_mbedtls || enc_ec256_mbedtls || enc_aes256_ec256 || custom_crypto {
         conf.conf.define("MBEDTLS_CONFIG_FILE", Some("<config-ec.h>"));
     } else if (sig_ecdsa || enc_ec256) && !enc_kw {
         conf.conf.define("MBEDTLS_CONFIG_FILE", Some("<config-asn1.h>"));
@@ -479,7 +532,7 @@ fn main() {
     conf.file("../../boot/bootutil/src/bootutil_img_security_cnt.c");
     if sig_rsa || sig_rsa3072 {
         conf.file("../../boot/bootutil/src/image_rsa.c");
-    } else if sig_ecdsa || sig_ecdsa_mbedtls || sig_ecdsa_psa {
+    } else if sig_ecdsa || sig_ecdsa_mbedtls || sig_ecdsa_psa || custom_crypto {
         conf.file("../../boot/bootutil/src/image_ecdsa.c");
     } else if sig_ed25519 {
         conf.file("../../boot/bootutil/src/image_ed25519.c");

--- a/sim/mcuboot-sys/csupport/custom_crypto/mcuboot_custom_crypto.h
+++ b/sim/mcuboot-sys/csupport/custom_crypto/mcuboot_custom_crypto.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Infineon Technologies AG, or an affiliate of Infineon
+ * Technologies AG
+ *
+ * Sim-only mcuboot_custom_crypto.h — satisfies the MCUBOOT_USE_CUSTOM_CRYPTO
+ * contract for the simulator.
+ *
+ * This header must be included before any bootutil/crypto headers. It includes
+ * sim_custom_*.h headers which provide typedef and static inline implementations
+ * of the bootutil crypto API.
+ */
+
+#ifndef MCUBOOT_CUSTOM_CRYPTO_H
+#define MCUBOOT_CUSTOM_CRYPTO_H
+
+#ifndef __BOOTSIM__
+#  error "csupport/custom_crypto/mcuboot_custom_crypto.h is a sim-only header. " \
+         "Embedded builds must use a different include path."
+#endif
+
+/* Tell image_ecdsa.c to pass the DER signature unchanged to verify(). */
+#define MCUBOOT_ECDSA_NEED_ASN1_SIG
+
+/*
+ * Include all sim custom crypto headers.
+ * Each defines bootutil_*_context and provides static inline
+ * implementations of the bootutil_* functions.
+ */
+#include "sim_custom_sha.h"
+#include "sim_custom_ecdsa.h"
+#if defined(MCUBOOT_ENC_IMAGES)
+#include "sim_custom_aes_ctr.h"
+#include "sim_custom_ecdh_p256.h"
+#include "sim_custom_hmac_sha256.h"
+#endif /* MCUBOOT_ENC_IMAGES */
+
+#endif /* MCUBOOT_CUSTOM_CRYPTO_H */

--- a/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_aes_ctr.h
+++ b/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_aes_ctr.h
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Infineon Technologies AG, or an affiliate of Infineon
+ * Technologies AG
+ *
+ * Simulator AES-CTR backend for MCUBOOT_USE_CUSTOM_CRYPTO.
+ * Thin wrapper around the existing mbedTLS AES-CTR header.
+ */
+
+#ifndef SIM_CUSTOM_AES_CTR_H
+#define SIM_CUSTOM_AES_CTR_H
+
+/*
+ * Reuse the production mbedTLS AES-CTR header directly.
+ * It defines bootutil_aes_ctr_context, BOOT_ENC_BLOCK_SIZE, and all
+ * bootutil_aes_ctr_* inline functions backed by mbedtls_aes_crypt_ctr.
+ */
+#include "bootutil/crypto/aes_ctr_mbedtls.h"
+
+#endif /* SIM_CUSTOM_AES_CTR_H */

--- a/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_ecdh_p256.h
+++ b/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_ecdh_p256.h
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Infineon Technologies AG, or an affiliate of Infineon
+ * Technologies AG
+ *
+ * Simulator ECDH-P256 backend for MCUBOOT_USE_CUSTOM_CRYPTO.
+ * Implements the bootutil ECDH-P256 abstraction using mbedTLS.
+ * The private key is received as raw bytes and used transiently.
+ */
+
+#ifndef SIM_CUSTOM_ECDH_P256_H
+#define SIM_CUSTOM_ECDH_P256_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include <mbedtls/build_info.h>
+#include <mbedtls/ecp.h>
+#include <mbedtls/ecdh.h>
+#include <mbedtls/bignum.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SIM_ECP256_PRIVKEY_BYTES (32u)
+#define SIM_ECP256_PUBKEY_BYTES  (65u)
+#define SIM_ECP256_SHARED_BYTES  (32u)
+
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+/* mbedTLS 3.x requires a non-NULL f_rng for ecp_mul (point blinding).
+ * This stub satisfies the requirement for the simulator context where
+ * side-channel resistance is not a concern. */
+static inline int sim_fake_rng(void *p_rng, unsigned char *output, size_t len)
+{
+    size_t i;
+    (void)p_rng;
+    for (i = 0; i < len; i++) {
+        output[i] = (unsigned char)i;
+    }
+    return 0;
+}
+#endif /* MBEDTLS_VERSION_NUMBER >= 0x03000000 */
+
+typedef struct { int _unused; } bootutil_ecdh_p256_context;
+typedef bootutil_ecdh_p256_context bootutil_key_exchange_ctx;
+
+static inline void bootutil_ecdh_p256_init(bootutil_ecdh_p256_context *ctx)
+{
+    (void)ctx;
+}
+
+static inline void bootutil_ecdh_p256_drop(bootutil_ecdh_p256_context *ctx)
+{
+    (void)ctx;
+}
+
+static inline int bootutil_ecdh_p256_shared_secret(
+        bootutil_ecdh_p256_context *ctx,
+        const uint8_t *pk,
+        const uint8_t *sk,
+        uint8_t *z)
+{
+    mbedtls_ecp_group grp;
+    mbedtls_ecp_point peer;
+    mbedtls_mpi       d, shared;
+    int rc = -1;
+
+    (void)ctx;
+
+    mbedtls_ecp_group_init(&grp);
+    mbedtls_ecp_point_init(&peer);
+    mbedtls_mpi_init(&d);
+    mbedtls_mpi_init(&shared);
+
+    if (mbedtls_ecp_group_load(&grp, MBEDTLS_ECP_DP_SECP256R1) != 0) { goto out; }
+    if (mbedtls_ecp_point_read_binary(&grp, &peer, pk, SIM_ECP256_PUBKEY_BYTES) != 0) { goto out; }
+    if (mbedtls_ecp_check_pubkey(&grp, &peer) != 0) { goto out; }
+    if (mbedtls_mpi_read_binary(&d, sk, SIM_ECP256_PRIVKEY_BYTES) != 0) { goto out; }
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+    if (mbedtls_ecdh_compute_shared(&grp, &shared, &peer, &d, sim_fake_rng, NULL) != 0) { goto out; }
+#else
+    if (mbedtls_ecdh_compute_shared(&grp, &shared, &peer, &d, NULL, NULL) != 0) { goto out; }
+#endif
+    if (mbedtls_mpi_write_binary(&shared, z, SIM_ECP256_SHARED_BYTES) != 0) { goto out; }
+    rc = 0;
+
+out:
+    mbedtls_mpi_free(&shared);
+    mbedtls_mpi_free(&d);
+    mbedtls_ecp_point_free(&peer);
+    mbedtls_ecp_group_free(&grp);
+    return rc;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SIM_CUSTOM_ECDH_P256_H */

--- a/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_ecdsa.h
+++ b/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_ecdsa.h
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Infineon Technologies AG, or an affiliate of Infineon
+ * Technologies AG
+ *
+ * Simulator ECDSA-P256 backend for MCUBOOT_USE_CUSTOM_CRYPTO.
+ * Implements the bootutil ECDSA abstraction using mbedTLS.
+ *
+ * Setting MCUBOOT_ECDSA_NEED_ASN1_SIG tells image_ecdsa.c to pass the raw
+ * DER-encoded signature to bootutil_ecdsa_verify() (same as the mbedTLS path).
+ */
+
+#ifndef SIM_CUSTOM_ECDSA_H
+#define SIM_CUSTOM_ECDSA_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <mbedtls/ecdsa.h>
+#include <mbedtls/asn1.h>
+#include <mbedtls/oid.h>
+
+/* Tell image_ecdsa.c to pass the DER signature unchanged to verify(). */
+#define MCUBOOT_ECDSA_NEED_ASN1_SIG
+
+#define SIM_NUM_ECC_BYTES (32)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ---- SubjectPublicKeyInfo parser (same logic as the mainline mbed path) -- */
+
+static const uint8_t sim_ec_pubkey_oid[]    = MBEDTLS_OID_EC_ALG_UNRESTRICTED;
+static const uint8_t sim_ec_secp256r1_oid[] = MBEDTLS_OID_EC_GRP_SECP256R1;
+
+static inline int sim_import_key(uint8_t **cp, uint8_t *end)
+{
+    size_t len;
+    mbedtls_asn1_buf alg, param;
+
+    if (mbedtls_asn1_get_tag(cp, end, &len,
+                             MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE)) {
+        return -1;
+    }
+    end = *cp + len;
+    if (mbedtls_asn1_get_alg(cp, end, &alg, &param)) { return -2; }
+    if (alg.len != sizeof(sim_ec_pubkey_oid) - 1 ||
+        memcmp(alg.p, sim_ec_pubkey_oid, sizeof(sim_ec_pubkey_oid) - 1)) {
+        return -3;
+    }
+    if (param.len != sizeof(sim_ec_secp256r1_oid) - 1 ||
+        memcmp(param.p, sim_ec_secp256r1_oid, sizeof(sim_ec_secp256r1_oid) - 1)) {
+        return -4;
+    }
+    if (mbedtls_asn1_get_bitstring_null(cp, end, &len)) { return -5; }
+    if (*cp + len != end) { return -6; }
+    if (len != 2 * SIM_NUM_ECC_BYTES + 1) { return -7; }
+    return 0;
+}
+
+/* ---- Context ------------------------------------------------------------- */
+
+typedef mbedtls_ecdsa_context bootutil_ecdsa_context;
+
+static inline void bootutil_ecdsa_init(bootutil_ecdsa_context *ctx)
+{
+    mbedtls_ecdsa_init(ctx);
+}
+
+static inline void bootutil_ecdsa_drop(bootutil_ecdsa_context *ctx)
+{
+    mbedtls_ecdsa_free(ctx);
+}
+
+/* Advance *cp past the SubjectPublicKeyInfo wrapper to the raw EC point. */
+static inline int bootutil_ecdsa_parse_public_key(bootutil_ecdsa_context *ctx,
+                                                  uint8_t **cp, uint8_t *end)
+{
+    (void)ctx;
+    return sim_import_key(cp, end);
+}
+
+/* pk/pk_len: raw 65-byte uncompressed EC point; sig/sig_len: DER signature. */
+static inline int bootutil_ecdsa_verify(bootutil_ecdsa_context *ctx,
+                                        uint8_t *pk, size_t pk_len,
+                                        uint8_t *hash, size_t hash_len,
+                                        uint8_t *sig, size_t sig_len)
+{
+    int rc;
+
+    rc = mbedtls_ecp_group_load(&ctx->MBEDTLS_PRIVATE(grp),
+                                MBEDTLS_ECP_DP_SECP256R1);
+    if (rc) { return -1; }
+
+    rc = mbedtls_ecp_point_read_binary(&ctx->MBEDTLS_PRIVATE(grp),
+                                       &ctx->MBEDTLS_PRIVATE(Q),
+                                       pk, pk_len);
+    if (rc) { return -1; }
+
+    rc = mbedtls_ecp_check_pubkey(&ctx->MBEDTLS_PRIVATE(grp),
+                                  &ctx->MBEDTLS_PRIVATE(Q));
+    if (rc) { return -1; }
+
+    rc = mbedtls_ecdsa_read_signature(ctx, hash, hash_len, sig, sig_len);
+    return (rc == 0) ? 0 : -1;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SIM_CUSTOM_ECDSA_H */

--- a/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_encrypted.c
+++ b/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_encrypted.c
@@ -1,116 +1,72 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright (c) 2018-2019 JUUL Labs
- * Copyright (c) 2019-2024 Arm Limited
- * Copyright (c) 2025 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Infineon Technologies AG, or an affiliate of Infineon
+ * Technologies AG
+ *
+ * Sim-only encryption support for the MCUBOOT_USE_CUSTOM_CRYPTO path.
+ *
+ * encrypted.c suppresses its entire body when MCUBOOT_USE_CUSTOM_CRYPTO is
+ * defined because embedded targets (e.g. Infineon SE RT) provide their own
+ * boot_enc_* symbols.  This file is the sim's custom implementation of those
+ * symbols for ECIES-P256 encryption, using the mbedTLS-backed custom crypto
+ * stubs.
+ *
+ * Provides: boot_enc_retrieve_private_key, boot_decrypt_key, boot_enc_init,
+ *           boot_enc_drop, boot_enc_set_key, boot_enc_load, boot_enc_valid,
+ *           boot_enc_encrypt, boot_enc_decrypt, boot_enc_zeroize.
  */
 
 #include "mcuboot_config/mcuboot_config.h"
 
-#if defined(MCUBOOT_ENC_IMAGES)
+#if defined(MCUBOOT_ENC_IMAGES) && defined(MCUBOOT_USE_CUSTOM_CRYPTO)
 
-/* When MCUBOOT_USE_CUSTOM_CRYPTO is active the custom crypto translation unit
- * provides all boot_enc_* and boot_decrypt_key symbols and handles HMAC/KDF
- * internally without depending on MBED_TLS or TINYCRYPT.  Suppress this
- * entire file to avoid duplicate symbol link errors. */
-#if !defined(MCUBOOT_USE_CUSTOM_CRYPTO)
-
+#include <assert.h>
 #include <stddef.h>
-#include <inttypes.h>
+#include <stdint.h>
+#include <stdbool.h>
 #include <string.h>
 
-#if defined(MCUBOOT_ENCRYPT_RSA)
-#define BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED
-#include "bootutil/crypto/rsa.h"
-#endif
-
-#if defined(MCUBOOT_ENCRYPT_KW)
-#include "bootutil/crypto/aes_kw.h"
-#endif
-
-#if !defined(MCUBOOT_USE_PSA_CRYPTO)
-#if defined(MCUBOOT_ENCRYPT_EC256)
 #include "bootutil/crypto/ecdh_p256.h"
-#endif
-
-#if defined(MCUBOOT_ENCRYPT_X25519)
-#include "bootutil/crypto/ecdh_x25519.h"
-#endif
-
-#if defined(MCUBOOT_ENCRYPT_EC256) || defined(MCUBOOT_ENCRYPT_X25519)
 #include "bootutil/crypto/sha.h"
 #include "bootutil/crypto/hmac_sha256.h"
-#include "mbedtls/oid.h"
-#include "mbedtls/asn1.h"
-#endif
-#endif
-
+#include "bootutil/crypto/aes_ctr.h"
+#include "bootutil/crypto/common.h"
 #include "bootutil/image.h"
 #include "bootutil/enc_key.h"
 #include "bootutil/sign_key.h"
-#include "bootutil/crypto/common.h"
 #include "bootutil/bootutil_log.h"
+
+#include "mbedtls/oid.h"
+#include "mbedtls/asn1.h"
 
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 #include "bootutil_priv.h"
 
-/* NOUP Fixme:  */
-#if !defined(CONFIG_BOOT_ED25519_PSA) && !defined(CONFIG_BOOT_ECDSA_PSA)
-#if defined(MCUBOOT_ENCRYPT_EC256) || defined(MCUBOOT_ENCRYPT_X25519)
-#if defined(_compare)
-static inline int bootutil_constant_time_compare(const uint8_t *a, const uint8_t *b, size_t size)
+/* ------------------------------------------------------------------ */
+/*  Constant-time compare                                             */
+/* ------------------------------------------------------------------ */
+static int
+sim_constant_time_compare(const uint8_t *a, const uint8_t *b, size_t size)
 {
-    return _compare(a, b, size);
-}
-#else
-static int bootutil_constant_time_compare(const uint8_t *a, const uint8_t *b, size_t size)
-{
-    const uint8_t *tempa = a;
-    const uint8_t *tempb = b;
     uint8_t result = 0;
-    unsigned int i;
+    size_t i;
 
     for (i = 0; i < size; i++) {
-        result |= tempa[i] ^ tempb[i];
+        result |= a[i] ^ b[i];
     }
     return result;
 }
-#endif
-#endif
 
-#if defined(MCUBOOT_ENCRYPT_KW)
-static int
-key_unwrap(const uint8_t *wrapped, uint8_t *enckey, struct bootutil_key *bootutil_enc_key)
-{
-    bootutil_aes_kw_context aes_kw;
-    int rc;
-
-    bootutil_aes_kw_init(&aes_kw);
-    rc = bootutil_aes_kw_set_unwrap_key(&aes_kw, bootutil_enc_key->key, *bootutil_enc_key->len);
-    if (rc != 0) {
-        goto done;
-    }
-    rc = bootutil_aes_kw_unwrap(&aes_kw, wrapped, BOOT_ENC_TLV_SIZE, enckey, BOOT_ENC_KEY_SIZE);
-    if (rc != 0) {
-        goto done;
-    }
-
-done:
-    bootutil_aes_kw_drop(&aes_kw);
-    return rc;
-}
-#endif /* MCUBOOT_ENCRYPT_KW */
-
+/* ------------------------------------------------------------------ */
+/*  parse_priv_enckey — PKCS#8 EC private key parser for EC256        */
+/* ------------------------------------------------------------------ */
 #if defined(MCUBOOT_ENCRYPT_EC256)
+
 static const uint8_t ec_pubkey_oid[] = MBEDTLS_OID_EC_ALG_UNRESTRICTED;
 static const uint8_t ec_secp256r1_oid[] = MBEDTLS_OID_EC_GRP_SECP256R1;
 
-/*
- * Parses the output of `imgtool keygen`, which produces a PKCS#8 elliptic
- * curve keypair. See RFC5208 and RFC5915.
- */
 static int
 parse_priv_enckey(uint8_t **p, uint8_t *end, uint8_t *private_key)
 {
@@ -151,7 +107,6 @@ parse_priv_enckey(uint8_t **p, uint8_t *end, uint8_t *private_key)
     }
 
     /* RFC5915 - ECPrivateKey */
-
     if (mbedtls_asn1_get_tag(p, end, &len,
                              MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE) != 0) {
         return -1;
@@ -163,90 +118,29 @@ parse_priv_enckey(uint8_t **p, uint8_t *end, uint8_t *private_key)
     }
 
     /* privateKey */
-
     if (mbedtls_asn1_get_tag(p, end, &len, MBEDTLS_ASN1_OCTET_STRING) != 0) {
         return -1;
     }
 
-    if (len != NUM_ECC_BYTES) {
+    if (len != SIM_NUM_ECC_BYTES) {
         return -1;
     }
 
     memcpy(private_key, *p, len);
-
-    /* publicKey usually follows but is not parsed here */
-
     return 0;
 }
-#endif /* defined(MCUBOOT_ENCRYPT_EC256) */
 
-#if defined(MCUBOOT_ENCRYPT_X25519)
-#define X25519_OID "\x6e"
-static const uint8_t ec_pubkey_oid[] = MBEDTLS_OID_ISO_IDENTIFIED_ORG \
-                                       MBEDTLS_OID_ORG_GOV X25519_OID;
+#endif /* MCUBOOT_ENCRYPT_EC256 */
+
+/* ------------------------------------------------------------------ */
+/*  HKDF (RFC 5869)                                                   */
+/* ------------------------------------------------------------------ */
+#if defined(MCUBOOT_ENCRYPT_EC256)
 
 static int
-parse_priv_enckey(uint8_t **p, uint8_t *end, uint8_t *private_key)
-{
-    size_t len;
-    int version;
-    mbedtls_asn1_buf alg;
-    mbedtls_asn1_buf param;
-
-    if (mbedtls_asn1_get_tag(p, end, &len, MBEDTLS_ASN1_CONSTRUCTED |
-                                           MBEDTLS_ASN1_SEQUENCE) != 0) {
-        return -1;
-    }
-
-    if (*p + len != end) {
-        return -1;
-    }
-
-    version = 0;
-    if (mbedtls_asn1_get_int(p, end, &version) || version != 0) {
-        return -1;
-    }
-
-    if (mbedtls_asn1_get_alg(p, end, &alg, &param) != 0) {
-        return -1;
-    }
-
-    if (alg.ASN1_CONTEXT_MEMBER(len) != sizeof(ec_pubkey_oid) - 1 ||
-        memcmp(alg.ASN1_CONTEXT_MEMBER(p), ec_pubkey_oid, sizeof(ec_pubkey_oid) - 1)) {
-        return -1;
-    }
-
-    if (mbedtls_asn1_get_tag(p, end, &len, MBEDTLS_ASN1_OCTET_STRING) != 0) {
-        return -1;
-    }
-
-    if (mbedtls_asn1_get_tag(p, end, &len, MBEDTLS_ASN1_OCTET_STRING) != 0) {
-        return -1;
-    }
-
-    if (len != EC_PRIVK_LEN) {
-        return -1;
-    }
-
-    memcpy(private_key, *p, EC_PRIVK_LEN);
-    return 0;
-}
-#endif /* defined(MCUBOOT_ENCRYPT_X25519) */
-
-#if defined(MCUBOOT_ENCRYPT_EC256) || defined(MCUBOOT_ENCRYPT_X25519)
-/*
- * HKDF as described by RFC5869.
- *
- * @param ikm       The input data to be derived.
- * @param ikm_len   Length of the input data.
- * @param info      An information tag.
- * @param info_len  Length of the information tag.
- * @param okm       Output of the KDF computation.
- * @param okm_len   On input the requested length; on output the generated length
- */
-static int
-hkdf(const uint8_t *ikm, size_t ikm_len, const uint8_t *info, size_t info_len,
-        uint8_t *okm, size_t *okm_len)
+hkdf(const uint8_t *ikm, size_t ikm_len,
+     const uint8_t *info, size_t info_len,
+     uint8_t *okm, size_t *okm_len)
 {
     bootutil_hmac_sha256_context hmac;
     uint8_t salt[BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE];
@@ -258,49 +152,37 @@ hkdf(const uint8_t *ikm, size_t ikm_len, const uint8_t *info, size_t info_len,
     bool first;
     int rc;
 
-    /*
-     * Extract
-     */
-
     if (ikm == NULL || okm == NULL || ikm_len == 0) {
         return -1;
     }
 
+    /* Extract */
     bootutil_hmac_sha256_init(&hmac);
-
     memset(salt, 0, BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
     rc = bootutil_hmac_sha256_set_key(&hmac, salt, BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
     if (rc != 0) {
         goto error;
     }
-
     rc = bootutil_hmac_sha256_update(&hmac, ikm, ikm_len);
     if (rc != 0) {
         goto error;
     }
-
     rc = bootutil_hmac_sha256_finish(&hmac, prk, BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
     if (rc != 0) {
         goto error;
     }
-
     bootutil_hmac_sha256_drop(&hmac);
 
-    /*
-     * Expand
-     */
-
+    /* Expand */
     len = *okm_len;
     counter = 1;
     first = true;
     for (off = 0; len > 0; off += BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE, ++counter) {
         bootutil_hmac_sha256_init(&hmac);
-
         rc = bootutil_hmac_sha256_set_key(&hmac, prk, BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
         if (rc != 0) {
             goto error;
         }
-
         if (first) {
             first = false;
         } else {
@@ -309,22 +191,18 @@ hkdf(const uint8_t *ikm, size_t ikm_len, const uint8_t *info, size_t info_len,
                 goto error;
             }
         }
-
         rc = bootutil_hmac_sha256_update(&hmac, info, info_len);
         if (rc != 0) {
             goto error;
         }
-
         rc = bootutil_hmac_sha256_update(&hmac, &counter, 1);
         if (rc != 0) {
             goto error;
         }
-
         rc = bootutil_hmac_sha256_finish(&hmac, T, BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
         if (rc != 0) {
             goto error;
         }
-
         bootutil_hmac_sha256_drop(&hmac);
 
         if (len > BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE) {
@@ -342,51 +220,30 @@ error:
     bootutil_hmac_sha256_drop(&hmac);
     return -1;
 }
-#endif /* MCUBOOT_ENCRYPT_EC256 || MCUBOOT_ENCRYPT_X25519 */
 
+#endif /* MCUBOOT_ENCRYPT_EC256 */
+
+/* ------------------------------------------------------------------ */
+/*  boot_enc_retrieve_private_key                                     */
+/* ------------------------------------------------------------------ */
 #if !defined(MCUBOOT_ENC_BUILTIN_KEY)
 extern const struct bootutil_key bootutil_enc_key;
 
-/*
- * Default implementation to retrieve the private encryption key which is
- * embedded in the bootloader code (when MCUBOOT_ENC_BUILTIN_KEY is not defined).
- */
-int boot_enc_retrieve_private_key(struct bootutil_key **private_key)
+int
+boot_enc_retrieve_private_key(struct bootutil_key **private_key)
 {
     *private_key = (struct bootutil_key *)&bootutil_enc_key;
-
     return 0;
 }
 #endif /* !MCUBOOT_ENC_BUILTIN_KEY */
 
-#if ( (defined(MCUBOOT_ENCRYPT_RSA) && defined(MCUBOOT_USE_MBED_TLS) && !defined(MCUBOOT_USE_PSA_CRYPTO)) || \
-      (defined(MCUBOOT_ENCRYPT_EC256) && defined(MCUBOOT_USE_MBED_TLS)) )
-#if MBEDTLS_VERSION_NUMBER >= 0x03000000
-static int fake_rng(void *p_rng, unsigned char *output, size_t len)
-{
-    size_t i;
-
-    (void)p_rng;
-    for (i = 0; i < len; i++) {
-        output[i] = (char)i;
-    }
-
-    return 0;
-}
-#endif /* MBEDTLS_VERSION_NUMBER */
-#endif /* (MCUBOOT_ENCRYPT_RSA && MCUBOOT_USE_MBED_TLS && !MCUBOOT_USE_PSA_CRYPTO) ||
-          (MCUBOOT_ENCRYPT_EC256 && MCUBOOT_USE_MBED_TLS) */
-
-/*
- * Decrypt an encryption key TLV.
- *
- * @param buf An encryption TLV read from flash (build time fixed length)
- * @param enckey An AES-128 or AES-256 key sized buffer to store to plain key.
- */
+/* ------------------------------------------------------------------ */
+/*  boot_decrypt_key                                                  */
+/* ------------------------------------------------------------------ */
 int
 boot_decrypt_key(const uint8_t *buf, uint8_t *enckey)
 {
-#if defined(MCUBOOT_ENCRYPT_EC256) || defined(MCUBOOT_ENCRYPT_X25519)
+#if defined(MCUBOOT_ENCRYPT_EC256)
     bootutil_hmac_sha256_context hmac;
     bootutil_aes_ctr_context aes_ctr;
     uint8_t tag[BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE];
@@ -394,187 +251,100 @@ boot_decrypt_key(const uint8_t *buf, uint8_t *enckey)
     uint8_t derived_key[BOOT_ENC_KEY_SIZE + BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE];
     uint8_t private_key[EC_PRIVK_LEN];
     uint8_t counter[BOOT_ENC_BLOCK_SIZE];
-#endif
-#if !defined(MCUBOOT_ENCRYPT_KW)
     bootutil_key_exchange_ctx pk_ctx;
     uint8_t *cp;
     uint8_t *cpend;
     size_t len;
-#endif
-    struct bootutil_key *bootutil_enc_key = NULL;
+    struct bootutil_key *bootutil_enc_key_ptr = NULL;
     int rc = -1;
 
     BOOT_LOG_DBG("boot_decrypt_key");
 
-    rc = boot_enc_retrieve_private_key(&bootutil_enc_key);
+    rc = boot_enc_retrieve_private_key(&bootutil_enc_key_ptr);
     if (rc) {
         return rc;
     }
-
-    if (bootutil_enc_key == NULL) {
-        return rc;
+    if (bootutil_enc_key_ptr == NULL) {
+        return -1;
     }
 
-#if !defined(MCUBOOT_ENCRYPT_KW)
-    cp = (uint8_t *)bootutil_enc_key->key;
-    cpend = cp + *bootutil_enc_key->len;
-#endif
+    cp = (uint8_t *)bootutil_enc_key_ptr->key;
+    cpend = cp + *bootutil_enc_key_ptr->len;
 
-#if defined(MCUBOOT_ENCRYPT_RSA)
-    bootutil_rsa_init(&pk_ctx);
-
-    /* The enckey is encrypted through RSA so for decryption we need the private key */
-    rc = bootutil_rsa_parse_private_key(&pk_ctx, &cp, cpend);
-    if (rc) {
-        bootutil_rsa_drop(&pk_ctx);
-        return rc;
-    }
-
-    rc = bootutil_rsa_oaep_decrypt(&pk_ctx, &len, buf, enckey, BOOT_ENC_KEY_SIZE);
-    bootutil_rsa_drop(&pk_ctx);
-    if (rc) {
-        return rc;
-    }
-
-#endif /* defined(MCUBOOT_ENCRYPT_RSA) */
-
-#if defined(MCUBOOT_ENCRYPT_KW)
-
-    assert(*bootutil_enc_key->len == BOOT_ENC_KEY_SIZE);
-    rc = key_unwrap(buf, enckey, bootutil_enc_key);
-
-#endif /* defined(MCUBOOT_ENCRYPT_KW) */
-
-#if defined(MCUBOOT_ENCRYPT_EC256)
-    /*
-     * Load the stored EC256 decryption private key
-     */
-
+    /* Parse the PKCS#8 EC private key */
     rc = parse_priv_enckey(&cp, cpend, private_key);
     if (rc) {
         BOOT_LOG_ERR("Failed to parse ASN1 private key");
         return rc;
     }
 
-    /*
-     * First "element" in the TLV is the curve point (public key)
-     */
+    /* ECDH shared secret */
     bootutil_ecdh_p256_init(&pk_ctx);
-
-    rc = bootutil_ecdh_p256_shared_secret(&pk_ctx, &buf[EC_PUBK_INDEX], private_key, shared);
+    rc = bootutil_ecdh_p256_shared_secret(&pk_ctx, &buf[EC_PUBK_INDEX],
+                                          private_key, shared);
     bootutil_ecdh_p256_drop(&pk_ctx);
     if (rc != 0) {
         return -1;
     }
 
-#endif /* defined(MCUBOOT_ENCRYPT_EC256) */
-
-#if defined(MCUBOOT_ENCRYPT_X25519)
-    /*
-     * Load the stored X25519 decryption private key
-     */
-
-    rc = parse_priv_enckey(&cp, cpend, private_key);
-    if (rc) {
-        BOOT_LOG_ERR("Failed to parse ASN1 private key");
-        return rc;
-    }
-
-    /*
-     * First "element" in the TLV is the curve point (public key)
-     */
-
-    bootutil_ecdh_x25519_init(&pk_ctx);
-
-    rc = bootutil_ecdh_x25519_shared_secret(&pk_ctx, &buf[EC_PUBK_INDEX], private_key, shared);
-    bootutil_ecdh_x25519_drop(&pk_ctx);
-    if (!rc) {
-        return -1;
-    }
-
-#endif /* defined(MCUBOOT_ENCRYPT_X25519) */
-
-#if defined(MCUBOOT_ENCRYPT_EC256) || defined(MCUBOOT_ENCRYPT_X25519)
-
-    /*
-     * Expand shared secret to create keys for AES-128-CTR + HMAC-SHA256
-     */
-
+    /* HKDF: derive AES key + HMAC key */
     len = BOOT_ENC_KEY_SIZE + BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE;
-    rc = hkdf(shared, EC_SHARED_LEN, (uint8_t *)"MCUBoot_ECIES_v1", 16,
-            derived_key, &len);
+    rc = hkdf(shared, EC_SHARED_LEN,
+              (const uint8_t *)"MCUBoot_ECIES_v1", 16,
+              derived_key, &len);
     if (rc != 0 || len != (BOOT_ENC_KEY_SIZE + BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE)) {
         return -1;
     }
 
-    /*
-     * HMAC the key and check that our received MAC matches the generated tag
-     */
-
+    /* HMAC-SHA256 verify the ciphertext tag */
     bootutil_hmac_sha256_init(&hmac);
-
-    /* First BOOT_ENC_KEY_SIZE are used for decryption, remaining 32 bytes are used
-     * for MAC tag key
-     */
     rc = bootutil_hmac_sha256_set_key(&hmac, &derived_key[BOOT_ENC_KEY_SIZE], 32);
     if (rc != 0) {
         (void)bootutil_hmac_sha256_drop(&hmac);
         return -1;
     }
-
-    rc = bootutil_hmac_sha256_update(&hmac, &buf[EC_CIPHERKEY_INDEX], BOOT_ENC_KEY_SIZE);
+    rc = bootutil_hmac_sha256_update(&hmac, &buf[EC_CIPHERKEY_INDEX],
+                                     BOOT_ENC_KEY_SIZE);
     if (rc != 0) {
         (void)bootutil_hmac_sha256_drop(&hmac);
         return -1;
     }
-
-    /* Assumes the tag buffer is at least sizeof(hmac_tag_size(state)) bytes */
     rc = bootutil_hmac_sha256_finish(&hmac, tag, BOOTUTIL_CRYPTO_SHA256_DIGEST_SIZE);
     (void)bootutil_hmac_sha256_drop(&hmac);
     if (rc != 0) {
         return -1;
     }
-
-    if (bootutil_constant_time_compare(tag, &buf[EC_TAG_INDEX], EC_TAG_LEN) != 0) {
+    if (sim_constant_time_compare(tag, &buf[EC_TAG_INDEX], EC_TAG_LEN) != 0) {
         return -1;
     }
 
-    /*
-     * Finally decrypt the received ciphered key
-     */
-
+    /* AES-CTR decrypt the wrapped key */
     bootutil_aes_ctr_init(&aes_ctr);
-    if (rc != 0) {
-        bootutil_aes_ctr_drop(&aes_ctr);
-        return -1;
-    }
-
     rc = bootutil_aes_ctr_set_key(&aes_ctr, derived_key);
     if (rc != 0) {
         bootutil_aes_ctr_drop(&aes_ctr);
         return -1;
     }
-
     memset(counter, 0, BOOT_ENC_BLOCK_SIZE);
-    rc = bootutil_aes_ctr_decrypt(&aes_ctr, counter, &buf[EC_CIPHERKEY_INDEX], BOOT_ENC_KEY_SIZE, 0, enckey);
+    rc = bootutil_aes_ctr_decrypt(&aes_ctr, counter,
+                                  &buf[EC_CIPHERKEY_INDEX],
+                                  BOOT_ENC_KEY_SIZE, 0, enckey);
+    bootutil_aes_ctr_drop(&aes_ctr);
     if (rc != 0) {
-        bootutil_aes_ctr_drop(&aes_ctr);
         return -1;
     }
 
-    bootutil_aes_ctr_drop(&aes_ctr);
-
-    rc = 0;
-
-#endif /* defined(MCUBOOT_ENCRYPT_EC256) || defined(MCUBOOT_ENCRYPT_X25519) */
-
-    return rc;
+    return 0;
+#else
+    (void)buf;
+    (void)enckey;
+    return -1;
+#endif /* MCUBOOT_ENCRYPT_EC256 */
 }
-#endif /* CONFIG_BOOT_ED25519_PSA  && CONFIG_BOOT_ECDSA_PSA */
 
-/*
- * Load encryption key.
- */
+/* ------------------------------------------------------------------ */
+/*  boot_enc_load                                                     */
+/* ------------------------------------------------------------------ */
 int
 boot_enc_load(struct boot_loader_state *state, int slot,
               const struct image_header *hdr, const struct flash_area *fap,
@@ -593,13 +363,11 @@ boot_enc_load(struct boot_loader_state *state, int slot,
 
     BOOT_LOG_DBG("boot_enc_load: slot %d", slot);
 
-    /* Already loaded... */
     if (boot_enc_valid(enc_state)) {
         BOOT_LOG_DBG("boot_enc_load: already loaded");
         return 1;
     }
 
-    /* Initialize the AES context */
     boot_enc_init(enc_state);
 
 #if defined(MCUBOOT_SWAP_USING_OFFSET)
@@ -633,6 +401,9 @@ boot_enc_load(struct boot_loader_state *state, int slot,
     return boot_decrypt_key(buf, bs->enckey[slot]);
 }
 
+/* ------------------------------------------------------------------ */
+/*  boot_enc_{init,drop,set_key,valid}                                */
+/* ------------------------------------------------------------------ */
 int
 boot_enc_init(struct enc_key_data *enc_state)
 {
@@ -660,7 +431,6 @@ boot_enc_set_key(struct enc_key_data *enc_state, const uint8_t *key)
     }
 
     enc_state->valid = 1;
-
     return 0;
 }
 
@@ -670,15 +440,17 @@ boot_enc_valid(const struct enc_key_data *enc_state)
     return enc_state->valid;
 }
 
+/* ------------------------------------------------------------------ */
+/*  boot_enc_{encrypt,decrypt}                                        */
+/* ------------------------------------------------------------------ */
 void
 boot_enc_encrypt(struct enc_key_data *enc, uint32_t off,
-             uint32_t sz, uint32_t blk_off, uint8_t *buf)
+                 uint32_t sz, uint32_t blk_off, uint8_t *buf)
 {
     uint8_t nonce[16];
 
-    /* Nothing to do with size == 0 */
     if (sz == 0) {
-       return;
+        return;
     }
 
     memset(nonce, 0, 12);
@@ -694,13 +466,12 @@ boot_enc_encrypt(struct enc_key_data *enc, uint32_t off,
 
 void
 boot_enc_decrypt(struct enc_key_data *enc, uint32_t off,
-             uint32_t sz, uint32_t blk_off, uint8_t *buf)
+                 uint32_t sz, uint32_t blk_off, uint8_t *buf)
 {
     uint8_t nonce[16];
 
-    /* Nothing to do with size == 0 */
     if (sz == 0) {
-       return;
+        return;
     }
 
     memset(nonce, 0, 12);
@@ -714,19 +485,18 @@ boot_enc_decrypt(struct enc_key_data *enc, uint32_t off,
     bootutil_aes_ctr_decrypt(&enc->aes_ctr, nonce, buf, sz, blk_off, buf);
 }
 
-/**
- * Clears encrypted state after use.
- */
+/* ------------------------------------------------------------------ */
+/*  boot_enc_zeroize                                                  */
+/* ------------------------------------------------------------------ */
 void
 boot_enc_zeroize(struct enc_key_data *enc_state)
 {
     uint8_t slot;
+
     for (slot = 0; slot < BOOT_NUM_SLOTS; slot++) {
         (void)boot_enc_drop(&enc_state[slot]);
     }
     memset(enc_state, 0, sizeof(struct enc_key_data) * BOOT_NUM_SLOTS);
 }
 
-#endif /* !MCUBOOT_USE_CUSTOM_CRYPTO */
-
-#endif /* MCUBOOT_ENC_IMAGES */
+#endif /* MCUBOOT_ENC_IMAGES && MCUBOOT_USE_CUSTOM_CRYPTO */

--- a/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_hmac_sha256.h
+++ b/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_hmac_sha256.h
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Infineon Technologies AG, or an affiliate of Infineon
+ * Technologies AG
+ *
+ * Simulator HMAC-SHA256 backend for MCUBOOT_USE_CUSTOM_CRYPTO.
+ * Implements the bootutil HMAC-SHA256 abstraction using mbedTLS.
+ */
+
+#ifndef SIM_CUSTOM_HMAC_SHA256_H
+#define SIM_CUSTOM_HMAC_SHA256_H
+
+#include <stdint.h>
+#include <mbedtls/md.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef mbedtls_md_context_t bootutil_hmac_sha256_context;
+
+static inline void bootutil_hmac_sha256_init(bootutil_hmac_sha256_context *ctx)
+{
+    mbedtls_md_init(ctx);
+}
+
+static inline void bootutil_hmac_sha256_drop(bootutil_hmac_sha256_context *ctx)
+{
+    mbedtls_md_free(ctx);
+}
+
+static inline int bootutil_hmac_sha256_set_key(bootutil_hmac_sha256_context *ctx,
+                                               const uint8_t *key,
+                                               unsigned int key_size)
+{
+    int rc;
+
+    rc = mbedtls_md_setup(ctx, mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), 1);
+    if (rc != 0) {
+        return rc;
+    }
+    rc = mbedtls_md_hmac_starts(ctx, key, key_size);
+    return rc;
+}
+
+static inline int bootutil_hmac_sha256_update(bootutil_hmac_sha256_context *ctx,
+                                              const void *data,
+                                              unsigned int data_length)
+{
+    return mbedtls_md_hmac_update(ctx, data, data_length);
+}
+
+static inline int bootutil_hmac_sha256_finish(bootutil_hmac_sha256_context *ctx,
+                                              uint8_t *tag,
+                                              unsigned int taglen)
+{
+    /*
+     * Finalize the HMAC computation and output the tag.
+     * mbedtls_md_hmac_finish() always outputs the full 32-byte SHA-256 digest
+     * and does not support truncation. taglen is ignored; caller must provide
+     * a 32-byte buffer.
+     */
+    (void)taglen;
+    return mbedtls_md_hmac_finish(ctx, tag);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SIM_CUSTOM_HMAC_SHA256_H */

--- a/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_sha.h
+++ b/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_sha.h
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Infineon Technologies AG, or an affiliate of Infineon
+ * Technologies AG
+ *
+ * Simulator SHA-256 backend for MCUBOOT_USE_CUSTOM_CRYPTO.
+ * Implements the bootutil SHA abstraction using mbedTLS.
+ */
+
+#ifndef SIM_CUSTOM_SHA_H
+#define SIM_CUSTOM_SHA_H
+
+#include <stdint.h>
+#include <mbedtls/sha256.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef mbedtls_sha256_context bootutil_sha_context;
+
+static inline int bootutil_sha_init(bootutil_sha_context *ctx)
+{
+    mbedtls_sha256_init(ctx);
+    return mbedtls_sha256_starts(ctx, 0 /* is224=0 → SHA-256 */);
+}
+
+static inline int bootutil_sha_drop(bootutil_sha_context *ctx)
+{
+    mbedtls_sha256_free(ctx);
+    return 0;
+}
+
+static inline int bootutil_sha_update(bootutil_sha_context *ctx,
+                                      const void *data,
+                                      uint32_t data_len)
+{
+    return mbedtls_sha256_update(ctx, (const unsigned char *)data, data_len);
+}
+
+static inline int bootutil_sha_finish(bootutil_sha_context *ctx,
+                                      uint8_t *output)
+{
+    return mbedtls_sha256_finish(ctx, output);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SIM_CUSTOM_SHA_H */

--- a/sim/mcuboot-sys/csupport/mcuboot_config/mcuboot_config.h
+++ b/sim/mcuboot-sys/csupport/mcuboot_config/mcuboot_config.h
@@ -17,6 +17,15 @@
  * exist, or bootutil won't build.
  */
 
+/*
+ * When using custom crypto, include mcuboot_custom_crypto.h to provide
+ * bootutil_*_context types and inline implementations before bootutil/crypto
+ * headers are processed.
+ */
+#if defined(MCUBOOT_USE_CUSTOM_CRYPTO)
+#include "mcuboot_custom_crypto.h"
+#endif
+
 #define MCUBOOT_WATCHDOG_FEED()         \
     do {                                \
     } while (0)

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -254,7 +254,8 @@ int invoke_boot_go(struct sim_context *ctx, struct area_desc *adesc,
 #if defined(MCUBOOT_SIGN_RSA) || \
     (defined(MCUBOOT_SIGN_EC256) && defined(MCUBOOT_USE_MBED_TLS)) ||\
     (defined(MCUBOOT_ENCRYPT_EC256) && defined(MCUBOOT_USE_MBED_TLS)) ||\
-    (defined(MCUBOOT_ENCRYPT_X25519) && defined(MCUBOOT_USE_MBED_TLS))
+    (defined(MCUBOOT_ENCRYPT_X25519) && defined(MCUBOOT_USE_MBED_TLS)) ||\
+    defined(MCUBOOT_USE_CUSTOM_CRYPTO)
     mbedtls_platform_set_calloc_free(calloc, free);
 #endif
 
@@ -302,7 +303,8 @@ int invoke_boot_load_image_from_flash_to_sram(struct sim_context *ctx, struct ar
 #if defined(MCUBOOT_SIGN_RSA) || \
     (defined(MCUBOOT_SIGN_EC256) && defined(MCUBOOT_USE_MBED_TLS)) ||\
     (defined(MCUBOOT_ENCRYPT_EC256) && defined(MCUBOOT_USE_MBED_TLS)) ||\
-    (defined(MCUBOOT_ENCRYPT_X25519) && defined(MCUBOOT_USE_MBED_TLS))
+    (defined(MCUBOOT_ENCRYPT_X25519) && defined(MCUBOOT_USE_MBED_TLS)) ||\
+    defined(MCUBOOT_USE_CUSTOM_CRYPTO)
     mbedtls_platform_set_calloc_free(calloc, free);
 #endif
 


### PR DESCRIPTION
The `MCUBOOT_USE_CUSTOM_CRYPTO` option allows to implement a custom
backend that lets users plug in any crypto library, hardware
accelerator, proprietary SDK, or another software implementation
without modifying MCUboot's own source.