### PR TITLE
scripts: imgtool: Update regex pattern

### DIFF
--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -264,12 +264,12 @@ def tlv_matches_key_type(tlv_type, key):
 
 def parse_uuid(namespace, value):
     # Check if UUID is in the RAW format (12345678-1234-5678-1234-567812345678)
-    uuid_re = r'[0-9A-f]{8}-[0-9A-f]{4}-[0-9A-f]{4}-[0-9A-f]{4}-[0-9A-f]{12}'
-    if re.match(uuid_re, value):
+    uuid_re = r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
+    if re.fullmatch(uuid_re, value):
         uuid_bytes = bytes.fromhex(value.replace('-', ''))
 
     # Check if UUID is in the RAW HEX format (12345678123456781234567812345678)
-    elif re.match(r'[0-9A-f]{32}', value):
+    elif re.fullmatch(r'[0-9a-fA-F]{32}', value):
         uuid_bytes = bytes.fromhex(value)
 
     # Check if UUID is in the string format


### PR DESCRIPTION
[A-f] regex mask search non-numeric characters below
<img width="572" height="537" alt="image" src="https://github.com/user-attachments/assets/dc8c78d7-4060-4cdc-a286-45611e14cbea" />

For clarity it would be better if it only search exact pattern.

Note: It is not critical change, just improvement for clarity, because even if non-numeric chars has been found with existing regex pattern while converting them to hex with
[bytes.fromhex()](https://github.com/mcu-tools/mcuboot/blob/main/scripts/imgtool/image.py#L269) function, it will fails.