### PR TITLE
bootutil: add fallthrough to fix implicit fallthrough warning

### DIFF
--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -622,7 +622,7 @@ boot_set_next(const struct flash_area *fa, bool active, bool confirm)
         if (rc != 0) {
             break;
         }
-        /* Pass */
+        /* fallthrough */
 
     case BOOT_MAGIC_GOOD:
         if (confirm) {


### PR DESCRIPTION
Add  /* fallthrough */ annotation in the switch statement within boot_set_next() to explicitly mark the intended fallthrough from BOOT_MAGIC_UNSET to BOOT_MAGIC_GOOD, suppressing the compiler warning.