### PR TITLE
boot: bootutil: loader: Fix bootstrap with swap using offset

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -934,7 +934,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
     const struct flash_area *fap_secondary_slot;
     uint8_t image_index;
 
-#if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
+#if defined(MCUBOOT_OVERWRITE_ONLY_FAST) || defined(MCUBOOT_SWAP_USING_MOVE) || defined(MCUBOOT_SWAP_USING_OFFSET)
     uint32_t sector;
     uint32_t trailer_sz;
     uint32_t off;
@@ -943,7 +943,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
 
     (void)bs;
 
-#if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
+#if defined(MCUBOOT_OVERWRITE_ONLY_FAST) || defined(MCUBOOT_SWAP_USING_MOVE) || defined(MCUBOOT_SWAP_USING_OFFSET)
     uint32_t src_size = 0;
     rc = boot_read_image_size(state, BOOT_SLOT_SECONDARY, &src_size);
     assert(rc == 0);
@@ -966,7 +966,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
         rc = boot_erase_region(fap_primary_slot, size, this_size, false);
         assert(rc == 0);
 
-#if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
+#if defined(MCUBOOT_OVERWRITE_ONLY_FAST) || defined(MCUBOOT_SWAP_USING_MOVE) || defined(MCUBOOT_SWAP_USING_OFFSET)
         if ((size + this_size) >= src_size) {
             size += src_size - size;
             size += BOOT_WRITE_SZ(state) - (size % BOOT_WRITE_SZ(state));
@@ -977,28 +977,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
         size += this_size;
     }
 
-#if defined(MCUBOOT_SWAP_USING_MOVE)
-    /* When using MCUBOOT_SWAP_USING_MOVE, primary region is larger then the secondary region
-     * Optimal region configuration: # useful regions in primary region = # regions in secondary region + 1
-     * This means that we have to use the size of the secondary region (so without the swap sector)
-     */
-    sect_count = boot_img_num_sectors(state, BOOT_SLOT_SECONDARY);
-    for (sect = 0, size = 0; sect < sect_count; sect++) {
-        this_size = boot_img_sector_size(state, BOOT_SLOT_SECONDARY, sect);
-
-#if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
-        if ((size + this_size) >= src_size) {
-            size += src_size - size;
-            size += BOOT_WRITE_SZ(state) - (size % BOOT_WRITE_SZ(state));
-            break;
-        }
-#endif
-
-        size += this_size;
-    }
-#endif
-
-#if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
+#if defined(MCUBOOT_OVERWRITE_ONLY_FAST) || defined(MCUBOOT_SWAP_USING_MOVE) || defined(MCUBOOT_SWAP_USING_OFFSET)
     trailer_sz = boot_trailer_sz(BOOT_WRITE_SZ(state));
     sector = boot_img_num_sectors(state, BOOT_SLOT_PRIMARY) - 1;
     sz = 0;
@@ -1039,7 +1018,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
         return rc;
     }
 
-#if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
+#if defined(MCUBOOT_OVERWRITE_ONLY_FAST) || defined(MCUBOOT_SWAP_USING_MOVE) || defined(MCUBOOT_SWAP_USING_OFFSET)
     rc = boot_write_magic(fap_primary_slot);
     if (rc != 0) {
         return rc;
@@ -1065,7 +1044,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
     }
 #endif /* MCUBOOT_HW_ROLLBACK_PROT */
 
-#ifndef MCUBOOT_OVERWRITE_ONLY_KEEP_BACKUP
+#if !defined(MCUBOOT_OVERWRITE_ONLY_KEEP_BACKUP) && !defined(MCUBOOT_SWAP_USING_MOVE) && !defined(MCUBOOT_SWAP_USING_OFFSET)
     /*
      * Erases header and trailer. The trailer is erased because when a new
      * image is written without a trailer as is the case when using newt, the

--- a/docs/release-notes.d/bootstrap-swap-offset.md
+++ b/docs/release-notes.d/bootstrap-swap-offset.md
@@ -1,0 +1,4 @@
+- Fixed various issues with bootstrap in swap modes whereby it
+  could read from beyond the flash area, erase (or not) erase
+  sectors, and whereby it would pointlessly copy the entire
+  slot instead of just copying the image data.

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -77,7 +77,10 @@ fn main() {
 
     if bootstrap {
         conf.conf.define("MCUBOOT_BOOTSTRAP", None);
-        conf.conf.define("MCUBOOT_OVERWRITE_ONLY_FAST", None);
+
+        if !swap_offset && !swap_move {
+            conf.conf.define("MCUBOOT_OVERWRITE_ONLY_FAST", None);
+        }
     }
 
     if check_load_addr {


### PR DESCRIPTION
    Fixes an issue when bootstrap is used to load an image in swap
    using offset mode whereby the copy size was not reduced to account
    for the swap sector
