### PR TITLE
boot: zephyr: flash_map_extended: use PARTITION_* macros and remove SoC specific code

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -21,58 +21,97 @@
 
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
-#if defined(CONFIG_STM32_MEMMAP)
-/* MEMORY MAPPED for XiP on external NOR flash takes the sspi-nor or ospi-nor or qspi-nor device */
-#define FLASH_DEVICE_ID SPI_FLASH_0_ID
-#if DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_xspi_nor), okay)
-#define DT_DRV_COMPAT st_stm32_xspi_nor
-#define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_INST_PARENT(0), 1)
-#elif DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_ospi_nor), okay)
-#define DT_DRV_COMPAT st_stm32_ospi_nor
-#define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_INST_PARENT(0), 1)
-#elif DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_qspi_nor), okay)
-#define DT_DRV_COMPAT st_stm32_qspi_nor
-#define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_INST_PARENT(0), 1)
-#else
-#error "FLASH_DEVICE_NODE could not be determined"
-#endif
+#define FLASH_PARTITION_ADDRESS(partition) (PARTITION_ADDRESS(partition) - PARTITION_OFFSET(partition))
 
-#elif (DT_NODE_HAS_COMPAT(DT_PARENT(DT_CHOSEN(zephyr_flash_controller)),       \
-			  nxp_imx_flexspi))
-#define FLASH_DEVICE_ID SPI_FLASH_0_ID
-#define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash_controller)
-#define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_PARENT(FLASH_DEVICE_NODE), 1)
-
-#elif (!defined(CONFIG_XTENSA) && DT_HAS_CHOSEN(zephyr_flash_controller))
-#define FLASH_DEVICE_ID SOC_FLASH_0_ID
-#define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS
-
-#elif (defined(CONFIG_XTENSA) && DT_NODE_EXISTS(DT_INST(0, jedec_spi_nor)))
-#define FLASH_DEVICE_ID SPI_FLASH_0_ID
-#define FLASH_DEVICE_BASE 0
-
-#elif defined(CONFIG_SOC_FAMILY_ESPRESSIF_ESP32)
-
-#define FLASH_DEVICE_ID SPI_FLASH_0_ID
-#define FLASH_DEVICE_BASE 0
-
-#elif (defined(CONFIG_SOC_SERIES_NRF54H) && DT_HAS_CHOSEN(zephyr_flash))
-
-#define FLASH_DEVICE_ID SOC_FLASH_0_ID
-#define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS
-
-#else
-#error "FLASH_DEVICE_ID could not be determined"
-#endif
+#define FLASH_PARTITION_DEV_UNIQUE(n, m) (PARTITION_EXISTS(n) && \
+                                          !(DT_SAME_NODE(PARTITION_MTD(n), PARTITION_MTD(m))))
 
 int flash_device_base(uint8_t fd_id, uintptr_t *ret)
 {
-    if (fd_id != FLASH_DEVICE_ID) {
-        BOOT_LOG_ERR("invalid flash ID %d; expected %d",
-                     fd_id, FLASH_DEVICE_ID);
+    switch (fd_id)
+    {
+    case 0U:
+        *ret = FLASH_PARTITION_ADDRESS(slot0_partition);
+        break;
+#if FLASH_PARTITION_DEV_UNIQUE(slot1_partition, slot0_partition)
+    case 1U:
+        *ret = FLASH_PARTITION_ADDRESS(slot1_partition);
+        break;
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot2_partition, slot1_partition)
+    case 2U:
+        *ret = FLASH_PARTITION_ADDRESS(slot2_partition);
+        break;
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot3_partition, slot2_partition)
+    case 3U:
+        *ret = FLASH_PARTITION_ADDRESS(slot3_partition);
+        break;
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot4_partition, slot3_partition)
+    case 4U:
+        *ret = FLASH_PARTITION_ADDRESS(slot4_partition);
+        break;
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot5_partition, slot4_partition)
+    case 5U:
+        *ret = FLASH_PARTITION_ADDRESS(slot5_partition);
+        break;
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot6_partition, slot5_partition)
+    case 6U:
+        *ret = FLASH_PARTITION_ADDRESS(slot6_partition);
+        break;
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot7_partition, slot6_partition)
+    case 7U:
+        *ret = FLASH_PARTITION_ADDRESS(slot7_partition);
+        break;
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot8_partition, slot7_partition)
+    case 8U:
+        *ret = FLASH_PARTITION_ADDRESS(slot8_partition);
+        break;
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot9_partition, slot8_partition)
+    case 9U:
+        *ret = FLASH_PARTITION_ADDRESS(slot9_partition);
+        break;
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot10_partition, slot9_partition)
+    case 10U:
+        *ret = FLASH_PARTITION_ADDRESS(slot10_partition);
+        break;
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot11_partition, slot10_partition)
+    case 11U:
+        *ret = FLASH_PARTITION_ADDRESS(slot11_partition);
+        break;
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot12_partition, slot11_partition)
+    case 12U:
+        *ret = FLASH_PARTITION_ADDRESS(slot12_partition);
+        break;
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot13_partition, slot12_partition)
+    case 13U:
+        *ret = FLASH_PARTITION_ADDRESS(slot13_partition);
+        break;
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot14_partition, slot13_partition)
+    case 14U:
+        *ret = FLASH_PARTITION_ADDRESS(slot14_partition);
+        break;
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot15_partition, slot14_partition)
+    case 15U:
+        *ret = FLASH_PARTITION_ADDRESS(slot15_partition);
+        break;
+#endif
+    default:
+        BOOT_LOG_ERR("invalid flash ID %d", fd_id);
         return -EINVAL;
     }
