### PR TITLE
boot: zephyr: enter USB DFU indefinitely on retention boot mode

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1137,6 +1137,14 @@ config BOOT_USB_DFU_DETECT_DELAY
 	  Useful for powering on when using the same button as
 	  the one used to place the device in bootloader mode.
 
+config BOOT_USB_DFU_BOOT_MODE
+	bool "Check boot mode via retention subsystem"
+	depends on RETENTION_BOOT_MODE
+	help
+	  Allows for entering USB DFU mode by using Zephyr's boot mode
+	  retention system (i.e. an application must set the boot mode to stay
+	  in USB DFU mode and reboot the module).
+
 config BOOT_USB_DFU_NO_APPLICATION
 	bool "Stay in bootloader if no application"
 	help

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -381,7 +381,8 @@
 #endif
 
 #if (defined(CONFIG_BOOT_USB_DFU_WAIT) || \
-     defined(CONFIG_BOOT_USB_DFU_GPIO))
+     defined(CONFIG_BOOT_USB_DFU_GPIO) || \
+     defined(CONFIG_BOOT_USB_DFU_BOOT_MODE))
 #define MCUBOOT_USB_DFU
 #endif
 

--- a/boot/zephyr/io.c
+++ b/boot/zephyr/io.c
@@ -35,7 +35,8 @@ BOOT_LOG_MODULE_DECLARE(mcuboot);
 #include <zephyr/drivers/hwinfo.h>
 #endif
 
-#if defined(CONFIG_BOOT_SERIAL_BOOT_MODE) || defined(CONFIG_BOOT_FIRMWARE_LOADER_BOOT_MODE)
+#if defined(CONFIG_BOOT_SERIAL_BOOT_MODE) || defined(CONFIG_BOOT_FIRMWARE_LOADER_BOOT_MODE) \
+    || defined(CONFIG_BOOT_USB_DFU_BOOT_MODE)
 #include <zephyr/retention/bootmode.h>
 #endif
 
@@ -196,7 +197,8 @@ bool io_detect_pin_reset(void)
 }
 #endif
 
-#if defined(CONFIG_BOOT_SERIAL_BOOT_MODE) || defined(CONFIG_BOOT_FIRMWARE_LOADER_BOOT_MODE)
+#if defined(CONFIG_BOOT_SERIAL_BOOT_MODE) || defined(CONFIG_BOOT_FIRMWARE_LOADER_BOOT_MODE) \
+    || defined(CONFIG_BOOT_USB_DFU_BOOT_MODE)
 bool io_detect_boot_mode(void)
 {
     int32_t boot_mode;

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -226,7 +226,8 @@ int main(void)
 {
     struct boot_rsp rsp;
     int rc;
-#if defined(CONFIG_BOOT_USB_DFU_GPIO) || defined(CONFIG_BOOT_USB_DFU_WAIT)
+#if defined(CONFIG_BOOT_USB_DFU_GPIO) || defined(CONFIG_BOOT_USB_DFU_WAIT) || \
+    defined(CONFIG_BOOT_USB_DFU_BOOT_MODE)
     bool usb_dfu_requested = false;
     bool usb_dfu_forever = false;
 #endif
@@ -297,7 +298,24 @@ int main(void)
     usb_dfu_requested = true;
 #endif
 
-#if defined(CONFIG_BOOT_USB_DFU_GPIO) || defined(CONFIG_BOOT_USB_DFU_WAIT)
+#if defined(CONFIG_BOOT_USB_DFU_BOOT_MODE)
+    BOOT_LOG_DBG("Checking boot mode for USB DFU request");
+    if (io_detect_boot_mode()) {
+        BOOT_LOG_DBG("Staying in USB DFU");
+
+        usb_dfu_requested = true;
+        usb_dfu_forever = true;
+
+#ifdef CONFIG_MCUBOOT_INDICATION_LED
+        io_led_set(1);
+#endif
+
+        mcuboot_status_change(MCUBOOT_STATUS_USB_DFU_ENTERED);
+    }
+#endif
+
+#if defined(CONFIG_BOOT_USB_DFU_GPIO) || defined(CONFIG_BOOT_USB_DFU_WAIT) || \
+    defined(CONFIG_BOOT_USB_DFU_BOOT_MODE)
     if (usb_dfu_requested) {
         rc = boot_usb_dfu_enable();
         if (rc) {


### PR DESCRIPTION
Adds `BOOT_USB_DFU_BOOT_MODE`, an independent USB DFU entrance method: an
application sets Zephyr's boot mode retention flag and reboots, and the
bootloader stays in USB DFU indefinitely. It mirrors `BOOT_SERIAL_BOOT_MODE`
for serial recovery.