### PR TITLE
boot_serial: register serial_encryption log module

### DIFF
--- a/boot/boot_serial/src/boot_serial_encryption.c
+++ b/boot/boot_serial/src/boot_serial_encryption.c
@@ -16,7 +16,7 @@
 #include "bootutil/bootutil_public.h"
 #include "bootutil/fault_injection_hardening.h"
 
-BOOT_LOG_MODULE_DECLARE(serial_encryption);
+BOOT_LOG_MODULE_REGISTER(serial_encryption);
 
 fih_ret
 boot_image_validate_encrypted(struct boot_loader_state *state,


### PR DESCRIPTION
### Summary

`boot_serial_encryption.c` declares its log module with
`BOOT_LOG_MODULE_DECLARE(serial_encryption)`, which *references* a module without
defining it. No other translation unit registers a `serial_encryption` module
(`git grep MODULE_REGISTER\(serial_encryption\)` returns nothing), so the symbol
`log_const_serial_encryption` is never emitted.

### Symptom

A build with `MCUBOOT_ENC_IMAGES` and a real (e.g. deferred) logging backend fails
to link:

```
undefined reference to `log_const_serial_encryption'
```

This stays latent in configurations where the logging macros expand to nothing,
which is why default CI configs don't surface it — it appears once encrypted
images and an active log backend are combined (e.g. serial recovery of encrypted
images with `CONFIG_LOG_MODE_DEFERRED`).

### Fix

`boot_serial_encryption.c` is the sole user of the `serial_encryption` module, so
it should *register* it rather than *declare* it. One-line change:
`BOOT_LOG_MODULE_DECLARE` → `BOOT_LOG_MODULE_REGISTER`.

### Testing

Builds an encrypted-image + serial-recovery bootloader (ECDSA-P384, ECIES image
encryption, `CONFIG_LOG_MODE_DEFERRED`, SWO backend) that previously failed to
link now link cleanly. No functional/logging behavior change in configs where the
module was already effectively unused.

Signed-off-by: Jay Beavers <jay@tolttechnologies.com>