### PR TITLE
boot: bootutil: fault-injection hardening for RSA-PSS verification

### DIFF
--- a/boot/bootutil/src/image_rsa.c
+++ b/boot/bootutil/src/image_rsa.c
@@ -115,6 +115,26 @@ pss_mgf1(uint8_t *mask, const uint8_t *hash)
 }
 
 /*
+ * FIH wrapper around bootutil_rsa_public() so the modular exponentiation
+ * call crosses a FIH_CALL boundary and is covered by control-flow
+ * integrity counting, consistent with the rest of bootutil. This guards
+ * against the whole call being skipped; the result check in the caller
+ * guards against a fault within the exponentiation itself.
+ */
+static fih_ret
+bootutil_rsa_public_fih(bootutil_rsa_context *ctx, const uint8_t *sig,
+  uint8_t *em)
+{
+    FIH_DECLARE(fih_rc, FIH_FAILURE);
+
+    if (bootutil_rsa_public(ctx, sig, em) == 0) {
+        fih_rc = FIH_SUCCESS;
+    }
+
+    FIH_RET(fih_rc);
+}
+
+/*
  * Validate an RSA signature, using RSA-PSS, as described in PKCS #1
  * v2.2, section 9.1.2, with many parameters required to have fixed
  * values. RSASSA-PSS-VERIFY RFC8017 section 8.1.2
@@ -129,6 +149,7 @@ bootutil_cmp_rsasig(bootutil_rsa_context *ctx, uint8_t *hash, uint32_t hlen,
     uint8_t h2[PSS_HLEN];
     int i;
     FIH_DECLARE(fih_rc, FIH_FAILURE);
+    FIH_DECLARE(fih_eq, FIH_FAILURE);
 
     /* The caller has already verified that slen == bootutil_rsa_get_len(ctx) */
     if (slen != PSS_EMLEN ||
@@ -140,10 +161,27 @@ bootutil_cmp_rsasig(bootutil_rsa_context *ctx, uint8_t *hash, uint32_t hlen,
         goto out;
     }
 
-    /* Apply RSAVP1 to produce em = sig^E mod N using the public key */
-    if (bootutil_rsa_public(ctx, sig, em)) {
+    /* Apply RSAVP1 to produce em = sig^E mod N using the public key.
+     * The call is made through a FIH_CALL boundary so that a skipped
+     * call is detected by control-flow integrity counting. */
+    FIH_CALL(bootutil_rsa_public_fih, fih_rc, ctx, sig, em);
+    if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
         goto out;
     }
+
+    /* Defensive check: a modular exponentiation that was skipped or
+     * otherwise short-circuited leaves the output buffer equal to its
+     * input. A genuine RSA public-key operation does not produce that,
+     * so treat em == sig as a failure and reject the signature. A
+     * dedicated fih_ret variable is used so that a fault skipping the
+     * comparison at the end of this function cannot leave a stale
+     * success value behind. */
+    FIH_CALL(boot_fih_memequal, fih_eq, em, sig, PSS_EMLEN);
+    if (FIH_EQ(fih_eq, FIH_SUCCESS)) {
+        FIH_SET(fih_rc, FIH_FAILURE);
+        goto out;
+    }
+    FIH_SET(fih_rc, FIH_FAILURE);
 
     /*
      * PKCS #1 v2.2, 9.1.2 EMSA-PSS-Verify

--- a/boot/bootutil/src/image_rsa.c
+++ b/boot/bootutil/src/image_rsa.c
@@ -278,20 +278,66 @@ out:
 
 #else /* MCUBOOT_USE_PSA_CRYPTO */
 
+/*
+ * FIH wrapper around bootutil_rsassa_pss_verify() so that each
+ * verification attempt crosses a FIH_CALL boundary and is covered by
+ * control-flow integrity counting, consistent with the rest of bootutil.
+ */
+static fih_ret
+bootutil_rsassa_pss_verify_fih(bootutil_rsa_context *ctx, uint8_t *hash,
+  uint32_t hlen, uint8_t *sig, size_t slen)
+{
+    FIH_DECLARE(fih_rc, FIH_FAILURE);
+
+    if (bootutil_rsassa_pss_verify(ctx, hash, hlen, sig, slen) == 0) {
+        fih_rc = FIH_SUCCESS;
+    }
+
+    FIH_RET(fih_rc);
+}
+
 static fih_ret
 bootutil_cmp_rsasig(bootutil_rsa_context *ctx, uint8_t *hash, uint32_t hlen,
   uint8_t *sig, size_t slen)
 {
-    int rc = -1;
     FIH_DECLARE(fih_rc, FIH_FAILURE);
+#ifdef MCUBOOT_RSA_PSA_DOUBLE_VERIFY
+    FIH_DECLARE(fih_rc2, FIH_FAILURE);
+#endif
 
     /* PSA Crypto APIs allow the verification in a single call */
-    rc = bootutil_rsassa_pss_verify(ctx, hash, hlen, sig, slen);
-
-    fih_rc = fih_ret_encode_zero_equality(rc);
+    FIH_CALL(bootutil_rsassa_pss_verify_fih, fih_rc, ctx, hash, hlen, sig,
+             slen);
     if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
         FIH_SET(fih_rc, FIH_FAILURE);
+        FIH_RET(fih_rc);
     }
+
+#ifdef MCUBOOT_RSA_PSA_DOUBLE_VERIFY
+    /*
+     * The modular exponentiation is performed inside the PSA crypto
+     * implementation and is not reachable from here, so it cannot be
+     * checked directly the way the non-PSA path is. When this option is
+     * enabled, perform the whole verification a second time and require
+     * both attempts to succeed, as a fault-injection countermeasure.
+     * Hardening of the modular exponentiation itself remains the
+     * responsibility of the PSA crypto implementation.
+     *
+     * The second attempt records its result in a dedicated fih_ret
+     * variable, and the first attempt's success is discarded before it is
+     * made, so that a fault skipping the second call cannot be masked by
+     * the result the first one left behind.
+     */
+    FIH_SET(fih_rc, FIH_FAILURE);
+
+    FIH_CALL(bootutil_rsassa_pss_verify_fih, fih_rc2, ctx, hash, hlen, sig,
+             slen);
+    if (FIH_NOT_EQ(fih_rc2, FIH_SUCCESS)) {
+        FIH_RET(fih_rc);
+    }
+
+    FIH_SET(fih_rc, FIH_SUCCESS);
+#endif /* MCUBOOT_RSA_PSA_DOUBLE_VERIFY */
 
     FIH_RET(fih_rc);
 }

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -303,6 +303,25 @@ config BOOT_RSA_PSA
 
 endchoice
 
