### PR TITLE
boot: zephyr: Add mcuboot,image-ram chosen node for RAM loading

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -711,17 +711,31 @@ config BOOT_SWAP_SAVE_ENCTLV
 
 endif # !SINGLE_APPLICATION_SLOT
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_SRAM := zephyr,sram
-
 if BOOT_RAM_LOAD || SINGLE_APPLICATION_SLOT_RAM_LOAD
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_SRAM := zephyr,sram
+DT_CHOSEN_MCUBOOT_IMAGE_RAM := mcuboot,image-ram
+
+config BOOT_MCUBOOT_LACKS_IMAGE_RAM_NODE
+	bool
+	default y if "$(dt_chosen_path,$(DT_CHOSEN_MCUBOOT_IMAGE_RAM))" = ""
+	select DEPRECATED
+	help
+	  If this option is selected, it means that your target does not have an
+	  ``mcuboot,image-ram`` chosen node which points to a RAM location for images to be
+	  loaded to.
+
 config BOOT_IMAGE_EXECUTABLE_RAM_START
-	hex "Boot image executable ram start"
+	hex "Boot image executable ram start" if BOOT_MCUBOOT_LACKS_IMAGE_RAM_NODE
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_MCUBOOT_IMAGE_RAM)) if \
+		!BOOT_MCUBOOT_LACKS_IMAGE_RAM_NODE
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_SRAM))
 
 config BOOT_IMAGE_EXECUTABLE_RAM_SIZE
-	int "Boot image executable base size"
+	int "Boot image executable base size" if BOOT_MCUBOOT_LACKS_IMAGE_RAM_NODE
+	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_MCUBOOT_IMAGE_RAM),0) if \
+		!BOOT_MCUBOOT_LACKS_IMAGE_RAM_NODE
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_SRAM),0)
 
 endif

--- a/boot/zephyr/boards/mimxrt1050_evk_mimxrt1052_hyperflash_ram_load.overlay
+++ b/boot/zephyr/boards/mimxrt1050_evk_mimxrt1052_hyperflash_ram_load.overlay
@@ -3,6 +3,7 @@
 		zephyr,bootloader-info = &boot_info0;
 		zephyr,code-partition = &boot_partition;
 		zephyr,sram = &mcuboot_sdram;
+		mcuboot,image-ram = &image_sdram;
 	};
 
 	soc {
@@ -44,5 +45,10 @@
 	mcuboot_sdram: memory@0 {
 		compatible = "mmio-sram";
 		reg = <0x0 DT_SIZE_K(30)>;
+	};
+
+	image_sdram: memory@8000 {
+		compatible = "mmio-sram";
+		reg = <0x8000 DT_SIZE_M(3)>;
 	};
 };

--- a/boot/zephyr/boards/mimxrt1050_evk_mimxrt1052_hyperflash_ram_load.overlay
+++ b/boot/zephyr/boards/mimxrt1050_evk_mimxrt1052_hyperflash_ram_load.overlay
@@ -1,35 +1,48 @@
 / {
-	sram@80007f00 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x80007f00 0x100>;
-		ranges = <0x0 0x80007f00 0x100>;
-		zephyr,memory-region = "RetainedMem";
-		status = "okay";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		retainedmem {
-			compatible = "zephyr,retained-ram";
-			status = "okay";
-			ranges;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			boot_info0: boot_info@0 {
-				compatible = "zephyr,retention";
-				status = "okay";
-				reg = <0x0 0x100>;
-			};
-		};
-	};
-
 	chosen {
 		zephyr,bootloader-info = &boot_info0;
 		zephyr,code-partition = &boot_partition;
+		zephyr,sram = &mcuboot_sdram;
+	};
+
+	soc {
+		memory@80007f00 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x80007f00 0x100>;
+			ranges = <0x0 0x80007f00 0x100>;
+			zephyr,memory-region = "RetainedMem";
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			retainedmem {
+				compatible = "zephyr,retained-ram";
+				status = "okay";
+				ranges;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				boot_info0: boot_info@0 {
+					compatible = "zephyr,retention";
+					status = "okay";
+					reg = <0x0 0x100>;
+				};
+			};
+		};
 	};
 };
 
 /* Reduce size of slot 0 to match slot 1 */
 &slot0_partition {
 	reg = <0x40000 0x300000>;
+};
+
+&sdram0 {
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	mcuboot_sdram: memory@0 {
+		compatible = "mmio-sram";
+		reg = <0x0 DT_SIZE_K(30)>;
+	};
 };

