### PR TITLE
bootutil: mynewt: Fix boot_serial unit tests

### DIFF
--- a/boot/bootutil/pkg.yml
+++ b/boot/bootutil/pkg.yml
@@ -47,7 +47,7 @@ pkg.ign_files:
     - "ed25519_psa.c"       # Currently no PSA for mynewet
     - "encrypted_psa.c"
 
-pkg.source_files.!BOOT_LOADER:
+pkg.source_files.'!BOOT_LOADER && !SELFTEST':
     - "src/bootutil_public.c"
 
 pkg.deps.BOOTUTIL_USE_MBED_TLS:


### PR DESCRIPTION
When in unittest we shall include all sources.