### PR TITLE
boot: zephyr: sysflash: Support TF-M naming convention for partitions

### DIFF
--- a/boot/zephyr/include/sysflash/sysflash.h
+++ b/boot/zephyr/include/sysflash/sysflash.h
@@ -16,6 +16,7 @@
 #if !defined(CONFIG_SINGLE_APPLICATION_SLOT) && !defined(CONFIG_MCUBOOT_BOOTLOADER_MODE_SINGLE_APP)
 
 /* Each pair of slots is separated by , and there is no terminating character */
+#if !defined(CONFIG_TFM_BL2)
 #define FLASH_AREA_IMAGE_0_SLOTS    slot0_partition, slot1_partition
 #define FLASH_AREA_IMAGE_1_SLOTS    slot2_partition, slot3_partition
 #define FLASH_AREA_IMAGE_2_SLOTS    slot4_partition, slot5_partition
@@ -24,6 +25,16 @@
 #define FLASH_AREA_IMAGE_5_SLOTS    slot10_partition, slot11_partition
 #define FLASH_AREA_IMAGE_6_SLOTS    slot12_partition, slot13_partition
 #define FLASH_AREA_IMAGE_7_SLOTS    slot14_partition, slot15_partition
+#else
+#define FLASH_AREA_IMAGE_0_SLOTS    slot0_partition, slot0_ns_partition
+#define FLASH_AREA_IMAGE_1_SLOTS    slot1_partition, slot1_ns_partition
+#define FLASH_AREA_IMAGE_2_SLOTS    slot2_partition, slot2_ns_partition
+#define FLASH_AREA_IMAGE_3_SLOTS    slot3_partition, slot3_ns_partition
+#define FLASH_AREA_IMAGE_4_SLOTS    slot4_partition, slot4_ns_partition
+#define FLASH_AREA_IMAGE_5_SLOTS    slot5_partition, slot5_ns_partition
+#define FLASH_AREA_IMAGE_6_SLOTS    slot6_partition, slot6_ns_partition
+#define FLASH_AREA_IMAGE_7_SLOTS    slot7_partition, slot7_ns_partition
+#endif /* !CONFIG_TFM_BL2 */
 
 #if (MCUBOOT_IMAGE_NUMBER == 1)
 #define ALL_AVAILABLE_SLOTS FLASH_AREA_IMAGE_0_SLOTS


### PR DESCRIPTION
In Zephyr, Trusted Firmware-M (TF-M) enabled builds use a different naming convention for the partitions due to their use as secure and non-secure firmware. Instead of slot0_partition and slot1_partition, the partitions are called slot0_partition and slot0_ns_partition, etc.

Use this convention for TF-M enabled builds to avoid build issues when compiling mcuboot bootutil library.