--- a/boot/zephyr/boards/nrf52840dk_nrf52840_ram_load.overlay
+++ b/boot/zephyr/boards/nrf52840dk_nrf52840_ram_load.overlay
@@ -3,33 +3,43 @@
 };
 
 / {
-	sram@2003fc00 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x2003fc00 DT_SIZE_K(1)>;
-		ranges = <0x0 0x2003fc00 DT_SIZE_K(1)>;
-		zephyr,memory-region = "RetainedMem";
-		status = "okay";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		retainedmem {
-			compatible = "zephyr,retained-ram";
-			status = "okay";
-			ranges;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			boot_info0: boot_info@0 {
-				compatible = "zephyr,retention";
-				status = "okay";
-				reg = <0x0 0x100>;
-			};
-		};
-	};
-
 	chosen {
 		/delete-property/ zephyr,boot-mode;
 		zephyr,bootloader-info = &boot_info0;
 		zephyr,code-partition = &boot_partition;
+		zephyr,sram = &mcuboot_sram;
+	};
+
+	soc {
+		memory@2003fc00 {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x2003fc00 DT_SIZE_K(1)>;
+			ranges = <0x0 0x2003fc00 DT_SIZE_K(1)>;
+			zephyr,memory-region = "RetainedMem";
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			retainedmem {
+				compatible = "zephyr,retained-ram";
+				status = "okay";
+				ranges;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				boot_info0: boot_info@0 {
+					compatible = "zephyr,retention";
+					status = "okay";
+					reg = <0x0 0x100>;
+				};
+			};
+		};
+	};
+};
+
+&sram0 {
+	mcuboot_sram: memory@0 {
+		compatible = "mmio-sram";
+		reg = <0x0 DT_SIZE_K(30)>;
 	};
 };

--- a/boot/zephyr/boards/nrf52840dk_nrf52840_ram_load.overlay
+++ b/boot/zephyr/boards/nrf52840dk_nrf52840_ram_load.overlay
@@ -8,6 +8,7 @@
 		zephyr,bootloader-info = &boot_info0;
 		zephyr,code-partition = &boot_partition;
 		zephyr,sram = &mcuboot_sram;
+		mcuboot,image-ram = &image_sram;
 	};
 
 	soc {
@@ -41,5 +42,10 @@
 	mcuboot_sram: memory@0 {
 		compatible = "mmio-sram";
 		reg = <0x0 DT_SIZE_K(30)>;
+	};
+
+	image_sram: memory@8000 {
+		compatible = "mmio-sram";
+		reg = <0x8000 DT_SIZE_K(192)>;
 	};
 };

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -283,8 +283,8 @@ static void do_boot(struct boot_rsp *rsp)
         /* jump to reset vector of an app */
         "   bx      r0\n"
         :
-        : "r" (vt->reset), "i" (CONFIG_SRAM_BASE_ADDRESS),
-          "i" (CONFIG_SRAM_SIZE * 1024), "i" (0)
+        : "r" (vt->reset), "i" (DT_CHOSEN_SRAM_ADDR),
+          "i" (DT_CHOSEN_SRAM_SIZE), "i" (0)
         : "r0", "r1", "r2", "r3", "memory"
     );
 #else

--- a/docs/release-notes.d/zephyr-ram-load.md
+++ b/docs/release-notes.d/zephyr-ram-load.md
@@ -1,0 +1,5 @@
+- Zephyr RAM load mode now uses a `mcuboot,image-ram` chosen
+  devicetree node to specify the RAM region to load the image
+  into.
+- Manually setting the `BOOT_IMAGE_EXECUTABLE_RAM_START` and
+  `BOOT_IMAGE_EXECUTABLE_RAM_SIZE` Kconfigs is now deprecated.

--- a/ext/nrf/cc310_glue.c
+++ b/ext/nrf/cc310_glue.c
@@ -43,7 +43,7 @@ void cc310_sha256_update(nrf_cc310_bl_hash_context_sha256_t *ctx,
      * if the data provided is not located in RAM.
      */
 
-    if ((uint32_t) data < CONFIG_SRAM_BASE_ADDRESS) {
+    if ((uint32_t) data < DT_CHOSEN_SRAM_ADDR) {
         uint8_t stack_buffer[data_len];
         uint32_t block_len = data_len;
         memcpy(stack_buffer, data, block_len);


### PR DESCRIPTION
    Adds a new chosen node which is used to specify the RAM area (in
    devicetree) where images should be loaded to, a deprecated warning
    is added if RAM load is used without this node

- [x] Doc update added