### PR TITLE
boot: zephyr: seed FIH delay RNG before first FIH macro

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -524,6 +524,13 @@ int main(void)
 #if defined(CONFIG_BOOT_USB_DFU_GPIO) || defined(CONFIG_BOOT_USB_DFU_WAIT)
     bool usb_dfu_requested = false;
 #endif
+
+    /* Init mbedTLS heap before any FIH macro: FIH_DECLARE calls
+     * fih_delay() under FIH_PROFILE_HIGH, which seeds CTR-DRBG.
+     */
+    os_heap_init();
+    (void)fih_delay_init();
+
     FIH_DECLARE(fih_rc, FIH_FAILURE);
 
     MCUBOOT_WATCHDOG_SETUP();
@@ -539,8 +546,6 @@ int main(void)
     /* LED init */
     io_led_init();
 #endif
-
-    os_heap_init();
 
     ZEPHYR_BOOT_LOG_START();
 


### PR DESCRIPTION
## Bug

Enabling `CONFIG_BOOT_FIH_PROFILE_HIGH=y` causes mcuboot to UsageFault during `main()` initialization on Zephyr — typically before the "Starting bootloader" log line, so the symptom looks like a silent watchdog reset loop.

## Root cause

`FIH_PROFILE_HIGH` selects `FIH_ENABLE_DELAY`, which makes every FIH macro call `fih_delay()` → `mbedtls_ctr_drbg_random()` against the global `fih_drbg_ctx`. That context lives in BSS (zero-initialized), so the first call dereferences a NULL `f_entropy` callback inside `mbedtls_ctr_drbg_reseed_internal` and faults.

`fih_delay_init()` exists to seed the DRBG, but no upstream port (zephyr, cypress, mynewt) calls it. The Zephyr port used to include the delay-RNG header (removed in 907476d7 for namespacing) without ever invoking the init.

The very first FIH macro is `FIH_DECLARE(fih_rc, FIH_FAILURE)` at the top of `main()`, so the fault hits immediately. Confirmed via GDB on nRF5340: stacked PC was a NULL deref out of `mbedtls_ctr_drbg_reseed_internal`, `fih_drbg_ctx` all zeros.

## Fix

Call `os_heap_init()` and `fih_delay_init()` at the top of `main()`, before `FIH_DECLARE`. `os_heap_init()` sets up the mbedTLS buffer allocator that CTR-DRBG seeding may use; it was previously called later in `main()`, just moved up. `fih_delay_init()` is a no-op (`always_inline` returning 1) when `FIH_ENABLE_DELAY` is unset, so the call costs nothing in profiles that do not enable random delays.

## Reproduction

Build any Zephyr-port mcuboot target with `CONFIG_BOOT_FIH_PROFILE_HIGH=y` and `MBEDTLS_CTR_DRBG_C=y` (the default delay RNG backend). On hardware the bootloader hangs in a fault loop.

## Test plan

- [x] Build Zephyr port with `BOOT_FIH_PROFILE_HIGH=y` on nRF5340 — no longer faults on first FIH macro
- [x] Verified end-to-end on hardware: boot reaches `boot_go`, fails magic check on empty slot0, drops into serial recovery via `BOOT_SERIAL_NO_APPLICATION`, blue LED solid, CDC-ACM enumerates
- [x] FIH_PROFILE_OFF and FIH_PROFILE_MEDIUM unchanged (delay disabled, init is no-op inline)