### PR TITLE
sim: replace deprecated rand 0.9 APIs

### DIFF
--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1646,11 +1646,11 @@ impl Images {
 
         self.mark_permanent_upgrades(&mut flash, 1);
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut resets = vec![0i32; count];
         let mut remaining_ops = total_ops;
         for reset in &mut resets {
-            let reset_counter = rng.gen_range(1 ..= remaining_ops / 2);
+            let reset_counter = rng.random_range(1 ..= remaining_ops / 2);
             let mut counter = reset_counter;
             match c::boot_go(&mut flash, &self.areadesc, Some(&mut counter),
                              None, false) {


### PR DESCRIPTION
## Summary

- Replace `rand::thread_rng()` with `rand::rng()` and `Rng::gen_range` with `Rng::random_range` in `sim/src/image.rs` — both were renamed in rand 0.9 and now emit deprecation warnings after the recent dependabot bump from 0.8.5 to 0.9.3.
- No behavioral change; the new names are direct renames.

## Test plan

- [x] `cargo build` (in repo root) is warning-free apart from the pre-existing C-side `ranlib: ... has no symbols` notes.
- [x] CI passes the existing simulator matrix.
