### PR TITLE
boot: zephyr: support encrypted images over USB DFU on a single slot

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2017 Open Source Foundries Limited
 # Copyright (c) 2023-2026 Nordic Semiconductor ASA
+# Copyright (c) 2026 Nerijus Bendžiūnas
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -312,6 +313,15 @@ if(CONFIG_MCUBOOT_SERIAL)
       zephyr_sources(boot_serial_extension_zephyr_basic.c)
     endif()
   endif()
+endif()
+
+if(NOT CONFIG_MCUBOOT_SERIAL AND CONFIG_BOOT_ENCRYPT_IMAGE AND
+   (CONFIG_BOOT_USB_DFU_WAIT OR CONFIG_BOOT_USB_DFU_GPIO))
+  zephyr_include_directories(
+    ${BOOT_DIR}/boot_serial/include
+    ${BOOT_DIR}/bootutil/include
+  )
+  zephyr_sources(${BOOT_DIR}/boot_serial/src/boot_serial_encryption.c)
 endif()
 
 if(NOT CONFIG_BOOT_SIGNATURE_TYPE_NONE AND NOT CONFIG_BOOT_BUILTIN_KEY AND NOT

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -338,6 +338,14 @@ if(CONFIG_BOOT_USB_DFU)
   zephyr_sources(usbd_dfu.c)
 endif()
 
+if(NOT CONFIG_MCUBOOT_SERIAL AND CONFIG_BOOT_ENCRYPT_IMAGE AND CONFIG_BOOT_USB_DFU)
+  zephyr_include_directories(
+    ${BOOT_DIR}/boot_serial/include
+    ${BOOT_DIR}/bootutil/include
+  )
+  zephyr_sources(${BOOT_DIR}/boot_serial/src/boot_serial_encryption.c)
+endif()
+
 if(NOT CONFIG_BOOT_SIGNATURE_TYPE_NONE AND NOT CONFIG_BOOT_BUILTIN_KEY AND NOT
   CONFIG_BOOT_SIGNATURE_KEY_FILE STREQUAL "")
 

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -767,7 +767,9 @@ config BOOT_ENCRYPT_IMAGE
 	select BOOT_ENCRYPT_RSA if BOOT_SIGNATURE_TYPE_RSA
 	select BOOT_ENCRYPT_EC256 if BOOT_SIGNATURE_TYPE_ECDSA_P256
 	select BOOT_ENCRYPT_X25519 if BOOT_SIGNATURE_TYPE_ED25519
-	depends on !SINGLE_APPLICATION_SLOT || MCUBOOT_SERIAL
+	depends on !SINGLE_APPLICATION_SLOT || MCUBOOT_SERIAL || \
+		((BOOT_USB_DFU_WAIT || BOOT_USB_DFU_GPIO) && \
+		 (BOOT_VALIDATE_SLOT0 || BOOT_VALIDATE_SLOT0_ONCE))
 	help
 	  If y, images in the secondary slot can be encrypted and are decrypted
 	  on the fly when upgrading to the primary slot, as well as encrypted

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -788,7 +788,8 @@ config BOOT_ENCRYPT_IMAGE
 	select BOOT_ENCRYPT_RSA if BOOT_SIGNATURE_TYPE_RSA
 	select BOOT_ENCRYPT_EC256 if BOOT_SIGNATURE_TYPE_ECDSA_P256
 	select BOOT_ENCRYPT_X25519 if BOOT_SIGNATURE_TYPE_ED25519
-	depends on !SINGLE_APPLICATION_SLOT || MCUBOOT_SERIAL
+	depends on !SINGLE_APPLICATION_SLOT || MCUBOOT_SERIAL || \
+		(BOOT_USB_DFU && (BOOT_VALIDATE_SLOT0 || BOOT_VALIDATE_SLOT0_ONCE))
 	help
 	  If y, images in the secondary slot can be encrypted and are decrypted
 	  on the fly when upgrading to the primary slot, as well as encrypted

--- a/boot/zephyr/single_loader.c
+++ b/boot/zephyr/single_loader.c
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2020 Nordic Semiconductor ASA
  * Copyright (c) 2020 Arm Limited
+ * Copyright (c) 2026 Nerijus Bendžiūnas
  */
 
 #include <assert.h>
@@ -15,6 +16,10 @@
 #include "bootutil/fault_injection_hardening.h"
 
 #include "mcuboot_config/mcuboot_config.h"
+
+#if defined(MCUBOOT_ENC_IMAGES) && defined(MCUBOOT_USB_DFU)
+#include "boot_serial/boot_serial_encryption.h"
+#endif
 
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
@@ -209,7 +214,20 @@ boot_go(struct boot_rsp *rsp)
 #endif
 
 #ifdef MCUBOOT_VALIDATE_PRIMARY_SLOT
+#if defined(MCUBOOT_ENC_IMAGES) && defined(MCUBOOT_USB_DFU)
+    bool primary_encrypted = IS_ENCRYPTED(&_hdr);
+#endif
     FIH_CALL(boot_image_validate, fih_rc, BOOT_IMG_AREA(&state, BOOT_SLOT_PRIMARY), &_hdr);
+#if defined(MCUBOOT_ENC_IMAGES) && defined(MCUBOOT_USB_DFU)
+    if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS) && primary_encrypted) {
+        BOOT_LOG_INF("Primary slot is encrypted; decrypting in place");
+        if (boot_handle_enc_fw(BOOT_IMG_AREA(&state, BOOT_SLOT_PRIMARY)) == 0 &&
+            boot_image_load_header(BOOT_IMG_AREA(&state, BOOT_SLOT_PRIMARY), &_hdr) == 0) {
+            FIH_CALL(boot_image_validate, fih_rc,
+                     BOOT_IMG_AREA(&state, BOOT_SLOT_PRIMARY), &_hdr);
+        }
+    }
+#endif
     if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
 #ifdef MCUBOOT_RAM_LOAD
         boot_remove_image_from_sram(&state);

