### PR TITLE
boot: bootutil: introduce boot_load_image_to_sram hook

### DIFF
--- a/boot/bootutil/include/bootutil/boot_hooks.h
+++ b/boot/bootutil/include/bootutil/boot_hooks.h
@@ -225,6 +225,21 @@ int boot_img_install_stat_hook(int image_index, int slot,
  */
 int boot_reset_request_hook(bool force);
 
+/** Hook provides a way for the custom image loading and validation.
+ *
+ * @param img_index the index of the image pair
+ * @param slot slot number
+ * @param img_dst image destination address to be populated
+ * @param img_sz image size to be populated
+ *
+ * @retval 0: success, mcuboot will follow normal code execution flow after
+ *            execution of this call.
+ *         non-zero: an error, will be transferred as part of command response
+ *            as "rc" entry.
+ */
+int boot_load_image_to_sram_hook(int image_index, int slot,
+                                 uint32_t *img_dst, uint32_t *img_sz);
+
 /**
  * Hook to implement custom action before boot_go() function.
  *

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -2307,7 +2307,14 @@ boot_load_and_validate_images(struct boot_loader_state *state)
              * when loading images from external (untrusted) flash to internal
              * (trusted) RAM and image is authenticated before copying.
              */
-            rc = boot_load_image_to_sram(state);
+            rc = BOOT_HOOK_CALL(boot_load_image_to_sram_hook, BOOT_HOOK_REGULAR,
+                    BOOT_CURR_IMG(state), active_slot,
+                    &state->slot_usage[BOOT_CURR_IMG(state)].img_dst,
+                    &state->slot_usage[BOOT_CURR_IMG(state)].img_sz);
+            if (rc == BOOT_HOOK_REGULAR)
+            {
+                rc = boot_load_image_to_sram(state);
+            }
             if (rc != 0 ) {
                 /* Image cannot be ramloaded. */
                 boot_remove_image_from_flash(state, active_slot);

--- a/boot/zephyr/hooks_sample.c
+++ b/boot/zephyr/hooks_sample.c
@@ -99,3 +99,9 @@ int boot_find_next_slot_hook(struct boot_loader_state *state, uint8_t image,
 {
     return BOOT_HOOK_REGULAR;
 }
+
+int boot_load_image_to_sram_hook(int image_index, int slot,
+                                 size_t *img_dst, size_t *img_sz)
+{
+    return BOOT_HOOK_REGULAR;
+}


### PR DESCRIPTION
This hook allows to define a custom way of handling loading an image to SRAM. This can be useful if a system needs to override image loading routines (for example, if a security enclave needs to perform loading and validation)