### PR TITLE
boot: zephyr: Add HW Image Swapping into boot flow

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1269,6 +1269,16 @@ config MCUBOOT_USE_TLV_ALLOW_LIST
 	  Disabling this option will cut down MCUboot size.
 	  The Kconfig controlls MCUboot configuration option MCUBOOT_USE_TLV_ALLOW_LIST.
 
+config BOOT_HW_IMAGE_SWAP
+	bool "Image swapping done by hardware"
+	depends on BOOT_DIRECT_XIP || BOOT_DIRECT_XIP_REVERT
+	help
+	  Image swapping will be done using hardware means which will result in zero flash wear compared
+	  to techniques like SWAP_MOVE or SWAP_SCRATCH that physically move data in flash.
+	  This requires support in hardware (e.g. address remapping, flash swapping...).
+	  This feature can only be used with MCUboot modes based on DIRECT_XIP.
+
+
 config BOOT_DECOMPRESSION_SUPPORT
 	bool
 	help

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -30,6 +30,10 @@
 #include <soc.h>
 #include <zephyr/linker/linker-defs.h>
 
+#if defined(CONFIG_BOOT_HW_IMAGE_SWAP)
+#include <zephyr/drivers/memc/hwimageswap.h>
+#endif
+
 #if defined(CONFIG_BOOT_DISABLE_CACHES)
 #include <zephyr/cache.h>
 #endif
@@ -674,6 +678,19 @@ int main(void)
     BOOT_LOG_INF("Image version: v%d.%d.%d", rsp.br_hdr->ih_ver.iv_major,
                                                     rsp.br_hdr->ih_ver.iv_minor,
                                                     rsp.br_hdr->ih_ver.iv_revision);
+
+#if defined(CONFIG_BOOT_HW_IMAGE_SWAP)
+    /* Configuration of HW image swapping based on offset of image selected for boot. */
+    uint32_t offset = 0;
+    rc = boot_hwimageswap_setup(rsp.br_image_off, &offset);
+    if (rc > 0) {
+        BOOT_LOG_INF("HW image swapping enabled with offset 0x%x", offset);
+        rsp.br_image_off += offset;
+    } else if (rc < 0) {
+        BOOT_LOG_ERR("Failed to setup HW image swapping");
+        FIH_PANIC;
+    }
+#endif
 
 #if defined(MCUBOOT_DIRECT_XIP)
     BOOT_LOG_INF("Jumping to the image slot");


### PR DESCRIPTION
This adds support for HW Image Swapping used with DIRECT_XIP modes. This enables zero-overhead image swapping that is done instantly and with no flash wear. This PR is for changes on MCUboot side.

After the image to be booted is selected it passes the image offset to the HW Image Swapping logic that controls the underlying HW swapping mechanism - this is implemented on the Zephyr side.

First NXP boards to use this are frdm_rw612 and rd_rw612_bga that use FlexSPI memory controller with address remapping feature. There is a number of other boards that can use this.

Zephyr side PR - https://github.com/zephyrproject-rtos/zephyr/pull/106683
