### PR TITLE
boot: zephyr: Add PSOC Edge case in flash_map_extended.c

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -46,6 +46,11 @@ BOOT_LOG_MODULE_DECLARE(mcuboot);
 #define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash_controller)
 #define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_PARENT(FLASH_DEVICE_NODE), 1)
 
+#elif (defined(CONFIG_SOC_SERIES_PSE84) && DT_HAS_CHOSEN(zephyr_flash_controller))
+#define FLASH_DEVICE_ID SOC_FLASH_0_ID
+#define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash_controller)
+#define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(FLASH_DEVICE_NODE, 1)
+
 #elif (!defined(CONFIG_XTENSA) && DT_HAS_CHOSEN(zephyr_flash_controller))
 #define FLASH_DEVICE_ID SOC_FLASH_0_ID
 #define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS


### PR DESCRIPTION
Add the correct selection for FLASH_DEVICE for the Infineon PSOC Edge family of devices.

For PSOC Edge devices, the MCUBoot gets placed in RRAM but the slots are placed in external flash. Therefore the flash node used to calculate the base address for the jump to slot needs to be based on the chosen_flash_controller node.