### PR TITLE
ci: python version coverage

### DIFF
--- a/.github/workflows/imgtool.yaml
+++ b/.github/workflows/imgtool.yaml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.x", "pypy3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.9", "pypy3.10", "pypy3.11"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pipenv'
@@ -35,7 +35,7 @@ jobs:
         pipenv run pip install pytest -e .
         pipenv run pytest --junitxml=../junit/pytest-results-${{ matrix.python-version }}.xml
     - name: Upload test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: pytest-results-${{ matrix.python-version }}
@@ -47,11 +47,11 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Cache pip
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip

--- a/scripts/imgtool/keys/general.py
+++ b/scripts/imgtool/keys/general.py
@@ -17,7 +17,7 @@ class FileHandler:
         self.kwargs = kwargs
 
     def __enter__(self):
-        if isinstance(self.file_in, str | bytes | os.PathLike):
+        if isinstance(self.file_in, (str, bytes, os.PathLike)):
             self.file = open(self.file_in, *self.args, **self.kwargs)
         else:
             self.file = self.file_in

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     license="Apache Software License",
     url="http://github.com/mcu-tools/mcuboot",
     packages=setuptools.find_packages(),
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     install_requires=[
         'cryptography>=40.0.0',
         'intelhex>=2.2.1',


### PR DESCRIPTION
Drop 3.6 and 3.7 support. Update CI with coverage for all supported versions, including those that are EOL (3.8, 3.9), and near EOL (3.10).

Wrote a script to test locally:

```
scripts/tests/local-matrix.sh
All requested versions already installed

========== Python 3.8 ==========
....................................................................................... [ 50%]
.....................................xxxx..x.................x........................x [100%]
167 passed, 7 xfailed in 6.73s
========== 3.8 OK ==========

========== Python 3.9 ==========
....................................................................................... [ 50%]
.....................................xxxx..x.................x........................x [100%]
167 passed, 7 xfailed in 5.86s
========== 3.9 OK ==========

========== Python 3.10 ==========
....................................................................................... [ 50%]
.....................................xxxx..x.................x........................x [100%]
167 passed, 7 xfailed in 6.69s
========== 3.10 OK ==========

========== Python 3.11 ==========
....................................................................................... [ 50%]
.....................................xxxx..x.................x........................x [100%]
167 passed, 7 xfailed in 5.88s
========== 3.11 OK ==========

========== Python 3.12 ==========
....................................................................................... [ 50%]
.....................................xxxx..x.................x........................x [100%]
167 passed, 7 xfailed in 6.45s
========== 3.12 OK ==========

========== Python 3.13 ==========
....................................................................................... [ 50%]
.....................................xxxx..x.................x........................x [100%]
167 passed, 7 xfailed in 6.14s
========== 3.13 OK ==========

========== Python 3.14 ==========
....................................................................................... [ 50%]
.....................................xxxx..x.................x........................x [100%]
167 passed, 7 xfailed in 6.59s
========== 3.14 OK ==========

========== Python pypy3.9 ==========
....................................................................................... [ 50%]
.....................................xxxx..x.................x........................x [100%]
167 passed, 7 xfailed in 13.73s
========== pypy3.9 OK ==========

========== Python pypy3.10 ==========
....................................................................................... [ 50%]
.....................................xxxx..x.................x........................x [100%]
167 passed, 7 xfailed in 14.63s
========== pypy3.10 OK ==========

========== Python pypy3.11 ==========
....................................................................................... [ 50%]
.....................................xxxx..x.................x........................x [100%]
167 passed, 7 xfailed in 9.37s
========== pypy3.11 OK ==========

All versions passed.
```