### PR TITLE
ci: imgtool: drop PyPy 3.9 and 3.10 from the test matrix

### DIFF
--- a/.github/workflows/imgtool.yaml
+++ b/.github/workflows/imgtool.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.9", "pypy3.10", "pypy3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.11"]
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
cryptography 47.0.0 (released April 2026) bumps its PyO3 minimum supported PyPy version to 3.11. Pip-installing imgtool's deps on PyPy 3.9 or 3.10 now fails during the cryptography wheel build with

  error: the configured PyPy interpreter version (3.10) is lower
         than PyO3's minimum supported version (3.11)

so every PR run against this workflow fails on those two matrix entries. The matrix that landed in 95a6e388 ("imgtool: python version coverage") was green at the time because it ran against cryptography 46.x; the next push exposed the issue.

Drop pypy3.9 and pypy3.10 from the matrix, keep pypy3.11. CPython coverage is unchanged.

Assisted-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>