### PR TITLE
boot: boot_serial: Fix mynewt build without encryption

### DIFF
--- a/boot/boot_serial/src/boot_serial_encryption.c
+++ b/boot/boot_serial/src/boot_serial_encryption.c
@@ -5,16 +5,16 @@
  * Copyright (c) 2020 Arm Limited
  */
 
+#include "mcuboot_config/mcuboot_config.h"
+
+#ifdef MCUBOOT_ENC_IMAGES
+
 #include <assert.h>
 #include "bootutil/image.h"
 #include <../src/bootutil_priv.h>
 #include "bootutil/bootutil_log.h"
 #include "bootutil/bootutil_public.h"
 #include "bootutil/fault_injection_hardening.h"
-
-#include "mcuboot_config/mcuboot_config.h"
-
-#ifdef MCUBOOT_ENC_IMAGES
 
 BOOT_LOG_MODULE_DECLARE(serial_encryption);
 


### PR DESCRIPTION
boot_serial_encryption.c can exclude all code when MCUBOOT_ENC_IMAGES is not defined.

However it first includes several headers that fail to build in mynewt where MCUBOOT_ENC_IMAGES is always undefined (so far).

This change includes configuration first and if
MCUBOOT_ENC_IMAGES is not defined it also skips
unnecessary includesion of headers and not only
actual code for encrypted images over serial.

Error that was detected:
```
repos/mcuboot/boot/bootutil/include/bootutil/crypto/aes_ctr.h: In function 'bootutil_aes_ctr_encrypt': repos/mcuboot/boot/bootutil/include/bootutil/crypto/aes_ctr.h:100:12: error: implicit declaration of function 'mbedtls_aes_crypt_ctr'; did you mean 'mbedtls_aes_crypt_ecb'? [-Wimplicit-function-declaration]
  100 |     return mbedtls_aes_crypt_ctr(ctx, mlen, &blk_off, counter, stream_block, m, c);
      |            ^~~~~~~~~~~~~~~~~~~~~
      |            mbedtls_aes_crypt_ecb
```