### PR TITLE
ci: mynewt: Add daily cron

### DIFF
--- a/.github/workflows/mynewt.yaml
+++ b/.github/workflows/mynewt.yaml
@@ -3,6 +3,8 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: 42 3 * * *
 
 name: Mynewt
 


### PR DESCRIPTION
Add daily build test to track Mynewt integration.

depends on https://github.com/mcu-tools/mcuboot/pull/2711