-    *ret = FLASH_DEVICE_BASE;
     return 0;
 }
 
@@ -156,8 +195,90 @@ int flash_area_id_from_direct_image(int image_id)
 
 uint8_t flash_area_get_device_id(const struct flash_area *fa)
 {
-    (void)fa;
-    return FLASH_DEVICE_ID;
+    const struct device *dev = flash_area_get_device(fa);
+
+    if (dev == PARTITION_DEVICE(slot0_partition)) {
+        return 0U;
+    }
+#if FLASH_PARTITION_DEV_UNIQUE(slot1_partition, slot0_partition)
+    if (dev == PARTITION_DEVICE(slot1_partition)) {
+        return 1U;
+    }
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot2_partition, slot1_partition)
+    if (dev == PARTITION_DEVICE(slot2_partition)) {
+        return 2U;
+    }
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot3_partition, slot2_partition)
+    if (dev == PARTITION_DEVICE(slot3_partition)) {
+        return 3U;
+    }
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot4_partition, slot3_partition)
+    if (dev == PARTITION_DEVICE(slot4_partition)) {
+        return 4U;
+    }
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot5_partition, slot4_partition)
+    if (dev == PARTITION_DEVICE(slot5_partition)) {
+        return 5U;
+    }
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot6_partition, slot5_partition)
+    if (dev == PARTITION_DEVICE(slot6_partition)) {
+        return 6U;
+    }
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot7_partition, slot6_partition)
+    if (dev == PARTITION_DEVICE(slot7_partition)) {
+        return 7U;
+    }
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot8_partition, slot7_partition)
+    if (dev == PARTITION_DEVICE(slot8_partition)) {
+        return 8U;
+    }
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot9_partition, slot8_partition)
+    if (dev == PARTITION_DEVICE(slot9_partition)) {
+        return 9U;
+    }
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot10_partition, slot9_partition)
+    if (dev == PARTITION_DEVICE(slot10_partition)) {
+        return 10U;
+    }
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot11_partition, slot10_partition)
+    if (dev == PARTITION_DEVICE(slot11_partition)) {
+        return 11U;
+    }
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot12_partition, slot11_partition)
+    if (dev == PARTITION_DEVICE(slot12_partition)) {
+        return 12U;
+    }
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot13_partition, slot12_partition)
+    if (dev == PARTITION_DEVICE(slot13_partition)) {
+        return 13U;
+    }
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot14_partition, slot13_partition)
+    if (dev == PARTITION_DEVICE(slot14_partition)) {
+        return 14U;
+    }
+#endif
+#if FLASH_PARTITION_DEV_UNIQUE(slot15_partition, slot14_partition)
+    if (dev == PARTITION_DEVICE(slot15_partition)) {
+        return 15U;
+    }
+#endif
+
+    __ASSERT(0, "invalid flash area device");
+
+    return 0U;
 }
 
 #define ERASED_VAL 0xff

--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -26,15 +26,12 @@ BOOT_LOG_MODULE_DECLARE(mcuboot);
 #define FLASH_DEVICE_ID SPI_FLASH_0_ID
 #if DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_xspi_nor), okay)
 #define DT_DRV_COMPAT st_stm32_xspi_nor
-#define FLASH_DEVICE_NODE DT_INST(0, st_stm32_xspi_nor)
 #define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_INST_PARENT(0), 1)
 #elif DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_ospi_nor), okay)
 #define DT_DRV_COMPAT st_stm32_ospi_nor
-#define FLASH_DEVICE_NODE DT_INST(0, st_stm32_ospi_nor)
 #define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_INST_PARENT(0), 1)
 #elif DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_qspi_nor), okay)
 #define DT_DRV_COMPAT st_stm32_qspi_nor
-#define FLASH_DEVICE_NODE DT_INST(0, st_stm32_qspi_nor)
 #define FLASH_DEVICE_BASE DT_REG_ADDR_BY_IDX(DT_INST_PARENT(0), 1)
 #else
 #error "FLASH_DEVICE_NODE could not be determined"
