### PR TITLE
bootutil: Use mbedtls/private paths for TF-PSA-Crypto

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/common.h
+++ b/boot/bootutil/include/bootutil/crypto/common.h
@@ -7,6 +7,21 @@
 #ifndef __BOOTUTIL_CRYPTO_COMMON_H__
 #define __BOOTUTIL_CRYPTO_COMMON_H__
 
+/*
+ * TF-PSA-Crypto keeps several legacy crypto declarations under the
+ * mbedtls private include tree (e.g. mbedtls/private/sha256.h).
+ * Classic Mbed TLS exposes the same APIs under mbedtls/sha256.h.
+ * Unless the build forces MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR to 0 or 1,
+ * detect at preprocess time whether the private sha256 header exists.
+ */
+#if !defined(MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR)
+#if defined(__has_include) && __has_include(<mbedtls/private/sha256.h>)
+#define MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR 1
+#else
+#define MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR 0
+#endif
+#endif
+
 /* The check below can be performed even for those cases
  * where MCUBOOT_USE_MBED_TLS has not been defined
  */

--- a/boot/bootutil/include/bootutil/crypto/ecdh_p256.h
+++ b/boot/bootutil/include/bootutil/crypto/ecdh_p256.h
@@ -19,9 +19,13 @@
 #endif
 
 #if defined(MCUBOOT_USE_MBED_TLS)
-    #include <mbedtls/ecp.h>
-    #include <mbedtls/ecdh.h>
-    #define EC256_PUBK_LEN (65)
+#include "bootutil/crypto/common.h"
+#if MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR
+#include <mbedtls/private/ecp.h>
+#else
+#include <mbedtls/ecp.h>
+#endif
+#define EC256_PUBK_LEN (65)
 #endif /* MCUBOOT_USE_MBED_TLS */
 
 #if defined(MCUBOOT_USE_TINYCRYPT)