+config BOOT_RSA_PSA_DOUBLE_VERIFY
+	bool "Verify RSA signatures twice (fault injection hardening)"
+	depends on BOOT_RSA_PSA
+	default y if BOOT_FIH_PROFILE_MEDIUM || BOOT_FIH_PROFILE_HIGH
+	help
+	  With the PSA crypto backend the RSA modular exponentiation is
+	  performed inside the PSA implementation and cannot be checked
+	  directly by MCUboot. When this option is enabled the whole
+	  RSA-PSS verification is performed a second time and both attempts
+	  must succeed, providing a fault injection countermeasure at the
+	  cost of doubling the (relatively expensive) RSA verification time.
+
+	  This is the same redundancy strategy as the MEDIUM profile's
+	  double variables, applied to the one operation FIH's control-flow
+	  checks cannot see into, so it defaults to enabled at the MEDIUM
+	  and HIGH profiles. The LOW profile stays control-flow only; enable
+	  this explicitly there if the boot time cost is acceptable. Disable
+	  it at any level if the cost outweighs the added protection.
+
 endif # BOOT_SIGNATURE_TYPE_RSA
 
 config BOOT_SIGNATURE_TYPE_ECDSA_P256

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -27,6 +27,10 @@
 #define MCUBOOT_SIGN_ED25519
 #endif
 