@@ -49,30 +46,24 @@ BOOT_LOG_MODULE_DECLARE(mcuboot);
 #elif (!defined(CONFIG_XTENSA) && DT_HAS_CHOSEN(zephyr_flash_controller))
 #define FLASH_DEVICE_ID SOC_FLASH_0_ID
 #define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS
-#define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash_controller)
 
 #elif (defined(CONFIG_XTENSA) && DT_NODE_EXISTS(DT_INST(0, jedec_spi_nor)))
 #define FLASH_DEVICE_ID SPI_FLASH_0_ID
 #define FLASH_DEVICE_BASE 0
-#define FLASH_DEVICE_NODE DT_INST(0, jedec_spi_nor)
 
 #elif defined(CONFIG_SOC_FAMILY_ESPRESSIF_ESP32)
 
 #define FLASH_DEVICE_ID SPI_FLASH_0_ID
 #define FLASH_DEVICE_BASE 0
-#define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash_controller)
 
 #elif (defined(CONFIG_SOC_SERIES_NRF54H) && DT_HAS_CHOSEN(zephyr_flash))
 
 #define FLASH_DEVICE_ID SOC_FLASH_0_ID
 #define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS
-#define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash)
 
 #else
 #error "FLASH_DEVICE_ID could not be determined"
 #endif
-
-static const struct device *flash_dev = DEVICE_DT_GET(FLASH_DEVICE_NODE);
 
 int flash_device_base(uint8_t fd_id, uintptr_t *ret)
 {
@@ -162,22 +153,6 @@ int flash_area_id_from_direct_image(int image_id)
     return -EINVAL;
 }
 #endif
-
-int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
-{
-    int rc;
-    struct flash_pages_info page;
-
-    rc = flash_get_page_info_by_offs(flash_dev, off, &page);
-    if (rc) {
-        return rc;
-    }
-
-    sector->fs_off = page.start_offset;
-    sector->fs_size = page.size;
-
-    return rc;
-}
 
 uint8_t flash_area_get_device_id(const struct flash_area *fa)
 {

--- a/boot/zephyr/include/flash_map_backend/flash_map_backend.h
+++ b/boot/zephyr/include/flash_map_backend/flash_map_backend.h
@@ -57,12 +57,6 @@ int flash_area_id_from_multi_image_slot(int image_index, int slot);
  */
 int flash_area_id_to_multi_image_slot(int image_index, int area_id);
 
-/* Retrieve the flash sector a given offset belongs to.
- *
- * Returns 0 on success, or an error code on failure.
- */
-int flash_area_sector_from_off(off_t off, struct flash_sector *sector);
-
 static inline uint32_t flash_area_get_off(const struct flash_area *fa)
 {
 	return (uint32_t)fa->fa_off;

--- a/boot/zephyr/include/sysflash/sysflash.h
+++ b/boot/zephyr/include/sysflash/sysflash.h
@@ -13,14 +13,6 @@
 #include <zephyr/devicetree/partitions.h>
 #include <zephyr/sys/util_macro.h>
 
-#ifndef SOC_FLASH_0_ID
-#define SOC_FLASH_0_ID 0
-#endif
-
-#ifndef SPI_FLASH_0_ID
-#define SPI_FLASH_0_ID 1
-#endif
-
 #if !defined(CONFIG_SINGLE_APPLICATION_SLOT) && !defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_SINGLE_APP)
 
 /* Each pair of slots is separated by , and there is no terminating character */

--- a/boot/zephyr/include/target.h
+++ b/boot/zephyr/include/target.h
@@ -31,12 +31,7 @@
 /*
  * Sanity check the target support.
  */
-#if (!defined(CONFIG_XTENSA) && !defined(CONFIG_SOC_SERIES_NRF54H) && \
-    !DT_HAS_CHOSEN(zephyr_flash_controller)) || \
-    (defined(CONFIG_XTENSA) && !DT_NODE_EXISTS(DT_INST(0, jedec_spi_nor)) && \
-    !defined(CONFIG_SOC_FAMILY_ESPRESSIF_ESP32)) || \
-    (defined(CONFIG_SOC_SERIES_NRF54H) && !DT_HAS_CHOSEN(zephyr_flash)) || \
-    !defined(FLASH_ALIGN) ||                  \
+#if !defined(FLASH_ALIGN) || \
     !(PARTITION_EXISTS(slot0_partition)) || \
     !(PARTITION_EXISTS(slot1_partition) || CONFIG_SINGLE_APPLICATION_SLOT) || \
     (defined(CONFIG_BOOT_SWAP_USING_SCRATCH) && !PARTITION_EXISTS(scratch_partition))


### PR DESCRIPTION
use PARTITION_* macros and implement getting
the device id and the flash base based on
PARTITION_* macros. With this we no longer
need to have SoC specific code here.

Also removes `flash_area_sector_from_off()` as it is no longer needed.