@@ -75,6 +79,35 @@ static inline int bootutil_ecdh_p256_shared_secret(bootutil_ecdh_p256_context *c
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000
 static int fake_rng(void *p_rng, unsigned char *output, size_t len);
 #endif
+
+static inline int bootutil_ecdh_compute_shared(mbedtls_ecp_group *grp, mbedtls_mpi *z,
+                                               const mbedtls_ecp_point *Q,
+                                               const mbedtls_mpi *d,
+                                               int (*f_rng)(void *, unsigned char *, size_t),
+                                               void *p_rng)
+{
+    int ret;
+    mbedtls_ecp_point P;
+
+    mbedtls_ecp_point_init(&P);
+
+    ret = mbedtls_ecp_mul(grp, &P, d, Q, f_rng, p_rng);
+    if (ret != 0) {
+        goto cleanup;
+    }
+
+    if (mbedtls_ecp_is_zero(&P) != 0) {
+        ret = MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
+        goto cleanup;
+    }
+
+    ret = mbedtls_mpi_copy(z, &P.MBEDTLS_CONTEXT_MEMBER(X));
+
+cleanup:
+    mbedtls_ecp_point_free(&P);
+
+    return ret;
+}
 
 typedef struct bootutil_ecdh_p256_context {
     mbedtls_ecp_group grp;
@@ -130,19 +163,11 @@ static inline int bootutil_ecdh_p256_shared_secret(bootutil_ecdh_p256_context *c
     mbedtls_mpi_read_binary(&ctx->d, sk, NUM_ECC_BYTES);
 
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000
-    rc = mbedtls_ecdh_compute_shared(&ctx->grp,
-                                     &ctx->z,
-                                     &ctx->P,
-                                     &ctx->d,
-                                     fake_rng,
-                                     NULL);
+    rc = bootutil_ecdh_compute_shared(&ctx->grp, &ctx->z, &ctx->P, &ctx->d,
+                                      fake_rng, NULL);
 #else
-    rc = mbedtls_ecdh_compute_shared(&ctx->grp,
-                                     &ctx->z,
-                                     &ctx->P,
-                                     &ctx->d,
-                                     NULL,
-                                     NULL);
+    rc = bootutil_ecdh_compute_shared(&ctx->grp, &ctx->z, &ctx->P, &ctx->d,
+                                      NULL, NULL);
 #endif
     mbedtls_mpi_write_binary(&ctx->z, z, NUM_ECC_BYTES);
 

--- a/boot/bootutil/include/bootutil/crypto/ecdsa.h
+++ b/boot/bootutil/include/bootutil/crypto/ecdsa.h
@@ -58,10 +58,15 @@
     #include <psa/crypto.h>
     #include <string.h>
 #elif defined(MCUBOOT_USE_MBED_TLS)
-    #include <mbedtls/ecdsa.h>
-    /* Indicate to the caller that the verify function needs the raw ASN.1
-     * signature, not a decoded one. */
-    #define MCUBOOT_ECDSA_NEED_ASN1_SIG
+#include "bootutil/crypto/common.h"
+#if MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR
+#include <mbedtls/private/ecdsa.h>
+#else
+#include <mbedtls/ecdsa.h>
+#endif
+/* Indicate to the caller that the verify function needs the raw ASN.1
+ * signature, not a decoded one. */
+#define MCUBOOT_ECDSA_NEED_ASN1_SIG
 #endif /* MCUBOOT_USE_MBED_TLS */
 
 /*TODO: remove this after cypress port mbedtls to abstract crypto api */

--- a/boot/bootutil/include/bootutil/crypto/hmac_sha256.h
+++ b/boot/bootutil/include/bootutil/crypto/hmac_sha256.h
@@ -19,10 +19,15 @@
 #endif
 
 #if defined(MCUBOOT_USE_MBED_TLS)
-    #include <stdint.h>
-    #include <stddef.h>
-    #include <mbedtls/cmac.h>
-    #include <mbedtls/md.h>
+#include <stdint.h>
+#include <stddef.h>
+#include "bootutil/crypto/common.h"
+#if MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR
+#include <mbedtls/private/cmac.h>
+#else
+#include <mbedtls/cmac.h>
+#endif
+#include <mbedtls/md.h>
 #endif /* MCUBOOT_USE_MBED_TLS */
 
 #if defined(MCUBOOT_USE_TINYCRYPT)

--- a/boot/bootutil/include/bootutil/crypto/rsa.h
+++ b/boot/bootutil/include/bootutil/crypto/rsa.h
@@ -43,8 +43,12 @@
 
 #elif defined(MCUBOOT_USE_MBED_TLS)
 
-#include "mbedtls/rsa.h"
-#include "mbedtls/version.h"
+#include "bootutil/crypto/common.h"
+#if MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR
+#include "mbedtls/private/rsa.h"
+#else
+#include <mbedtls/rsa.h>
+#endif
 #if defined(BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED)
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000
 #include "rsa_alt_helpers.h"
@@ -53,7 +57,6 @@
 #endif
 #endif /* BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED */
 #include "mbedtls/asn1.h"
-#include "bootutil/crypto/common.h"
 
 #endif /* MCUBOOT_USE_MBED_TLS */
 

--- a/boot/bootutil/include/bootutil/crypto/sha.h
+++ b/boot/bootutil/include/bootutil/crypto/sha.h
@@ -62,10 +62,20 @@
 
 #elif defined(MCUBOOT_USE_MBED_TLS)
 
+#include "bootutil/crypto/common.h"
+
+#if MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR
+#ifdef MCUBOOT_SHA512
+#include <mbedtls/private/sha512.h>
+#else
+#include <mbedtls/private/sha256.h>
+#endif
+#else
 #ifdef MCUBOOT_SHA512
 #include <mbedtls/sha512.h>
 #else
 #include <mbedtls/sha256.h>
+#endif
 #endif
 
 #include <mbedtls/version.h>

--- a/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_ecdh_p256.h
+++ b/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_ecdh_p256.h
@@ -15,10 +15,15 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include "bootutil/crypto/common.h"
 #include <mbedtls/build_info.h>
+#if MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR
+#include <mbedtls/private/ecp.h>
+#include <mbedtls/private/bignum.h>
+#else
 #include <mbedtls/ecp.h>
-#include <mbedtls/ecdh.h>
 #include <mbedtls/bignum.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,6 +47,35 @@ static inline int sim_fake_rng(void *p_rng, unsigned char *output, size_t len)
     return 0;
 }
 #endif /* MBEDTLS_VERSION_NUMBER >= 0x03000000 */
+
+static inline int sim_ecdh_compute_shared(mbedtls_ecp_group *grp, mbedtls_mpi *z,
+                                          const mbedtls_ecp_point *Q,
+                                          const mbedtls_mpi *d,
+                                          int (*f_rng)(void *, unsigned char *, size_t),
+                                          void *p_rng)
+{
+    int ret;
+    mbedtls_ecp_point P;
+
+    mbedtls_ecp_point_init(&P);
+
+    ret = mbedtls_ecp_mul(grp, &P, d, Q, f_rng, p_rng);
+    if (ret != 0) {
+        goto cleanup;
+    }
+
+    if (mbedtls_ecp_is_zero(&P) != 0) {
+        ret = MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
+        goto cleanup;
+    }
+
+    ret = mbedtls_mpi_copy(z, &P.MBEDTLS_CONTEXT_MEMBER(X));
+
+cleanup:
+    mbedtls_ecp_point_free(&P);
+
+    return ret;
+}
 
 typedef struct { int _unused; } bootutil_ecdh_p256_context;
 typedef bootutil_ecdh_p256_context bootutil_key_exchange_ctx;
@@ -79,9 +113,13 @@ static inline int bootutil_ecdh_p256_shared_secret(
     if (mbedtls_ecp_check_pubkey(&grp, &peer) != 0) { goto out; }
     if (mbedtls_mpi_read_binary(&d, sk, SIM_ECP256_PRIVKEY_BYTES) != 0) { goto out; }
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000
-    if (mbedtls_ecdh_compute_shared(&grp, &shared, &peer, &d, sim_fake_rng, NULL) != 0) { goto out; }
+    if (sim_ecdh_compute_shared(&grp, &shared, &peer, &d, sim_fake_rng, NULL) != 0) {
+        goto out;
+    }
 #else
-    if (mbedtls_ecdh_compute_shared(&grp, &shared, &peer, &d, NULL, NULL) != 0) { goto out; }
+    if (sim_ecdh_compute_shared(&grp, &shared, &peer, &d, NULL, NULL) != 0) {
+        goto out;
+    }
 #endif
     if (mbedtls_mpi_write_binary(&shared, z, SIM_ECP256_SHARED_BYTES) != 0) { goto out; }
     rc = 0;

--- a/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_ecdsa.h
+++ b/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_ecdsa.h
@@ -18,7 +18,12 @@
 #include <stddef.h>
 #include <string.h>
 
+#include "bootutil/crypto/common.h"
+#if MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR
+#include <mbedtls/private/ecdsa.h>
+#else
 #include <mbedtls/ecdsa.h>
+#endif
 #include <mbedtls/asn1.h>
 #include <mbedtls/oid.h>
 

--- a/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_sha.h
+++ b/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_sha.h
@@ -12,7 +12,12 @@
 #define SIM_CUSTOM_SHA_H
 
 #include <stdint.h>
+#include "bootutil/crypto/common.h"
+#if MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR
+#include <mbedtls/private/sha256.h>
+#else
 #include <mbedtls/sha256.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -15,7 +15,12 @@
 #include "bootsim.h"
 
 #ifdef MCUBOOT_ENCRYPT_RSA
+#include "bootutil/crypto/common.h"
+#if MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR
+#include "mbedtls/private/rsa.h"
+#else
 #include "mbedtls/rsa.h"
+#endif
 #include "mbedtls/asn1.h"
 #endif
 
@@ -25,7 +30,6 @@
 
 #define BOOT_LOG_LEVEL BOOT_LOG_LEVEL_ERROR
 #include <bootutil/bootutil_log.h>
-#include "bootutil/crypto/common.h"
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 


### PR DESCRIPTION
MCUboot Mbed TLS crypto wrappers and simulator custom crypto helpers included legacy headers as mbedtls/<alg>.h. TF-PSA-Crypto now exposes these declarations only under mbedtls/private/.


Assisted-by: Cursor: Auto