### PR TITLE
boot: bootutil: skip redundant primary validation on boot with MCUBOOT_BOOTSTRAP

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1553,17 +1553,33 @@ boot_prepare_image_for_update(struct boot_loader_state *state,
 
 #ifdef MCUBOOT_BOOTSTRAP
             if (BOOT_SWAP_TYPE(state) == BOOT_SWAP_TYPE_NONE) {
-                /* Header checks are done first because they are
-                 * inexpensive. Since overwrite-only copies starting from
-                 * offset 0, if interrupted, it might leave a valid header
-                 * magic, so also run validation on the primary slot to be
-                 * sure it's not OK.
+#ifdef MCUBOOT_OVERWRITE_ONLY
+                /* Overwrite-only copies start at offset 0, so an interrupted
+                 * copy can leave a valid header magic over an incomplete image.
+                 * Validate the primary slot to detect and re-copy that case.
                  */
                 FIH_CALL(boot_validate_slot, fih_rc,
                          state, BOOT_SLOT_PRIMARY, bs, 0);
                 if (boot_check_header_erased(state, BOOT_SLOT_PRIMARY) ||
-                    FIH_NOT_EQ(fih_rc, FIH_SUCCESS)) {
-
+                    FIH_NOT_EQ(fih_rc, FIH_SUCCESS))
+#else
+                /* This branch runs only when there is no partial swap to
+                 * resume (boot_status_is_reset() is true); any interrupted swap
+                 * was already finished by boot_complete_partial_swap() above.
+                 * Gate bootstrap on the cheap header sanity check instead of a
+                 * full signature verify: a primary that is erased or whose
+                 * header is corrupt is (re-)bootstrapped from the secondary,
+                 * which is itself validated below before any copy, while a
+                 * structurally valid primary is left as-is. This skips the
+                 * primary-slot public-key verify that otherwise runs on every
+                 * normal boot even for a valid, confirmed primary (and even
+                 * when MCUBOOT_VALIDATE_PRIMARY_SLOT is disabled). With a
+                 * validated secondary still present (e.g. the swapped-out image
+                 * after an update), that verify can dominate boot time.
+                 */
+                if (!boot_check_header_valid(state, BOOT_SLOT_PRIMARY))
+#endif
+                {
                     rc = (boot_img_hdr(state, BOOT_SLOT_SECONDARY)->ih_magic == IMAGE_MAGIC) ? 1: 0;
                     FIH_CALL(boot_validate_slot, fih_rc,
                              state, BOOT_SLOT_SECONDARY, bs, 0);


### PR DESCRIPTION
With MCUBOOT_BOOTSTRAP, boot_prepare_image_for_update() runs a full
boot_validate_slot() on the primary slot on every boot (when the swap type is
NONE) to decide whether to bootstrap an image from the secondary slot. For a
signed image that is a public-key signature verification, and it runs on every
normal boot even when the primary already holds a valid, confirmed image, and
even when MCUBOOT_VALIDATE_PRIMARY_SLOT is disabled. On a Cortex-M33 with
ECDSA-P384/SHA-384 and FIH_PROFILE_HIGH this added ~14 s to every boot.

The validation guards against a primary that is present but invalid. That can
only arise here for MCUBOOT_OVERWRITE_ONLY: overwrite-only copies start at
offset 0, so an interrupted copy can leave a valid header magic over an
incomplete image. Swap-based modes cannot reach this point in that state: this
block runs only in the no-partial-swap branch (boot_status_is_reset()), and any
interrupted swap has already been finished by boot_complete_partial_swap() in
the sibling branch, so the primary here is settled -- a valid image or an
erased slot.

Keep the full validation for MCUBOOT_OVERWRITE_ONLY. For swap-based modes gate
bootstrap on the cheap boot_check_header_erased() check instead: a present
primary is bootable and needs no re-validation here, and an erased primary is
still bootstrapped from a validated secondary as before. The per-mode #ifdef
keeps the FIH_NOT_EQ() comparison inline rather than laundering a
fault-injection result through a bool.

Fixes #2781

### Testing
- Validated on hardware (nRF5340, swap-using-offset, ECDSA-P384/SHA-384, FIH_PROFILE_HIGH): boot drops from ~15 s to sub-second; empty-slot-0 bootstrap recovery still works.
- `MCUBOOT_OVERWRITE_ONLY` path is unchanged.
- Not yet run against the mcuboot simulator matrix — guidance welcome on which bootstrap × {overwrite-only, swap} sim configs to cover.
