### PR TITLE
boot: use flash_area_flatten() for no-erase devices

### DIFF
--- a/boot/bootutil/src/bootutil_area.c
+++ b/boot/bootutil/src/bootutil_area.c
@@ -37,6 +37,24 @@
 
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
+#ifndef MIN
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+#ifndef MAX
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
+/* Maximum amount of bytes scrambled in a single flash_area_flatten() call
+ * by boot_scramble_region() on devices that do not require explicit erase.
+ * Bounds the latency of an individual driver call and gives the watchdog a
+ * chance to be fed between driver calls. The value can be overridden by
+ * the port via mcuboot_config.h to optimise for very small or very large
+ * RAM-like / auto-erase storage devices.
+ */
+#ifndef BOOT_SCRAMBLE_FLATTEN_CHUNK
+#define BOOT_SCRAMBLE_FLATTEN_CHUNK 4096
+#endif
+
 /**
  * Amount of space used to save information required when doing a swap,
  * or while a swap is under progress, but not the status of sector swap
@@ -309,51 +327,73 @@ boot_scramble_region(const struct flash_area *fa, uint32_t off, uint32_t size, b
         rc = -1;
         goto done;
     } else {
-        uint8_t buf[BOOT_MAX_ALIGN];
+#ifdef MCUBOOT_SUPPORT_DEV_WITHOUT_ERASE
+        /* Devices without explicit erase: prefer flash_area_flatten() which
+         * dispatches to the driver's erase callback (typically a single bulk
+         * fill operation) over the previous loop that issued one
+         * write-block-sized flash_area_write() per write block. The previous
+         * approach generated tens of thousands of driver API calls per slot
+         * for devices like nRF RRAM / MRAM, which is very slow.
+         *
+         * The region is split into chunks so that MCUBOOT_WATCHDOG_FEED() can
+         * still be invoked periodically during a long scramble, and to bound
+         * the latency contribution of any single driver call.
+         *
+         * Guarded by MCUBOOT_SUPPORT_DEV_WITHOUT_ERASE because only the
+         * Zephyr port currently exposes flash_area_flatten() in its
+         * flash_map_backend; other ports keep device_requires_erase() == true
+         * so this branch is never reached at runtime, but must still compile.
+         */
         const size_t write_block = flash_area_align(fa);
-        uint32_t end_offset;
+        const size_t chunk = MAX(write_block, (size_t)BOOT_SCRAMBLE_FLATTEN_CHUNK);
 
-        BOOT_LOG_DBG("boot_scramble_region: device without erase, overwriting");
-        memset(buf, flash_area_erased_val(fa), sizeof(buf));
+        BOOT_LOG_DBG("boot_scramble_region: device without erase, flattening "
+                     "in %u-byte chunks (backwards=%d)", (unsigned int)chunk,
+                     (int)backwards);
 
         if (backwards) {
-            end_offset = ALIGN_DOWN(off, write_block);
-            /* Starting at the last write block in range */
-            off += size - write_block;
+            uint32_t cur = off + size;
+            const uint32_t end = off;
+
+            while (cur > end) {
+                size_t step = MIN(chunk, (size_t)(cur - end));
+
+                cur -= step;
+                rc = flash_area_flatten(fa, cur, step);
+                if (rc != 0) {
+                    BOOT_LOG_DBG("boot_scramble_region: flatten error %d for "
+                                 "%p %" PRIu32 " %u",
+                                 rc, fa, cur, (unsigned int)step);
+                    break;
+                }
+                MCUBOOT_WATCHDOG_FEED();
+            }
         } else {
-            end_offset = ALIGN_DOWN((off + size), write_block);
-        }
-        BOOT_LOG_DBG("boot_scramble_region: start offset %" PRIu32 ", "
-                     "end offset %" PRIu32, off, end_offset);
+            uint32_t cur = off;
+            const uint32_t end = off + size;
 
