### PR TITLE
boot/zephyr: serial_adapter: batch UART FIFO reads in ISR

### DIFF
--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -137,6 +137,15 @@ config BOOT_SERIAL_MAX_RECEIVE_SIZE
 	  bound keeps the buffer large enough to hold one fragment so that a
 	  misconfiguration fails here rather than silently dropping frames.
 
+config BOOT_SERIAL_UART_RX_BATCH_SIZE
+	int "UART RX batch read size"
+	default 512
+	range 1 1024
+	help
+	  Number of bytes read from the UART FIFO per uart_fifo_read() call
+	  in the serial recovery ISR. Larger values reduce per-call overhead
+	  at the cost of a slightly larger static buffer.
+
 config BOOT_ERASE_PROGRESSIVELY
 	bool "Erase flash progressively when receiving new firmware"
 	default y if SOC_FAMILY_NORDIC_NRF || SOC_FAMILY_NXP_IMXRT

--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -62,6 +62,9 @@ static sys_slist_t avail_queue;
 static sys_slist_t lines_queue;
 
 static uint16_t cur;
+#ifndef CONFIG_BOOT_SERIAL_RAW_PROTOCOL
+static uint8_t rx_batch_buf[CONFIG_BOOT_SERIAL_UART_RX_BATCH_SIZE];
+#endif
 
 static int boot_uart_fifo_getline(char **line);
 static int boot_uart_fifo_init(void);
@@ -184,7 +187,6 @@ static void
 boot_uart_fifo_callback(const struct device *dev, void *user_data)
 {
 	static struct line_input *cmd;
-	uint8_t byte;
 	int rx;
 
 	uart_irq_update(uart_dev);
@@ -194,6 +196,9 @@ boot_uart_fifo_callback(const struct device *dev, void *user_data)
 	}
 
 	while (true) {
+#ifdef CONFIG_BOOT_SERIAL_RAW_PROTOCOL
+		uint8_t byte;
+
 		rx = uart_fifo_read(uart_dev, &byte, 1);
 		if (rx != 1) {
 			break;
@@ -211,7 +216,6 @@ boot_uart_fifo_callback(const struct device *dev, void *user_data)
 			cmd = CONTAINER_OF(node, struct line_input, node);
 		}
 
-#ifdef CONFIG_BOOT_SERIAL_RAW_PROTOCOL
 		cmd->line[cur++] = byte;
 
 		if (cur >= CONFIG_BOOT_MAX_LINE_INPUT_LEN) {
@@ -221,15 +225,42 @@ boot_uart_fifo_callback(const struct device *dev, void *user_data)
 			cmd = NULL;
 		}
 #else
-		if (cur < CONFIG_BOOT_MAX_LINE_INPUT_LEN) {
-			cmd->line[cur++] = byte;
+		rx = uart_fifo_read(uart_dev, rx_batch_buf, sizeof(rx_batch_buf));
+		if (rx <= 0) {
+			break;
 		}
 
-		if (byte ==  '\n') {
-			cmd->len = cur;
-			sys_slist_append(&lines_queue, &cmd->node);
-			cur = 0;
-			cmd = NULL;
+		const uint8_t *p = rx_batch_buf;
+		const uint8_t *batch_end = p + rx;
+
+		while (p < batch_end) {
+			if (!cmd) {
+				sys_snode_t *node;
+
+				node = sys_slist_get(&avail_queue);
+				if (!node) {
+					BOOT_LOG_ERR("Not enough memory to store"
+						     " incoming data!");
+					return;
+				}
+				cmd = CONTAINER_OF(node, struct line_input, node);
+			}
+
+			const uint8_t *nl = memchr(p, '\n', batch_end - p);
+			size_t chunk = nl ? (size_t)(nl - p + 1) : (size_t)(batch_end - p);
+			size_t room = CONFIG_BOOT_MAX_LINE_INPUT_LEN - cur;
+			size_t copy_len = MIN(chunk, room);
+
+			memcpy(&cmd->line[cur], p, copy_len);
+			cur += copy_len;
+			p += chunk;
+
+			if (nl) {
+				cmd->len = cur;
+				sys_slist_append(&lines_queue, &cmd->node);
+				cur = 0;
+				cmd = NULL;
+			}
 		}
 #endif
 	}

--- a/docs/release-notes.d/zephyr-serial-batch-rx.md
+++ b/docs/release-notes.d/zephyr-serial-batch-rx.md
@@ -1,0 +1,6 @@
+- Zephyr: serial recovery UART ISR now reads the FIFO in configurable
+  batches instead of one byte at a time. The batch size is controlled by
+  the new `BOOT_SERIAL_UART_RX_BATCH_SIZE` Kconfig option (default 512).
+  Within each batch, `memchr`/`memcpy` are used to locate line delimiters
+  and copy data, reducing per-byte loop overhead compared to the previous
+  single-byte loop.


### PR DESCRIPTION
Replace the single-byte `uart_fifo_read()` loop in `boot_uart_fifo_callback()` with a configurable batch read. Within each batch, `memchr()` locates the line delimiter and `memcpy()` copies data into the line buffer, reducing per-byte loop overhead compared to the previous approach.

A new Kconfig option `BOOT_SERIAL_UART_RX_BATCH_SIZE` (default 512, range 1-1024) is added to control the read batch size.

The behavior for overlong lines (truncation + CRC failure) is preserved from the original implementation.