### PR TITLE
boot_record: fix potential infinite loop

### DIFF
--- a/boot/bootutil/src/boot_record.c
+++ b/boot/bootutil/src/boot_record.c
@@ -354,11 +354,10 @@ int boot_save_shared_data(const struct image_header *hdr, const struct flash_are
 #endif
 
 #if !defined(MCUBOOT_SINGLE_APPLICATION_SLOT) && defined(MCUBOOT_HW_ROLLBACK_PROT)
-    image = 0;
-    while (image < BOOT_IMAGE_NUMBER && !rc) {
+    for (image = 0; image < BOOT_IMAGE_NUMBER && !rc; image++) {
         FIH_CALL(boot_nv_security_counter_get, fih_rc, image, &security_cnt);
         if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
-            /* Some platforms support only a single security counter. */
+            /* Some platforms expose only one NV counter; skip other image indices. */
             continue;
         }
 
@@ -366,10 +365,6 @@ int boot_save_shared_data(const struct image_header *hdr, const struct flash_are
                                           BLINFO_SECURITY_COUNTER_IMAGE_0 + image,
                                           sizeof(security_cnt),
                                           (void *)&security_cnt);
-        if (!rc) {
-            break;
-        }
-        ++image;
     }
 #endif /* !defined(MCUBOOT_SINGLE_APPLICATION_SLOT) && defined(MCUBOOT_HW_ROLLBACK_PROT) */
 

--- a/docs/release-notes.d/boot-record-infinite-loop.md
+++ b/docs/release-notes.d/boot-record-infinite-loop.md
@@ -1,0 +1,5 @@
+- Fixed a possible infinite loop in ``boot_save_shared_data()`` (``boot_record.c``) when
+  ``MCUBOOT_DATA_SHARING_BOOTINFO`` and hardware rollback protection are enabled: iterating
+  boot-info security counters could spin forever if ``boot_nv_security_counter_get`` failed for
+  an image index (for example, backends that expose only one NV counter while
+  ``BOOT_IMAGE_NUMBER`` is greater than one).


### PR DESCRIPTION
Fixed potentail infinite loop on access to a security counter which is unavielable for given image index.