--- a/boot/zephyr/single_loader.c
+++ b/boot/zephyr/single_loader.c
@@ -16,6 +16,10 @@
 
 #include "mcuboot_config/mcuboot_config.h"
 
+#if defined(MCUBOOT_ENC_IMAGES) && defined(MCUBOOT_USB_DFU)
+#include "boot_serial/boot_serial_encryption.h"
+#endif
+
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 /* Variables passed outside of unit via pointers. */
@@ -209,7 +213,20 @@ boot_go(struct boot_rsp *rsp)
 #endif
 
 #ifdef MCUBOOT_VALIDATE_PRIMARY_SLOT
+#if defined(MCUBOOT_ENC_IMAGES) && defined(MCUBOOT_USB_DFU)
+    bool primary_encrypted = IS_ENCRYPTED(&_hdr);
+#endif
     FIH_CALL(boot_image_validate, fih_rc, BOOT_IMG_AREA(&state, BOOT_SLOT_PRIMARY), &_hdr);
+#if defined(MCUBOOT_ENC_IMAGES) && defined(MCUBOOT_USB_DFU)
+    if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS) && primary_encrypted) {
+        BOOT_LOG_INF("Primary slot is encrypted; decrypting in place");
+        if (boot_handle_enc_fw(BOOT_IMG_AREA(&state, BOOT_SLOT_PRIMARY)) == 0 &&
+            boot_image_load_header(BOOT_IMG_AREA(&state, BOOT_SLOT_PRIMARY), &_hdr) == 0) {
+            FIH_CALL(boot_image_validate, fih_rc,
+                     BOOT_IMG_AREA(&state, BOOT_SLOT_PRIMARY), &_hdr);
+        }
+    }
+#endif
     if (FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
 #ifdef MCUBOOT_RAM_LOAD
         boot_remove_image_from_sram(&state);


### PR DESCRIPTION
With a single application slot MCUboot jumps directly to the primary
slot, so an encrypted image from USB DFU (which, unlike serial recovery,
has no decrypt-on-upload) is never decrypted and faults.

Decrypt during validation: if the primary slot fails validation while
still flagged encrypted, decrypt in place via boot_handle_enc_fw() and
revalidate; an already-decrypted slot passes and is not decrypted again.
This happens on the same boot, right after wait_for_usb_dfu() returns,
so no reboot is needed. Relax the BOOT_ENCRYPT_IMAGE single-slot
dependency for USB DFU, which requires slot validation since that gates
the decrypt, and build boot_serial_encryption.c.