### PR TITLE
imgtool: fix sign command with no signing key

### DIFF
--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -502,8 +502,7 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
 
     enckey = load_key(encrypt) if encrypt else None
 
-
-    first_key = loaded_keys[0]
+    first_key = loaded_keys[0] if loaded_keys else None
     if enckey and key and ((isinstance(first_key, keys.ECDSA256P1) and
          not isinstance(enckey, keys.ECDSA256P1Public))
        or (isinstance(first_key, keys.ECDSA384P1) and


### PR DESCRIPTION
 ## Summary
Fix imgtool sign so it can create unsigned images when no signing key is provided.

  ## Problem
The command help says imgtool sign can create signed or unsigned images, but invoking it without --key fails before image creation starts.

The failure happens because loaded_keys is set to None when no key is provided, and the code unconditionally accesses the first entry to validate the encryption key type.

  ## Fix
  Guard access to the first signing key so the validation logic only inspects it when a signing key is actually present.