### PR TITLE
ci: fih: add workflow to build FIH docker image

### DIFF
--- a/.github/workflows/fih_docker_build.yaml
+++ b/.github/workflows/fih_docker_build.yaml
@@ -1,0 +1,39 @@
+on:
+  workflow_dispatch:
+
+name: Build FIH Docker Image
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+        submodules: false
+
+    - name: Load image config
+      run: |
+        source ./ci/fih-tests_config.sh
+        echo "FIH_IMAGE_NAME=$FIH_IMAGE_NAME" >> $GITHUB_ENV
+        echo "FIH_IMAGE_VERSION=$FIH_IMAGE_VERSION" >> $GITHUB_ENV
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Authenticate to GH Container Registry
+      uses: docker/login-action@v4
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v7
+      with:
+        context: ci/fih_test_docker/docker-build
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/${{ env.FIH_IMAGE_NAME }}:${{ env.FIH_IMAGE_VERSION }}


### PR DESCRIPTION
Add a manually triggered workflow to build the docker image for the FIH tests and push it to the GitHub Container Registry. This facilitates updating the FIH tests in the future without having to manually build and push the docker image.