+#ifdef CONFIG_BOOT_RSA_PSA_DOUBLE_VERIFY
+#define MCUBOOT_RSA_PSA_DOUBLE_VERIFY
+#endif
+
 #if defined(CONFIG_BOOT_USE_TINYCRYPT)
 #  if defined(CONFIG_MBEDTLS) || defined(CONFIG_BOOT_USE_CC310)
 #     error "One crypto library implementation allowed at a time."

--- a/samples/mcuboot_config/mcuboot_config.template.h
+++ b/samples/mcuboot_config/mcuboot_config.template.h
@@ -34,6 +34,17 @@
 /* #define MCUBOOT_SIGN_EC256 */
 
 /*
+ * When MCUBOOT_SIGN_RSA is used together with the PSA crypto backend
+ * (MCUBOOT_USE_PSA_CRYPTO), the RSA modular exponentiation happens inside
+ * the PSA implementation and cannot be checked directly by MCUboot.
+ * Uncomment to perform the RSA-PSS verification twice and require both
+ * attempts to succeed, as a fault injection countermeasure at the cost of
+ * doubling the RSA verification time.  Recommended when fault injection
+ * hardening is otherwise enabled.
+ */
+/* #define MCUBOOT_RSA_PSA_DOUBLE_VERIFY */
+
+/*
  * Public key handling
  *
  * Choose one or none from the different public key handling options.


### PR DESCRIPTION
## Summary

This series adds fault-injection hardening around the RSA-PSS signature verification in `bootutil`, in line with the FIH patterns already used elsewhere in the bootloader.

## Changes

**1. Harden the non-PSA RSA-PSS verification path**

`bootutil_cmp_rsasig()` previously invoked the public-key modular exponentiation as a plain, unwrapped call with no hardening around it. Two defensive measures are added:

- The `bootutil_rsa_public()` call is routed through a thin `FIH` wrapper invoked via `FIH_CALL`, so a skipped call is caught by control-flow integrity counting, consistent with the rest of `bootutil`.
- After the exponentiation, the signature is rejected if the output buffer is identical to the input. A correct RSA public-key operation does not produce that result. A dedicated `fih_ret` variable is used for this comparison so a later skipped check cannot leave a stale success value behind.

**2. Optional redundant RSA-PSS verification for the PSA crypto path**

With the PSA crypto backend the verification is a single `psa_verify_hash()` call and the modular exponentiation runs inside the PSA implementation, where it is not reachable from MCUboot. A new optional countermeasure runs the whole RSA-PSS verification a second time and requires both attempts to succeed.

It is gated by a new Kconfig option, `BOOT_RSA_PSA_DOUBLE_VERIFY`, because the extra verification roughly doubles the RSA verify time and different users will want different tradeoffs. The option defaults to enabled whenever a fault injection hardening profile is active, and disabled otherwise. Ports that do not define `MCUBOOT_RSA_PSA_DOUBLE_VERIFY` keep the previous single-verification behaviour. Hardening of the modular exponentiation itself remains the responsibility of the PSA crypto implementation.

## Testing

- `cargo test --features sig-rsa` and `--features sig-rsa3072`: all pass; legitimately signed images still validate.
- The non-PSA path compiles cleanly under all four FIH profiles (`OFF`/`LOW`/`MEDIUM`/`HIGH`).
- The PSA path compiles cleanly with and without `MCUBOOT_RSA_PSA_DOUBLE_VERIFY`.
- Negative check: temporarily forcing the exponentiation output to equal its input causes `bootutil_cmp_rsasig()` to reject the image, confirming the new check fires.
