### PR TITLE
boot: bootutil: add PSA Crypto FIH delay RNG implementation

### DIFF
--- a/boot/bootutil/CMakeLists.txt
+++ b/boot/bootutil/CMakeLists.txt
@@ -27,7 +27,6 @@ target_sources(bootutil
         src/caps.c
         src/encrypted.c
         src/fault_injection_hardening.c
-        src/fault_injection_hardening_delay_rng_mbedtls.c
         src/image_ecdsa.c
         src/image_ed25519.c
         src/image_rsa.c
@@ -40,3 +39,13 @@ target_sources(bootutil
         src/ram_load.c
         src/tlv.c
 )
+
+# Select the FIH delay RNG implementation.
+# When the bootloader uses PSA Crypto (CONFIG_BOOT_USE_PSA_CRYPTO), use
+# psa_generate_random() instead of the legacy mbedTLS entropy + CTR-DRBG
+# APIs that were removed in tf-psa-crypto 1.0.
+if(CONFIG_BOOT_USE_PSA_CRYPTO)
+  target_sources(bootutil PRIVATE src/fault_injection_hardening_delay_rng_psa.c)
+else()
+  target_sources(bootutil PRIVATE src/fault_injection_hardening_delay_rng_mbedtls.c)
+endif()

--- a/boot/bootutil/src/fault_injection_hardening_delay_rng_psa.c
+++ b/boot/bootutil/src/fault_injection_hardening_delay_rng_psa.c
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2026 Schneider Electric
+ */
+
+/* PSA Crypto implementation of the FIH delay RNG.
+ *
+ * Replaces fault_injection_hardening_delay_rng_mbedtls.c when the bootloader
+ * uses PSA Crypto as its primary crypto stack (CONFIG_BOOT_USE_PSA_CRYPTO on
+ * Zephyr: BOOT_ECDSA_PSA, BOOT_ED25519_PSA, or BOOT_RSA_PSA).
+ *
+ * tf-psa-crypto 1.0 (mbedTLS 4.x) removed the public mbedTLS entropy and
+ * CTR-DRBG APIs that the mbedTLS implementation relied on.  psa_generate_random()
+ * is the stable, backend-independent replacement.
+ */
+
+#include "bootutil/fault_injection_hardening.h"
+
+#ifdef FIH_ENABLE_DELAY
+
+#include "psa/crypto.h"
+
+int fih_delay_init(void)
+{
+    psa_status_t status = psa_crypto_init();
+
+    return (status == PSA_SUCCESS) ? 1 : 0;
+}
+
+unsigned char fih_delay_random_uchar(void)
+{
+    unsigned char delay = 1U; /* safe non-zero fallback */
+
+    (void)psa_generate_random(&delay, sizeof(delay));
+
+    return delay;
+}
+
+#endif /* FIH_ENABLE_DELAY */

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -118,7 +118,11 @@ endif()
 zephyr_link_libraries(MCUBOOT_BOOTUTIL)
 
 if(CONFIG_BOOT_FIH_PROFILE_HIGH)
-  zephyr_sources(${BOOT_DIR}/bootutil/src/fault_injection_hardening_delay_rng_mbedtls.c)
+  if(CONFIG_BOOT_USE_PSA_CRYPTO)
+    zephyr_sources(${BOOT_DIR}/bootutil/src/fault_injection_hardening_delay_rng_psa.c)
+  else()
+    zephyr_sources(${BOOT_DIR}/bootutil/src/fault_injection_hardening_delay_rng_mbedtls.c)
+  endif()
 endif()
 
 if(CONFIG_SINGLE_APPLICATION_SLOT_RAM_LOAD)


### PR DESCRIPTION
The existing fault_injection_hardening_delay_rng_mbedtls.c relies on the public mbedTLS entropy and CTR-DRBG APIs (mbedtls_entropy_func, mbedtls_ctr_drbg_random, ...) which were made private or removed in tf-psa-crypto 1.0 (mbedTLS 4.x).

Add an equivalent implementation backed by psa_generate_random() which:
 - requires no legacy mbedTLS modules
 - is automatically selected when BOOT_ECDSA_PSA or BOOT_ED25519_PSA is enabled (both imply PSA Crypto is already available)

The selection logic is added to boot/bootutil/CMakeLists.txt and mirrored in boot/zephyr/CMakeLists.txt.