### PR TITLE
boot: bootutil: bounds-check TLV length in tlv iterator

### DIFF
--- a/boot/bootutil/src/tlv.c
+++ b/boot/bootutil/src/tlv.c
@@ -119,8 +119,53 @@ bootutil_tlv_iter_next(struct image_tlv_iter *it, uint32_t *off, uint16_t *len,
                  it->type, IMAGE_TLV_ANY, it->tlv_off, it->tlv_end);
 
     while (it->tlv_off < it->tlv_end) {
+        /*
+         * No more TLVs in the protected area. This is checked before
+         * loading or validating any entry so that a malformed TLV in
+         * the unprotected area cannot turn a protected-only search into
+         * an error instead of a clean "not found".
+         */
+        if (it->prot && it->tlv_off >= it->prot_end) {
+            BOOT_LOG_DBG("bootutil_tlv_iter_next: protected TLV %d not found", it->type);
+            return 1;
+        }
+
         if (it->hdr->ih_protect_tlv_size > 0 && it->tlv_off == it->prot_end) {
             it->tlv_off += sizeof(struct image_tlv_info);
+            /*
+             * Re-evaluate the loop condition: if the unprotected area
+             * holds no TLV entries (it_tlv_tot is just the info header)
+             * the skip lands on tlv_end and iteration is simply done,
+             * which must read as "not found" rather than a bounds error.
+             */
+            continue;
+        }
+
+        /*
+         * Validate against the end of the section actually being
+         * iterated: the protected area when iterating protected TLVs,
+         * the whole TLV area otherwise. This keeps a protected TLV
+         * whose payload spills past prot_end from being handed to a
+         * protected-only caller as if it were protected data.
+         */
+        uint32_t end = it->prot ? it->prot_end : it->tlv_end;
+
+        /*
+         * Ensure the TLV header fits before loading it, so the load
+         * cannot read past the section. tlv.it_len then comes straight
+         * from flash and is attacker-controlled in a crafted image;
+         * without the final check a bogus length advances it->tlv_off
+         * past the section end and yields an out-of-section (off, len)
+         * pair to the caller. The first clause defensively guards the
+         * unsigned subtraction in the others, so the uint32_t arithmetic
+         * can neither overflow nor wrap.
+         */
+        if (it->tlv_off > end ||
+            (uint32_t)sizeof(tlv) > end - it->tlv_off) {
+            BOOT_LOG_DBG("bootutil_tlv_iter_next: TLV header at %" PRIu32
+                         " overruns section end %" PRIu32,
+                         it->tlv_off, end);
+            return -1;
         }
 
         rc = LOAD_IMAGE_DATA(it->hdr, it->fap, it->tlv_off, &tlv, sizeof tlv);
@@ -131,10 +176,11 @@ bootutil_tlv_iter_next(struct image_tlv_iter *it, uint32_t *off, uint16_t *len,
             return -1;
         }
 
-        /* No more TLVs in the protected area */
-        if (it->prot && it->tlv_off >= it->prot_end) {
-            BOOT_LOG_DBG("bootutil_tlv_iter_next: protected TLV %d not found", it->type);
-            return 1;
+        if (tlv.it_len > end - it->tlv_off - (uint32_t)sizeof(tlv)) {
+            BOOT_LOG_DBG("bootutil_tlv_iter_next: malformed TLV at %" PRIu32
+                         " overruns section end %" PRIu32,
+                         it->tlv_off, end);
+            return -1;
         }
 
         if (it->type == IMAGE_TLV_ANY || tlv.it_type == it->type) {


### PR DESCRIPTION
## Summary

Adds a bounds check to `bootutil_tlv_iter_next()` so that a TLV header and its payload are verified to lie fully within the TLV section before the iterator advances or hands an `(off, len)` pair to the caller.

`tlv.it_len` is a `uint16_t` read straight from flash and is attacker-controlled in a crafted image. Without this check, a bogus length advances `it->tlv_off` past the section end and yields an out-of-section `(off, len)` pair.

## Severity / framing

This is a **defense-in-depth / robustness fix, not a critical vulnerability**:

- Every current consumer in `image_validate.c` already validates `len` against a small fixed buffer before reading (hash, key, signature, security counter, UUID), so a bogus `it_len` does not currently cause a large out-of-bounds read or a buffer overflow.
- An overshooting iterator previously just terminated the `while (it->tlv_off < it->tlv_end)` loop early; for whole-area searches, malformed TLVs cause validation to **fail closed**, not to be bypassed.

The value of the fix is that it makes the iterator self-contained and correct instead of relying on every current and future caller to sanity-check `len`.

## The check

Each entry is validated against the end of the section actually being iterated: the protected area (`prot_end`) when iterating protected TLVs, the whole TLV area (`tlv_end`) otherwise. This keeps a protected TLV whose payload spills past `prot_end` from being handed to a protected-only caller (security-counter, dependency validation) as if it were protected data.

The header-size check runs *before* the entry is loaded, so the load itself cannot read past the section. This matters for the RAM-load build, where `LOAD_IMAGE_DATA` is a bare `memcpy`. The first comparison guards the subtraction in the others (`tlv_off` can overshoot the end after the unprotected info-header skip), so the `uint32_t` arithmetic can neither overflow nor wrap.

The protected-boundary "not found" check is now performed *before* any entry in the unprotected area is loaded or validated, so a protected-only search stops cleanly at the protected boundary regardless of what follows it.

## Behavioural change

- For whole-area iteration, malformed TLV lengths now produce an explicit iteration error (`-1`) instead of silently truncating iteration.
- For protected-only iteration, a malformed TLV in the *unprotected* area now yields a clean "not found" (`1`) at the protected boundary rather than an error — the protected boundary is checked before any unprotected entry is touched.
- For any well-formed image the check is a no-op.

## Testing

Existing sim suite passes unchanged with `sig-ecdsa`, `sig-ecdsa,swap-offset`, and `sig-ed25519` (25 tests each; `sig-ed25519` and the dependency/security-counter paths exercise protected-TLV iteration). The check is a no-op for any well-formed image, so no behavioural change is expected for valid images.
