### PR TITLE
boot: clear AES key material and plaintext from the in-place decrypt path

### DIFF
--- a/boot/boot_serial/src/boot_serial_encryption.c
+++ b/boot/boot_serial/src/boot_serial_encryption.c
@@ -33,18 +33,23 @@ boot_image_validate_encrypted(struct boot_loader_state *state,
     if (MUST_DECRYPT(fa_p, BOOT_CURR_IMG(state), hdr)) {
         rc = boot_enc_load(state, BOOT_SLOT_SECONDARY, hdr, fa_p, bs);
         if (rc < 0) {
-            FIH_RET(fih_rc);
+            goto out;
         }
         rc = boot_enc_set_key(BOOT_CURR_ENC_SLOT(state, BOOT_SLOT_SECONDARY), bs->enckey[BOOT_SLOT_SECONDARY]);
         if (rc < 0) {
-            FIH_RET(fih_rc);
+            goto out;
         }
     }
 
     FIH_CALL(bootutil_img_validate, fih_rc, state,
              hdr, fa_p, buf, buf_size, NULL, 0, NULL);
 
+out:
     boot_enc_zeroize(BOOT_CURR_ENC(state));
+    /* boot_enc_load() populates _bs.enckey[] with the raw AES key; wipe it
+     * so it does not survive on the stack after this function returns.
+     */
+    bootutil_wipe_memory(&_bs, sizeof(_bs));
 
     FIH_RET(fih_rc);
 }
@@ -264,7 +269,7 @@ decrypt_image_inplace(const struct flash_area *fa_p,
     for (sect = 0, size = 0; size < src_size && sect < sect_count; sect++) {
         rc = decrypt_region_inplace(&enc_data, fa_p, hdr, size, sect_size);
         if (rc != 0) {
-            FIH_RET(fih_rc);
+            goto total_out;
         }
         size += sect_size;
     }
@@ -273,6 +278,10 @@ decrypt_image_inplace(const struct flash_area *fa_p,
 total_out:
     boot_enc_zeroize(&enc_data);
     boot_state_clear(state);
+    /* boot_enc_load() populates _bs.enckey[] with the raw AES key; wipe it
+     * so it does not survive on the stack after this function returns.
+     */
+    bootutil_wipe_memory(&_bs, sizeof(_bs));
     FIH_RET(fih_rc);
 }
 

--- a/boot/boot_serial/src/boot_serial_encryption.c
+++ b/boot/boot_serial/src/boot_serial_encryption.c
@@ -141,7 +141,8 @@ decrypt_region_inplace(struct enc_key_data *enc_data,
 
         rc = flash_area_read(fap, off + bytes_copied, buf, chunk_sz);
         if (rc != 0) {
-            return BOOT_EFLASH;
+            rc = BOOT_EFLASH;
+            goto out;
         }
 
         if (IS_ENCRYPTED(hdr)) {
@@ -177,11 +178,13 @@ decrypt_region_inplace(struct enc_key_data *enc_data,
         }
         rc = boot_erase_region(fap, off + bytes_copied, chunk_sz, false);
         if (rc != 0) {
-            return BOOT_EFLASH;
+            rc = BOOT_EFLASH;
+            goto out;
         }
         rc = flash_area_write(fap, off + bytes_copied, buf, chunk_sz);
         if (rc != 0) {
-            return BOOT_EFLASH;
+            rc = BOOT_EFLASH;
+            goto out;
         }
 
         bytes_copied += chunk_sz;
@@ -189,7 +192,11 @@ decrypt_region_inplace(struct enc_key_data *enc_data,
         MCUBOOT_WATCHDOG_FEED();
     }
 
-    return 0;
+    rc = 0;
+out:
+    /* buf may hold decrypted image plaintext; clear it before returning. */
+    bootutil_wipe_memory(buf, sizeof buf);
+    return rc;
 }
 
 /**

--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -29,6 +29,7 @@
 #define H_BOOTUTIL_
 
 #include <inttypes.h>
+#include <stddef.h>
 #include "bootutil/fault_injection_hardening.h"
 #include "bootutil/bootutil_public.h"
 
@@ -134,6 +135,19 @@ uint32_t boot_get_state_secondary_offset(struct boot_loader_state *state,
 #define SPLIT_GO_ERR                (-2)
 
 fih_ret split_go(int loader_slot, int split_slot, void **entry);
+
+/**
+ * Securely wipes a region of memory.
+ *
+ * Equivalent to memset(p, 0, n), but written so that the compiler cannot
+ * optimize the store away when the memory is no longer read before going
+ * out of scope. Use this for buffers that have held key material or other
+ * secrets.
+ *
+ * @param p     Pointer to the memory to wipe.
+ * @param n     Number of bytes to wipe.
+ */
+void bootutil_wipe_memory(void *p, size_t n);
 
 #ifdef __cplusplus
 }

--- a/boot/bootutil/include/bootutil/crypto/aes_ctr_tinycrypt.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_ctr_tinycrypt.h
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <stdint.h>
 #include "mcuboot_config/mcuboot_config.h"
+#include "bootutil/bootutil.h"
 #include "bootutil/enc_key_public.h"
 
 #include <tinycrypt/aes.h>
@@ -37,7 +38,10 @@ static inline void bootutil_aes_ctr_init(bootutil_aes_ctr_context *ctx)
 
 static inline void bootutil_aes_ctr_drop(bootutil_aes_ctr_context *ctx)
 {
-    (void)ctx;
+    /* Tinycrypt has no aes_free()-style call; the expanded key schedule
+     * lives entirely in ctx, so wipe it directly.
+     */
+    bootutil_wipe_memory(ctx, sizeof(*ctx));
 }
 
 static inline int bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx, const uint8_t *k)

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -664,3 +664,20 @@ void boot_state_clear(struct boot_loader_state *state)
     (void)state;
 #endif
 }
