### PR TITLE
boot: zephyr: boards: Add nRF93M1DK configuration

### DIFF
--- a/boot/zephyr/boards/nrf93m1dk_nrf54l15_cpuapp.conf
+++ b/boot/zephyr/boards/nrf93m1dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Ensure that the SPI NOR driver is disabled by default
+CONFIG_SPI_NOR=n
+
+CONFIG_BOOT_WATCHDOG_FEED=n
+
+# Ensure the fastest RRAM write operations
+CONFIG_NRF_RRAM_WRITE_BUFFER_SIZE=32


### PR DESCRIPTION
Add configuration for nrf93m1dk/nrf54l15/cpuapp
to disable SPI which requires kernel.

This is a copy from nrf54l15dk_nrf54l15_cpuapp.conf