### PR TITLE
boot: bootutil: Add a hook for implement image's pre-copying action (encrypted XIP support)

### DIFF
--- a/boot/bootutil/include/bootutil/boot_hooks.h
+++ b/boot/bootutil/include/bootutil/boot_hooks.h
@@ -152,6 +152,28 @@ fih_ret boot_image_check_hook(int img_index, int slot);
 int boot_perform_update_hook(int img_index, struct image_header *img_head,
                              const struct flash_area *area);
 
+/** Hook for implement image's pre-copying action
+ *
+ * This hook is for implement action which might be done right before image is
+ * copied to the primary slot. This hook is called in MCUBOOT_OVERWRITE_ONLY
+ * mode only.
+ *
+ * @param img_index the index of the image pair
+ * @param primary_area the flash area of the primary image.
+ * @param secondary_area the flash area of the secondary image.
+ * @param size size of copied image.
+ *
+ * @retval 0: success, mcuboot will follow normal code execution flow after
+ *            execution of this call.
+ *         non-zero: an error, mcuboot will return from
+ *         boot_copy_image() with error.
+ *         Update will be undone so might be resume on the next boot.
+ */
+int boot_copy_region_pre_hook(int img_index,
+                              const struct flash_area *primary_area,
+                              const struct flash_area *secondary_area,
+                              size_t size);
+
 /** Hook for implement image's post copying action
  *
  * This hook is for implement action which might be done right after image was

--- a/boot/bootutil/include/bootutil/boot_hooks.h
+++ b/boot/bootutil/include/bootutil/boot_hooks.h
@@ -151,6 +151,24 @@ fih_ret boot_image_check_hook(int img_index, int slot);
  */
 int boot_perform_update_hook(int img_index, struct image_header *img_head,
                              const struct flash_area *area);
+/** Hook for implement image's pre-copying action
+ *
+ * This hook is for implement action which might be done right before image is
+ * copied to the primary slot. This hook is called in MCUBOOT_OVERWRITE_ONLY
+ * mode only.
+ *
+ * @param img_index the index of the image pair
+ * @param area the flash area of the primary image.
+ * @param size size of copied image.
+ *
+ * @retval 0: success, mcuboot will follow normal code execution flow after
+ *            execution of this call.
+ *         non-zero: an error, mcuboot will return from
+ *         boot_copy_image() with error.
+ *         Update will be undone so might be resume on the next boot.
+ */
+int boot_copy_region_pre_hook(int img_index, const struct flash_area *area, 
+                              size_t size);
 
 /** Hook for implement image's post copying action
  *

--- a/boot/bootutil/include/bootutil/boot_hooks.h
+++ b/boot/bootutil/include/bootutil/boot_hooks.h
@@ -164,6 +164,31 @@ fih_ret boot_image_check_hook(int img_index, int slot);
 int boot_perform_update_hook(int img_index, struct image_header *img_head,
                              const struct flash_area *area);
 
+/** Hook for implement image's pre-copying action
+ *
+ * This hook is for implement action which might be done right before image is
+ * copied to the primary slot. This hook is called in MCUBOOT_OVERWRITE_ONLY
+ * mode only.
+ *
+ * Typical uses include preparing a hardware encryption engine for encrypted
+ * XIP (e.g. initializing it based on the source image size).
+ *
+ * @param img_index the index of the image pair
+ * @param primary_area the flash area of the primary image.
+ * @param secondary_area the flash area of the secondary image.
+ * @param size size of copied image.
+ *
+ * @retval 0: success, mcuboot will follow normal code execution flow after
+ *            execution of this call.
+ *         non-zero: an error, mcuboot will return from
+ *         boot_copy_image() with error.
+ *         Update will be undone so might be resume on the next boot.
+ */
+int boot_copy_region_pre_hook(int img_index,
+                              const struct flash_area *primary_area,
+                              const struct flash_area *secondary_area,
+                              size_t size);
+
 /** Hook for implement image's post copying action
  *
  * This hook is for implement action which might be done right after image was

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -962,6 +962,11 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
     rc = boot_read_image_size(state, BOOT_SLOT_SECONDARY, &src_size);
     assert(rc == 0);
 #endif
+    rc = BOOT_HOOK_CALL(boot_copy_region_pre_hook, 0, BOOT_CURR_IMG(state),
+                        BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY), src_size);
+    if (rc != 0) {
+        return rc;
+    }
 
     image_index = BOOT_CURR_IMG(state);
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -948,6 +948,13 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
     rc = boot_read_image_size(state, BOOT_SLOT_SECONDARY, &src_size);
     assert(rc == 0);
 #endif
+    
+    rc = BOOT_HOOK_CALL(boot_copy_region_pre_hook, 0, BOOT_CURR_IMG(state),
+                        BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY),
+                        BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY), src_size);
+    if (rc != 0) {
+        return rc;
+    }
 
     image_index = BOOT_CURR_IMG(state);
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -946,11 +946,18 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
 
     (void)bs;
 
-#if defined(MCUBOOT_OVERWRITE_ONLY_FAST) || defined(MCUBOOT_SWAP_USING_MOVE) || defined(MCUBOOT_SWAP_USING_OFFSET)
+#if defined(MCUBOOT_OVERWRITE_ONLY_FAST) || defined(MCUBOOT_SWAP_USING_MOVE) || defined(MCUBOOT_SWAP_USING_OFFSET) || defined(MCUBOOT_IMAGE_ACCESS_HOOKS)
     uint32_t src_size = 0;
     rc = boot_read_image_size(state, BOOT_SLOT_SECONDARY, &src_size);
     assert(rc == 0);
 #endif
+
+    rc = BOOT_HOOK_CALL(boot_copy_region_pre_hook, 0, BOOT_CURR_IMG(state),
+                        BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY),
+                        BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY), src_size);
+    if (rc != 0) {
+        return rc;
+    }
 
     image_index = BOOT_CURR_IMG(state);
 


### PR DESCRIPTION
This PR adds a generic hook for implementing image pre-copying actions in boot_copy_image(). 

The placement of this hook is ideal for vendors with specific hardware encryption engines who would like to implement encrypted XIP and cannot use SWAP upgrade mode, making OVERWRITE_ONLY upgrade mode the only viable option. Some additional context is available here: https://github.com/mcu-tools/mcuboot/pull/2685#issuecomment-4200588824

Typically, before an image is written (re-encrypted) into the primary slot, the hardware encryption engine needs initialization based on the source image size. Another consideration is that some encryption engines implicitly consume more physical memory, so additional flash sectors must be pre-erased before the update.

This approach is successfully used in our NXP MCUboot fork. For more information see https://github.com/nxp-mcuxpresso/mcuxsdk-examples/blob/release/26.03.00/ota_examples/_doc/encrypted_xip_readme.md
