### PR TITLE
boot/bootutil/crypto: unconditionally read out rfc3447 version field

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/rsa.h
+++ b/boot/bootutil/include/bootutil/crypto/rsa.h
@@ -237,12 +237,15 @@ bootutil_rsa_parse_private_key(bootutil_rsa_context *ctx, uint8_t **p, uint8_t *
         return -2;
     }
 
-#if !defined(TF_PSA_CRYPTO_VERSION_NUMBER)
+    int dummy;
+    int* version = &dummy;
     /* version - "ver" field was removed from RSA structure starting from TF-PSA-Crypto. */
-    if (mbedtls_asn1_get_int(p, end, &ctx->MBEDTLS_CONTEXT_MEMBER(ver)) != 0) {
+#if !defined(TF_PSA_CRYPTO_VERSION_NUMBER)
+    version = &ctx->MBEDTLS_CONTEXT_MEMBER(ver);
+#endif /* !TF_PSA_CRYPTO_VERSION_NUMBER */
+    if (mbedtls_asn1_get_int(p, end, version) != 0) {
         return -3;
     }
-#endif /* !TF_PSA_CRYPTO_VERSION_NUMBER */
 
     /* Non-optional fields. */
     if ( /* public modulus */


### PR DESCRIPTION
Commit d1829aa4ef5e76cc5763f90f8c69d6a19802eeb5 (see #2693) introduced a bug that makes it possible to skip reading the version field, causing its value to be read into the public modulus field instead which makes `rsa_check_context` fail when attempting to use the key. This commit makes the reading part unconditional, keeping the conditional check for the version value's destination.