### PR TITLE
boot: zephyr: unify USB DFU entrance config with serial recovery

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1050,38 +1050,25 @@ config MCUBOOT_LOG_THREAD_STACK_SIZE
 	help
 	  Set the internal stack size for MCUBoot log processing thread.
 
-menu "USB DFU"
-
-choice BOOT_USB_DFU
-	prompt "USB DFU"
-	default BOOT_USB_DFU_NO
-
-config BOOT_USB_DFU_NO
-	prompt "Disabled"
-
-config BOOT_USB_DFU_WAIT
-	bool "Wait for a prescribed duration to see if USB DFU is invoked"
+menuconfig BOOT_USB_DFU
+	bool "USB DFU"
 	select USB_DEVICE_STACK
 	select USB_DFU_CLASS
 	select IMG_MANAGER
 	select STREAM_FLASH
 	select MULTITHREADING
+	help
+	  If y, enable USB DFU support in the bootloader. Select one or more of
+	  the entrance methods below to control when USB DFU mode is entered.
+
+if BOOT_USB_DFU
+
+config BOOT_USB_DFU_WAIT
+	bool "Wait for a prescribed duration to see if USB DFU is invoked"
 	help
 	  If y, MCUboot waits for a prescribed duration of time to allow
 	  for USB DFU to be invoked. Please note DFU always updates the
 	  slot1 image.
-
-config BOOT_USB_DFU_GPIO
-	bool "Use GPIO to detect whether to trigger DFU mode"
-	select USB_DEVICE_STACK
-	select USB_DFU_CLASS
-	select IMG_MANAGER
-	select STREAM_FLASH
-	select MULTITHREADING
-	help
-	  If y, MCUboot uses GPIO to detect whether to invoke USB DFU.
-
-endchoice
 
 config BOOT_USB_DFU_WAIT_DELAY_MS
 	int "USB DFU wait duration"
@@ -1090,33 +1077,34 @@ config BOOT_USB_DFU_WAIT_DELAY_MS
 	help
 	  Milliseconds to wait for USB DFU to be invoked.
 
-if BOOT_USB_DFU_GPIO
+config BOOT_USB_DFU_GPIO
+	bool "Use GPIO to detect whether to trigger DFU mode"
+	help
+	  If y, MCUboot uses GPIO to detect whether to invoke USB DFU.
 
 config BOOT_USB_DFU_DETECT_DELAY
 	int "Serial detect pin detection delay time [ms]"
+	depends on BOOT_USB_DFU_GPIO
 	default 0
 	help
 	  Used to prevent the bootloader from loading on button press.
 	  Useful for powering on when using the same button as
 	  the one used to place the device in bootloader mode.
 
-endif # BOOT_USB_DFU_GPIO
-
 config BOOT_USB_DFU_NO_APPLICATION
 	bool "Stay in bootloader if no application"
-	depends on !BOOT_USB_DFU_NO
 	help
 	  Allows for entering USB DFU recovery mode if there is no bootable
 	  application that the bootloader can jump to.
 
-endmenu
+endif # BOOT_USB_DFU
 
 rsource "Kconfig.serial_recovery"
 
 config MCUBOOT_INDICATION_LED
 	bool "Turns on LED indication when device is in DFU"
 	select GPIO
-	depends on MCUBOOT_SERIAL || !BOOT_USB_DFU_NO
+	depends on MCUBOOT_SERIAL || BOOT_USB_DFU
 	help
 	  Device device activates the LED while in bootloader mode.
 	  mcuboot-led0 alias must be set in the device's .dts

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -189,6 +189,7 @@ int main(void)
     int rc;
 #if defined(CONFIG_BOOT_USB_DFU_GPIO) || defined(CONFIG_BOOT_USB_DFU_WAIT)
     bool usb_dfu_requested = false;
+    bool usb_dfu_forever = false;
 #endif
     FIH_DECLARE(fih_rc, FIH_FAILURE);
 
@@ -243,6 +244,7 @@ int main(void)
         BOOT_LOG_DBG("Entering USB DFU");
 
         usb_dfu_requested = true;
+        usb_dfu_forever = true;
 
 #ifdef CONFIG_MCUBOOT_INDICATION_LED
         io_led_set(1);
@@ -250,7 +252,9 @@ int main(void)
 
         mcuboot_status_change(MCUBOOT_STATUS_USB_DFU_ENTERED);
     }
-#elif defined(CONFIG_BOOT_USB_DFU_WAIT)
+#endif
+
+#if defined(CONFIG_BOOT_USB_DFU_WAIT)
     usb_dfu_requested = true;
 #endif
 
@@ -262,16 +266,18 @@ int main(void)
         } else {
             BOOT_LOG_INF("Waiting for USB DFU");
 
+            if (usb_dfu_forever) {
+                wait_for_usb_dfu(K_FOREVER);
+                BOOT_LOG_INF("USB DFU wait terminated");
 #if defined(CONFIG_BOOT_USB_DFU_WAIT)
-            BOOT_LOG_DBG("Waiting for USB DFU for %dms", CONFIG_BOOT_USB_DFU_WAIT_DELAY_MS);
-            mcuboot_status_change(MCUBOOT_STATUS_USB_DFU_WAITING);
-            wait_for_usb_dfu(K_MSEC(CONFIG_BOOT_USB_DFU_WAIT_DELAY_MS));
-            BOOT_LOG_INF("USB DFU wait time elapsed");
-            mcuboot_status_change(MCUBOOT_STATUS_USB_DFU_TIMED_OUT);
-#else
-            wait_for_usb_dfu(K_FOREVER);
-            BOOT_LOG_INF("USB DFU wait terminated");
+            } else {
+                BOOT_LOG_DBG("Waiting for USB DFU for %dms", CONFIG_BOOT_USB_DFU_WAIT_DELAY_MS);
+                mcuboot_status_change(MCUBOOT_STATUS_USB_DFU_WAITING);
+                wait_for_usb_dfu(K_MSEC(CONFIG_BOOT_USB_DFU_WAIT_DELAY_MS));
+                BOOT_LOG_INF("USB DFU wait time elapsed");
+                mcuboot_status_change(MCUBOOT_STATUS_USB_DFU_TIMED_OUT);
 #endif
+            }
         }
     }
 #endif


### PR DESCRIPTION
USB DFU was the odd one out: a mutually-exclusive choice (NO/WAIT/GPIO) whose options each repeated the same five USB stack selects. Replace it with a menuconfig parent that holds those selects once and independent WAIT/GPIO entrance bools that can be combined.

Enabling USB DFU now requires CONFIG_BOOT_USB_DFU=y alongside an entrance method, and CONFIG_BOOT_USB_DFU_NO is removed.