### PR TITLE
Fixed compiler warnings in boot_serial

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -278,7 +278,7 @@ bs_list_img_ver(char *dst, int maxlen, struct image_version *ver)
                   (uint16_t)ver->iv_minor, ver->iv_revision);
 
    if (ver->iv_build_num != 0 && len > 0 && len < maxlen) {
-      snprintf(&dst[len], (maxlen - len), ".%u", ver->iv_build_num);
+      snprintf(&dst[len], (maxlen - len), ".%" PRIu32, ver->iv_build_num);
    }
 }
 #endif /* !MCUBOOT_USE_SNPRINTF */
@@ -1497,7 +1497,11 @@ boot_serial_output(void)
 static int
 boot_serial_in_dec(char *in, int inlen, char *out, int *out_off, int maxout)
 {
+#if defined(__ZEPHYR__) || defined(__ESPRESSIF__)
     size_t rc;
+#else
+    int rc;
+#endif
     uint16_t crc;
     uint16_t len;
 

--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -1497,27 +1497,28 @@ boot_serial_output(void)
 static int
 boot_serial_in_dec(char *in, int inlen, char *out, int *out_off, int maxout)
 {
-#if defined(__ZEPHYR__) || defined(__ESPRESSIF__)
-    size_t rc;
-#else
-    int rc;
-#endif
+    int decoded_len;
     uint16_t crc;
     uint16_t len;
 
 #ifdef __ZEPHYR__
+    size_t rc;
     int err;
     err = base64_decode( &out[*out_off], maxout - *out_off, &rc, in, inlen - 2);
     if (err) {
         return -1;
     }
+    decoded_len = (int)rc;
 #elif __ESPRESSIF__
+    size_t rc;
     int err;
     err = base64_decode((unsigned char *)&out[*out_off], maxout - *out_off, &rc, (unsigned char *)in, inlen);
     if (err) {
         return -1;
     }
+    decoded_len = (int)rc;
 #else
+    int rc;
     if (*out_off + base64_decode_len(in) >= maxout) {
         return -1;
     }
@@ -1525,9 +1526,10 @@ boot_serial_in_dec(char *in, int inlen, char *out, int *out_off, int maxout)
     if (rc < 0) {
         return -1;
     }
+    decoded_len = rc;
 #endif
 
-    *out_off += rc;
+    *out_off += decoded_len;
     if (*out_off <= sizeof(uint16_t)) {
         return 0;
     }


### PR DESCRIPTION
- Switched the build-number format from %u to %" PRIu32 " for uint32_t.
- Made rc type `size_t` only for Zephyr/ESP base64 APIs, and `int` for the fallback decoder.

This last one may worth some thinking (from the code owner?) as it looks a bit off having to use a var with different types depending on the platform...

Closes #2753 