-        while (off != end_offset) {
-            /* Write over the area to scramble data that is there */
-            rc = flash_area_write(fa, off, buf, write_block);
-            if (rc != 0) {
-                BOOT_LOG_DBG("boot_scramble_region: error %d for %p "
-                             "%" PRIu32 " %u",
-                             rc, fa, off, (unsigned int)write_block);
-                break;
-            }
+            while (cur < end) {
+                size_t step = MIN(chunk, (size_t)(end - cur));
 
-            MCUBOOT_WATCHDOG_FEED();
-
-            if (backwards) {
-                if (end_offset >= off) {
-                    /* Reached the first offset in range and already scrambled it */
+                rc = flash_area_flatten(fa, cur, step);
+                if (rc != 0) {
+                    BOOT_LOG_DBG("boot_scramble_region: flatten error %d for "
+                                 "%p %" PRIu32 " %u",
+                                 rc, fa, cur, (unsigned int)step);
                     break;
                 }
-
-                off -= write_block;
-            } else {
-                off += write_block;
-
-                if (end_offset <= off) {
-                    /* Reached the end offset in range and already scrambled it */
-                    break;
-                }
+                cur += step;
+                MCUBOOT_WATCHDOG_FEED();
             }
         }
+#else
+        /* Unreachable on ports without no-erase support (the
+         * device_requires_erase(fa) branch above always succeeds), but kept
+         * to preserve the original behaviour as a safety net.
+         */
+        (void)0;
+        rc = -1;
+#endif /* MCUBOOT_SUPPORT_DEV_WITHOUT_ERASE */
     }
 
 done:

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1322,6 +1322,23 @@ config MCUBOOT_STORAGE_WITH_ERASE
 	help
 	  Support for devices with erase
 
+config BOOT_SCRAMBLE_FLATTEN_CHUNK
+	int "Per-call chunk size for boot_scramble_region() on no-erase devices"
+	depends on MCUBOOT_STORAGE_WITHOUT_ERASE
+	default 4096
+	range 16 65536
+	help
+	  When scrambling a region on a device without explicit erase
+	  (e.g. RRAM, MRAM, FRAM), boot_scramble_region() splits the work
+	  into chunks of this many bytes and calls flash_area_flatten() per
+	  chunk, feeding the watchdog between calls.
+
+	  Larger values reduce per-call overhead (fewer driver API calls,
+	  better use of the underlying flash controller's write buffer)
+	  but make a single driver call run longer between watchdog feeds.
+	  The default of 4 KiB matches typical flash sector / RRAM page sizes
+	  and gives one watchdog feed per page.
+
 config MCUBOOT_STORAGE_MINIMAL_SCRAMBLE
 	bool "Do minimal required work to remove data [EXPERIMENTAL]"
 	select EXPERIMENTAL

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -393,6 +393,17 @@
 #endif
 
 /*
+ * Per-call chunk size used by boot_scramble_region() when scrambling
+ * regions on devices without explicit erase. Larger values minimise the
+ * number of driver API calls; smaller values give the watchdog more
+ * frequent feeding opportunities and bound the latency of any individual
+ * driver call.
+ */
+#ifdef CONFIG_BOOT_SCRAMBLE_FLATTEN_CHUNK
+#define BOOT_SCRAMBLE_FLATTEN_CHUNK CONFIG_BOOT_SCRAMBLE_FLATTEN_CHUNK
+#endif
+
+/*
  * Enabling this option uses newer flash map APIs. This saves RAM and
  * avoids deprecated API usage.
  *


### PR DESCRIPTION
For devices that report no explicit-erase capability, MCUboot currently scrambles the affected region by issuing a flash_area_write() of erase_value for every alignment-sized chunk. On RAM-like backings (RRAM/MRAM/FRAM/auto-erase NOR) this collapses to one tiny write per 4..16 byte chunk, each forcing the underlying driver to commit its hardware write buffer. Scrambling a 1 MiB slot during a downgrade prevention pass costs millions of buffer commits and seconds of wall time on nRF54L RRAM.