+
+/**
+ * Securely wipes a region of memory.
+ *
+ * A plain memset() on a buffer that is not read again before it goes out of
+ * scope is a dead store that the compiler is free to remove. Writing through
+ * a volatile pointer forces the stores to be emitted, so key material and
+ * other secrets are actually cleared.
+ */
+void bootutil_wipe_memory(void *p, size_t n)
+{
+    volatile unsigned char *v = (volatile unsigned char *)p;
+
+    for (size_t i = 0; i < n; i++) {
+        v[i] = 0;
+    }
+}

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -752,20 +752,6 @@ boot_validated_swap_type(struct boot_loader_state *state,
 
 #if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)
 
-#if defined(MCUBOOT_ENC_IMAGES) || defined(MCUBOOT_SWAP_SAVE_ENCTLV)
-/* Replacement for memset(p, 0, sizeof(*p) that does not get
- * optimized out.
- */
-static void like_mbedtls_zeroize(void *p, size_t n)
-{
-    volatile unsigned char *v = (unsigned char *)p;
-
-    for (size_t i = 0; i < n; i++) {
-        v[i] = 0;
-    }
-}
-#endif
-
 /**
  * Copies the contents of one flash region to another.  You must erase the
  * destination region prior to calling this function.
@@ -1978,7 +1964,7 @@ out:
      * easily recover them.
      */
 #if defined(MCUBOOT_ENC_IMAGES) || defined(MCUBOOT_SWAP_SAVE_ENCTLV)
-    like_mbedtls_zeroize(&bs, sizeof(bs));
+    bootutil_wipe_memory(&bs, sizeof(bs));
 #else
     memset(&bs, 0, sizeof(struct boot_status));
 #endif


### PR DESCRIPTION
## What

The serial-recovery in-place decrypt path keeps AES key material and decrypted image plaintext in stack-local buffers and crypto contexts, but did not consistently clear them once they were no longer needed. This series makes that path (and the Tinycrypt AES-CTR backend) clear sensitive data on every exit.

## Changes

Four commits:

1. **Add `bootutil_wipe_memory()` secure-zero helper.** `loader.c` already had a file-local `like_mbedtls_zeroize()` that writes zeros through a `volatile` pointer so the compiler cannot drop the store as a dead store. This commit promotes it to `bootutil_misc.c` (declared in `bootutil_priv.h`), renamed without the provenance baggage, and updates `loader.c` to use it. No behavioural change.

2. **Clear AES key material from the stack after in-place decrypt.** `decrypt_image_inplace()` and `boot_image_validate_encrypted()` keep the raw AES key in a local `struct boot_status` (`_bs.enckey[]`) and did not clear it on exit. `decrypt_image_inplace()` also returned directly from the per-sector loop on a decrypt failure, bypassing the `total_out:` cleanup entirely. Route every exit through a common cleanup label and clear `_bs` there with `bootutil_wipe_memory()`. The early-`FIH_RET` → `goto` change is a correctness fix in its own right.

3. **Clear decrypted plaintext from the in-place decrypt buffer.** `decrypt_region_inplace()` decrypts each flash sector into a stack buffer; on return that buffer still held a chunk of decrypted image plaintext. Restructure the function to a single cleanup point and clear the buffer there.

4. **Clear the AES key schedule in the Tinycrypt `aes_ctr_drop`.** `bootutil_aes_ctr_drop()` is the hook for releasing an AES-CTR context. The mbedTLS and PSA backends free/destroy the underlying key state, but the Tinycrypt implementation was an empty stub, leaving the expanded key schedule behind. Clear the context so `boot_enc_drop()` / `boot_state_clear()` wipe it for this backend too.

## Notes

Hardening/cleanup. The bulk of the change is in `boot_serial_encryption.c`, which the Rust simulator does not compile (it is a Zephyr/Mynewt-only file), so commits 2 and 3 are reviewed at the code level rather than exercised by the sim suite. Commits 1 and 4 are exercised by `cargo test` with the encryption features enabled.

## Testing

`cd sim && cargo test --features enc-rsa` and `--features enc-kw` pass (25 tests each).
