### PR TITLE
bootutil: zephyr: link to `mbedTLS` only when `CONFIG_MBEDTLS_BUILTIN`

### DIFF
--- a/boot/bootutil/zephyr/CMakeLists.txt
+++ b/boot/bootutil/zephyr/CMakeLists.txt
@@ -38,6 +38,6 @@ if(CONFIG_MCUBOOT_BOOTUTIL_LIB)
   endif()
 
   if(CONFIG_BOOT_USE_MBEDTLS OR CONFIG_BOOT_PSA_CRYPTO_BACKEND_MBEDTLS)
-    zephyr_link_libraries(mbedTLS)
+    zephyr_link_libraries_ifdef(CONFIG_MBEDTLS_BUILTIN mbedTLS)
   endif()
 endif()


### PR DESCRIPTION
The CMake library is created only when `CONFIG_MBEDTLS_BUILTIN` is `y`.