Fixes the following compile error:
```
/home/user/west_workspace/bootloader/mcuboot/boot/bootutil/src/bootutil_public.c
In file included from /home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:34,
                 from /home/user/west_workspace/zephyr/include/zephyr/irq_multilevel.h:16,
                 from /home/user/west_workspace/zephyr/include/zephyr/devicetree.h:21,
                 from /home/user/west_workspace/bootloader/mcuboot/boot/bootutil/zephyr/../../zephyr/include/mcuboot_config/mcuboot_config.h:13,
                 from /home/user/west_workspace/bootloader/mcuboot/boot/bootutil/zephyr/../../zephyr/include/sysflash/sysflash.h:10,
                 from /home/user/west_workspace/bootloader/mcuboot/boot/bootutil/src/bootutil_public.c:43:
/home/user/west_workspace/bootloader/mcuboot/boot/bootutil/zephyr/../../zephyr/include/sysflash/sysflash.h: In function '__flash_area_ids_for_slot':
/home/user/west_workspace/zephyr/include/zephyr/devicetree.h:197:36: error: 'DT_N_NODELABEL_slot2_partition_PARTITION_ID' undeclared (first use in this function); did you mean 'DT_N_NODELABEL_slot1_partition'?
  197 | #define DT_NODELABEL(label) DT_CAT(DT_N_NODELABEL_, label)
      |                                    ^~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:72:26: note: in definition of macro '__DEBRACKET'
   72 | #define __DEBRACKET(...) __VA_ARGS__
      |                          ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:64:9: note: in expansion of macro '__GET_ARG2_DEBRACKET'
   64 |         __GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
      |         ^~~~~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:61:9: note: in expansion of macro '__COND_CODE'
   61 |         __COND_CODE(_ZZZZ##_flag, _if_0_code, _else_code)
      |         ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:226:9: note: in expansion of macro 'Z_COND_CODE_0'
  226 |         Z_COND_CODE_0(_flag, _if_0_code, _else_code)
      |         ^~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:598:9: note: in expansion of macro 'COND_CODE_0'
  598 |         COND_CODE_0(                                                    \
      |         ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:69:53: note: in expansion of macro '__DEBRACKET'
   69 | #define __GET_ARG2_DEBRACKET(ignore_this, val, ...) __DEBRACKET val
      |                                                     ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:64:9: note: in expansion of macro '__GET_ARG2_DEBRACKET'
   64 |         __GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
      |         ^~~~~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:59:9: note: in expansion of macro '__COND_CODE'
   59 |         __COND_CODE(_XXXX##_flag, _if_1_code, _else_code)
      |         ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:210:9: note: in expansion of macro 'Z_COND_CODE_1'
  210 |         Z_COND_CODE_1(_flag, _if_1_code, _else_code)
      |         ^~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/storage/flash_map.h:378:9: note: in expansion of macro 'COND_CODE_1'
  378 |         COND_CODE_1(DT_NODE_HAS_COMPAT(DT_NODELABEL(label), zephyr_mapped_partition),   \
      |         ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/devicetree/fixed-partitions.h:78:40: note: in expansion of macro 'DT_CAT'
   78 | #define DT_FIXED_PARTITION_ID(node_id) DT_CAT(node_id, _PARTITION_ID)
      |                                        ^~~~~~
/home/user/west_workspace/zephyr/include/zephyr/storage/flash_map.h:380:22: note: in expansion of macro 'DT_FIXED_PARTITION_ID'
  380 |                     (DT_FIXED_PARTITION_ID(DT_NODELABEL(label))))
      |                      ^~~~~~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/devicetree.h:197:29: note: in expansion of macro 'DT_CAT'
  197 | #define DT_NODELABEL(label) DT_CAT(DT_N_NODELABEL_, label)
      |                             ^~~~~~
/home/user/west_workspace/zephyr/include/zephyr/storage/flash_map.h:380:44: note: in expansion of macro 'DT_NODELABEL'
  380 |                     (DT_FIXED_PARTITION_ID(DT_NODELABEL(label))))
      |                                            ^~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_loops.h:1457:9: note: in expansion of macro 'PARTITION_ID'
 1457 |         fixed_arg0(x)
      |         ^~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_loops.h:38:9: note: in expansion of macro 'Z_FOR_EACH_EXEC'
   38 |         z_call(2, x, fixed_arg0, fixed_arg1)
      |         ^~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_loops.h:41:9: note: in expansion of macro 'Z_FOR_LOOP_3'
   41 |         Z_FOR_LOOP_3(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
      |         ^~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_loops.h:23:81: note: in expansion of macro 'Z_FOR_LOOP_4'
   23 |                                 _57, _58, _59, _60, _61, _62, _63, _64, N, ...) N
      |                                                                                 ^
/home/user/west_workspace/zephyr/include/zephyr/sys/util_loops.h:1460:9: note: in expansion of macro 'Z_FOR_EACH_ENGINE'
 1460 |         Z_FOR_EACH_ENGINE(Z_FOR_EACH_EXEC, sep, F, _, __VA_ARGS__)
      |         ^~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:543:9: note: in expansion of macro 'Z_FOR_EACH'
  543 |         Z_FOR_EACH(F, sep, REVERSE_ARGS(__VA_ARGS__))
      |         ^~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:605:25: note: in expansion of macro 'FOR_EACH'
  605 |                         FOR_EACH(F, term, LIST_DROP_EMPTY(__VA_ARGS__)) \
      |                         ^~~~~~~~
/home/user/west_workspace/bootloader/mcuboot/boot/bootutil/zephyr/../../zephyr/include/sysflash/sysflash.h:77:9: note: in expansion of macro 'FOR_EACH_NONEMPTY_TERM'
   77 |         FOR_EACH_NONEMPTY_TERM(PARTITION_ID, (,), ALL_AVAILABLE_SLOTS)
      |         ^~~~~~~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/devicetree.h:197:36: note: each undeclared identifier is reported only once for each function it appears in
  197 | #define DT_NODELABEL(label) DT_CAT(DT_N_NODELABEL_, label)
      |                                    ^~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:72:26: note: in definition of macro '__DEBRACKET'
   72 | #define __DEBRACKET(...) __VA_ARGS__
      |                          ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:64:9: note: in expansion of macro '__GET_ARG2_DEBRACKET'
   64 |         __GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
      |         ^~~~~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:61:9: note: in expansion of macro '__COND_CODE'
   61 |         __COND_CODE(_ZZZZ##_flag, _if_0_code, _else_code)
      |         ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:226:9: note: in expansion of macro 'Z_COND_CODE_0'
  226 |         Z_COND_CODE_0(_flag, _if_0_code, _else_code)
      |         ^~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:598:9: note: in expansion of macro 'COND_CODE_0'
  598 |         COND_CODE_0(                                                    \
      |         ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:69:53: note: in expansion of macro '__DEBRACKET'
   69 | #define __GET_ARG2_DEBRACKET(ignore_this, val, ...) __DEBRACKET val
      |                                                     ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:64:9: note: in expansion of macro '__GET_ARG2_DEBRACKET'
   64 |         __GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
      |         ^~~~~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:59:9: note: in expansion of macro '__COND_CODE'
   59 |         __COND_CODE(_XXXX##_flag, _if_1_code, _else_code)
      |         ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:210:9: note: in expansion of macro 'Z_COND_CODE_1'
  210 |         Z_COND_CODE_1(_flag, _if_1_code, _else_code)
      |         ^~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/storage/flash_map.h:378:9: note: in expansion of macro 'COND_CODE_1'
  378 |         COND_CODE_1(DT_NODE_HAS_COMPAT(DT_NODELABEL(label), zephyr_mapped_partition),   \
      |         ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/devicetree/fixed-partitions.h:78:40: note: in expansion of macro 'DT_CAT'
   78 | #define DT_FIXED_PARTITION_ID(node_id) DT_CAT(node_id, _PARTITION_ID)
      |                                        ^~~~~~
/home/user/west_workspace/zephyr/include/zephyr/storage/flash_map.h:380:22: note: in expansion of macro 'DT_FIXED_PARTITION_ID'
  380 |                     (DT_FIXED_PARTITION_ID(DT_NODELABEL(label))))
      |                      ^~~~~~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/devicetree.h:197:29: note: in expansion of macro 'DT_CAT'
  197 | #define DT_NODELABEL(label) DT_CAT(DT_N_NODELABEL_, label)
      |                             ^~~~~~
/home/user/west_workspace/zephyr/include/zephyr/storage/flash_map.h:380:44: note: in expansion of macro 'DT_NODELABEL'
  380 |                     (DT_FIXED_PARTITION_ID(DT_NODELABEL(label))))
      |                                            ^~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_loops.h:1457:9: note: in expansion of macro 'PARTITION_ID'
 1457 |         fixed_arg0(x)
      |         ^~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_loops.h:38:9: note: in expansion of macro 'Z_FOR_EACH_EXEC'
   38 |         z_call(2, x, fixed_arg0, fixed_arg1)
      |         ^~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_loops.h:41:9: note: in expansion of macro 'Z_FOR_LOOP_3'
   41 |         Z_FOR_LOOP_3(z_call, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__) \
      |         ^~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_loops.h:23:81: note: in expansion of macro 'Z_FOR_LOOP_4'
   23 |                                 _57, _58, _59, _60, _61, _62, _63, _64, N, ...) N
      |                                                                                 ^
/home/user/west_workspace/zephyr/include/zephyr/sys/util_loops.h:1460:9: note: in expansion of macro 'Z_FOR_EACH_ENGINE'
 1460 |         Z_FOR_EACH_ENGINE(Z_FOR_EACH_EXEC, sep, F, _, __VA_ARGS__)
      |         ^~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:543:9: note: in expansion of macro 'Z_FOR_EACH'
  543 |         Z_FOR_EACH(F, sep, REVERSE_ARGS(__VA_ARGS__))
      |         ^~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:605:25: note: in expansion of macro 'FOR_EACH'
  605 |                         FOR_EACH(F, term, LIST_DROP_EMPTY(__VA_ARGS__)) \
      |                         ^~~~~~~~
/home/user/west_workspace/bootloader/mcuboot/boot/bootutil/zephyr/../../zephyr/include/sysflash/sysflash.h:77:9: note: in expansion of macro 'FOR_EACH_NONEMPTY_TERM'
   77 |         FOR_EACH_NONEMPTY_TERM(PARTITION_ID, (,), ALL_AVAILABLE_SLOTS)
      |         ^~~~~~~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/devicetree.h:197:36: error: 'DT_N_NODELABEL_slot3_partition_PARTITION_ID' undeclared (first use in this function); did you mean 'DT_N_NODELABEL_slot1_partition'?
  197 | #define DT_NODELABEL(label) DT_CAT(DT_N_NODELABEL_, label)
      |                                    ^~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:72:26: note: in definition of macro '__DEBRACKET'
   72 | #define __DEBRACKET(...) __VA_ARGS__
      |                          ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:64:9: note: in expansion of macro '__GET_ARG2_DEBRACKET'
   64 |         __GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
      |         ^~~~~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:61:9: note: in expansion of macro '__COND_CODE'
   61 |         __COND_CODE(_ZZZZ##_flag, _if_0_code, _else_code)
      |         ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:226:9: note: in expansion of macro 'Z_COND_CODE_0'
  226 |         Z_COND_CODE_0(_flag, _if_0_code, _else_code)
      |         ^~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:598:9: note: in expansion of macro 'COND_CODE_0'
  598 |         COND_CODE_0(                                                    \
      |         ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:69:53: note: in expansion of macro '__DEBRACKET'
   69 | #define __GET_ARG2_DEBRACKET(ignore_this, val, ...) __DEBRACKET val
      |                                                     ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:64:9: note: in expansion of macro '__GET_ARG2_DEBRACKET'
   64 |         __GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
      |         ^~~~~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_internal.h:59:9: note: in expansion of macro '__COND_CODE'
   59 |         __COND_CODE(_XXXX##_flag, _if_1_code, _else_code)
      |         ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:210:9: note: in expansion of macro 'Z_COND_CODE_1'
  210 |         Z_COND_CODE_1(_flag, _if_1_code, _else_code)
      |         ^~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/storage/flash_map.h:378:9: note: in expansion of macro 'COND_CODE_1'
  378 |         COND_CODE_1(DT_NODE_HAS_COMPAT(DT_NODELABEL(label), zephyr_mapped_partition),   \
      |         ^~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/devicetree/fixed-partitions.h:78:40: note: in expansion of macro 'DT_CAT'
   78 | #define DT_FIXED_PARTITION_ID(node_id) DT_CAT(node_id, _PARTITION_ID)
      |                                        ^~~~~~
/home/user/west_workspace/zephyr/include/zephyr/storage/flash_map.h:380:22: note: in expansion of macro 'DT_FIXED_PARTITION_ID'
  380 |                     (DT_FIXED_PARTITION_ID(DT_NODELABEL(label))))
      |                      ^~~~~~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/devicetree.h:197:29: note: in expansion of macro 'DT_CAT'
  197 | #define DT_NODELABEL(label) DT_CAT(DT_N_NODELABEL_, label)
      |                             ^~~~~~
/home/user/west_workspace/zephyr/include/zephyr/storage/flash_map.h:380:44: note: in expansion of macro 'DT_NODELABEL'
  380 |                     (DT_FIXED_PARTITION_ID(DT_NODELABEL(label))))
      |                                            ^~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_loops.h:1457:9: note: in expansion of macro 'PARTITION_ID'
 1457 |         fixed_arg0(x)
      |         ^~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_loops.h:43:9: note: in expansion of macro 'Z_FOR_EACH_EXEC'
   43 |         z_call(3, x, fixed_arg0, fixed_arg1)
      |         ^~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_loops.h:23:81: note: in expansion of macro 'Z_FOR_LOOP_4'
   23 |                                 _57, _58, _59, _60, _61, _62, _63, _64, N, ...) N
      |                                                                                 ^
/home/user/west_workspace/zephyr/include/zephyr/sys/util_loops.h:1460:9: note: in expansion of macro 'Z_FOR_EACH_ENGINE'
 1460 |         Z_FOR_EACH_ENGINE(Z_FOR_EACH_EXEC, sep, F, _, __VA_ARGS__)
      |         ^~~~~~~~~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:543:9: note: in expansion of macro 'Z_FOR_EACH'
  543 |         Z_FOR_EACH(F, sep, REVERSE_ARGS(__VA_ARGS__))
      |         ^~~~~~~~~~
/home/user/west_workspace/zephyr/include/zephyr/sys/util_macro.h:605:25: note: in expansion of macro 'FOR_EACH'
  605 |                         FOR_EACH(F, term, LIST_DROP_EMPTY(__VA_ARGS__)) \
      |                         ^~~~~~~~
/home/user/west_workspace/bootloader/mcuboot/boot/bootutil/zephyr/../../zephyr/include/sysflash/sysflash.h:77:9: note: in expansion of macro 'FOR_EACH_NONEMPTY_TERM'
   77 |         FOR_EACH_NONEMPTY_TERM(PARTITION_ID, (,), ALL_AVAILABLE_SLOTS)
      |   
```