### PR TITLE
boot: bootutil: Change assert() calls to ASSERT()

### DIFF
--- a/boot/bootutil/src/bootutil_loader.c
+++ b/boot/bootutil/src/bootutil_loader.c
@@ -56,7 +56,7 @@ boot_check_header_erased(struct boot_loader_state *state, int slot)
     struct image_header *hdr;
 
     fap = BOOT_IMG_AREA(state, slot);
-    assert(fap != NULL);
+    ASSERT(fap != NULL);
 
     hdr = boot_img_hdr(state, slot);
     if (bootutil_buffer_is_erased(fap, &hdr->ih_magic, sizeof(hdr->ih_magic))) {
@@ -74,7 +74,7 @@ boot_check_header_valid(struct boot_loader_state *state, int slot)
     uint32_t size;
 
     fap = BOOT_IMG_AREA(state, slot);
-    assert(fap != NULL);
+    ASSERT(fap != NULL);
 
     hdr = boot_img_hdr(state, slot);
     if (hdr->ih_magic != IMAGE_MAGIC) {
@@ -167,7 +167,7 @@ boot_check_image(struct boot_loader_state *state, struct boot_status *bs, int sl
     struct image_header *hdr;
 
     fap = BOOT_IMG_AREA(state, slot);
-    assert(fap != NULL);
+    ASSERT(fap != NULL);
 
     hdr = boot_img_hdr(state, slot);
 
@@ -255,7 +255,7 @@ boot_update_security_counter(struct boot_loader_state *state, int slot, int hdr_
     int rc;
 
     fap = BOOT_IMG_AREA(state, slot);
-    assert(fap != NULL);
+    ASSERT(fap != NULL);
 
     rc = bootutil_get_img_security_cnt(state, hdr_slot_idx, fap, &img_security_cnt);
     if (rc != 0) {
@@ -328,7 +328,7 @@ boot_open_all_flash_areas(struct boot_loader_state *state)
         for (slot = 0; slot < BOOT_NUM_SLOTS; slot++) {
             fa_id = flash_area_id_from_multi_image_slot(image_index, slot);
             rc = flash_area_open(fa_id, &BOOT_IMG_AREA(state, slot));
-            assert(rc == 0);
+            ASSERT(rc == 0);
 
             if (rc != 0) {
                 BOOT_LOG_ERR("Failed to open flash area ID %d (image %d slot %zu): %d",
@@ -340,7 +340,7 @@ boot_open_all_flash_areas(struct boot_loader_state *state)
 
 #if MCUBOOT_SWAP_USING_SCRATCH
     rc = flash_area_open(FLASH_AREA_IMAGE_SCRATCH, &BOOT_SCRATCH_AREA(state));
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
     if (rc != 0) {
         BOOT_LOG_ERR("Failed to open scratch flash area: %d", rc);

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -137,7 +137,7 @@ boot_status_off(const struct flash_area *fap)
     }
 #endif
 
-    assert(off_from_end <= flash_area_get_size(fap));
+    ASSERT(off_from_end <= flash_area_get_size(fap));
     return flash_area_get_size(fap) - off_from_end;
 }
 
@@ -389,10 +389,10 @@ boot_read_image_size(struct boot_loader_state *state, int slot, uint32_t *size)
     uint32_t protect_tlv_size;
     int rc;
 
-    assert(slot == BOOT_SLOT_PRIMARY || slot == BOOT_SLOT_SECONDARY);
+    ASSERT(slot == BOOT_SLOT_PRIMARY || slot == BOOT_SLOT_SECONDARY);
 
     fap = BOOT_IMG_AREA(state, slot);
-    assert(fap != NULL);
+    ASSERT(fap != NULL);
 
     off = BOOT_TLV_OFF(boot_img_hdr(state, slot));
 

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -357,7 +357,7 @@ boot_write_trailer(const struct flash_area *fap, uint32_t off,
     align = ALIGN_UP(inlen, align);
     if (align > BOOT_MAX_ALIGN) {
         /* This should never happen */
-        assert(0);
+        ASSERT(0);
         return -1;
     }
     erased_val = flash_area_erased_val(fap);
@@ -585,7 +585,7 @@ boot_set_next(const struct flash_area *fa, bool active, bool confirm)
 
     default:
         /* Something is not OK, this should never happen */
-        assert(0);
+        ASSERT(0);
         rc = BOOT_EBADIMAGE;
     }
 
@@ -654,7 +654,7 @@ boot_set_next(const struct flash_area *fa, bool active, bool confirm)
 
     default:
         /* Something is not OK, this should never happen */
-        assert(0);
+        ASSERT(0);
         rc = BOOT_EBADSTATUS;
     }
 

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -440,7 +440,7 @@ boot_decrypt_key(const uint8_t *buf, uint8_t *enckey)
 
 #if defined(MCUBOOT_ENCRYPT_KW)
 
-    assert(*bootutil_enc_key->len == BOOT_ENC_KEY_SIZE);
+    ASSERT(*bootutil_enc_key->len == BOOT_ENC_KEY_SIZE);
     rc = key_unwrap(buf, enckey, bootutil_enc_key);
 
 #endif /* defined(MCUBOOT_ENCRYPT_KW) */
@@ -688,7 +688,7 @@ boot_enc_encrypt(struct enc_key_data *enc, uint32_t off,
     nonce[14] = (uint8_t)(off >> 8);
     nonce[15] = (uint8_t)off;
 
-    assert(enc->valid == 1);
+    ASSERT(enc->valid == 1);
     bootutil_aes_ctr_encrypt(&enc->aes_ctr, nonce, buf, sz, blk_off, buf);
 }
 
@@ -710,7 +710,7 @@ boot_enc_decrypt(struct enc_key_data *enc, uint32_t off,
     nonce[14] = (uint8_t)(off >> 8);
     nonce[15] = (uint8_t)off;
 
-    assert(enc->valid == 1);
+    ASSERT(enc->valid == 1);
     bootutil_aes_ctr_decrypt(&enc->aes_ctr, nonce, buf, sz, blk_off, buf);
 }
 

--- a/boot/bootutil/src/encrypted_psa.c
+++ b/boot/bootutil/src/encrypted_psa.c
@@ -212,7 +212,7 @@ void bootutil_aes_ctr_init(bootutil_aes_ctr_context *ctx)
 
     if (psa_ret != PSA_SUCCESS) {
         BOOT_LOG_ERR("AES init PSA crypto init failed %d", psa_ret);
-        assert(0);
+        ASSERT(0);
     }
 
     ctx->key = PSA_KEY_ID_NULL;
@@ -228,7 +228,7 @@ void bootutil_aes_ctr_drop(bootutil_aes_ctr_context *ctx)
          * either because it is invalid key number or something is really
          * wrong; either way we have no way to recover.
          */
-        assert(0);
+        ASSERT(0);
     }
 
     ctx->key = PSA_KEY_ID_NULL;

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -306,7 +306,7 @@ boot_verify_slot_dependencies(struct boot_loader_state *state, uint32_t slot)
     int rc;
 
     fap = BOOT_IMG_AREA(state, slot);
-    assert(fap != NULL);
+    ASSERT(fap != NULL);
 
     BOOT_LOG_DBG("boot_verify_slot_dependencies");
 #if defined(MCUBOOT_SWAP_USING_OFFSET)
@@ -553,7 +553,7 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
 #endif
 
     fap = BOOT_IMG_AREA(state, slot);
-    assert(fap != NULL);
+    ASSERT(fap != NULL);
 
     hdr = boot_img_hdr(state, slot);
     if (boot_check_header_erased(state, slot) || (hdr->ih_flags & IMAGE_F_NON_BOOTABLE)) {
@@ -576,7 +576,7 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
                 boot_swap_type_multi(BOOT_CURR_IMG(state)) == BOOT_SWAP_TYPE_REVERT) {
                 const struct flash_area *fap_pri = BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY);
 
-                assert(fap_pri != NULL);
+                ASSERT(fap_pri != NULL);
 
                 if (swap_scramble_trailer_sectors(state, fap_pri) == 0) {
                     BOOT_LOG_INF("Cleared image %d primary slot trailer due to stuck revert",
@@ -946,7 +946,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
 #if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
     uint32_t src_size = 0;
     rc = boot_read_image_size(state, BOOT_SLOT_SECONDARY, &src_size);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 #endif
 
     image_index = BOOT_CURR_IMG(state);
@@ -955,16 +955,16 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
     BOOT_LOG_INF("Erasing the primary slot");
 
     fap_primary_slot = BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY);
-    assert(fap_primary_slot != NULL);
+    ASSERT(fap_primary_slot != NULL);
 
     fap_secondary_slot = BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY);
-    assert(fap_secondary_slot != NULL);
+    ASSERT(fap_secondary_slot != NULL);
 
     sect_count = boot_img_num_sectors(state, BOOT_SLOT_PRIMARY);
     for (sect = 0, size = 0; sect < sect_count; sect++) {
         this_size = boot_img_sector_size(state, BOOT_SLOT_PRIMARY, sect);
         rc = boot_erase_region(fap_primary_slot, size, this_size, false);
-        assert(rc == 0);
+        ASSERT(rc == 0);
 
 #if defined(MCUBOOT_OVERWRITE_ONLY_FAST)
         if ((size + this_size) >= src_size) {
@@ -1009,7 +1009,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
     } while (sz < trailer_sz);
 
     rc = boot_erase_region(fap_primary_slot, off, sz, false);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 #endif
 
 #ifdef MCUBOOT_ENC_IMAGES
@@ -1075,7 +1075,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
     rc = boot_scramble_region(fap_secondary_slot,
                               boot_img_sector_off(state, BOOT_SLOT_SECONDARY, 0),
                               boot_img_sector_size(state, BOOT_SLOT_SECONDARY, 0), false);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 #endif
 
     last_sector = boot_img_num_sectors(state, BOOT_SLOT_SECONDARY) - 1;
@@ -1085,7 +1085,7 @@ boot_copy_image(struct boot_loader_state *state, struct boot_status *bs)
                                     last_sector),
                               boot_img_sector_size(state, BOOT_SLOT_SECONDARY,
                                     last_sector), false);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
     /* TODO: Perhaps verify the primary slot's signature again? */
 
@@ -1132,18 +1132,18 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
         hdr = boot_img_hdr(state, BOOT_SLOT_PRIMARY);
         if (hdr->ih_magic == IMAGE_MAGIC) {
             rc = boot_read_image_size(state, BOOT_SLOT_PRIMARY, &copy_size);
-            assert(rc == 0);
+            ASSERT(rc == 0);
         }
 
 #ifdef MCUBOOT_ENC_IMAGES
         if (IS_ENCRYPTED(hdr)) {
             fap = BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY);
             rc = boot_enc_load(state, BOOT_SLOT_PRIMARY, hdr, fap, bs);
-            assert(rc >= 0);
+            ASSERT(rc >= 0);
 
             if (rc == 0) {
                 rc = boot_enc_set_key(BOOT_CURR_ENC_SLOT(state, BOOT_SLOT_PRIMARY), bs->enckey[BOOT_SLOT_PRIMARY]);
-                assert(rc == 0);
+                ASSERT(rc == 0);
             } else {
                 rc = 0;
             }
@@ -1155,7 +1155,7 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
         hdr = boot_img_hdr(state, BOOT_SLOT_SECONDARY);
         if (hdr->ih_magic == IMAGE_MAGIC) {
             rc = boot_read_image_size(state, BOOT_SLOT_SECONDARY, &size);
-            assert(rc == 0);
+            ASSERT(rc == 0);
         }
 
 #ifdef MCUBOOT_ENC_IMAGES
@@ -1163,11 +1163,11 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
         if (IS_ENCRYPTED(hdr)) {
             fap = BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY);
             rc = boot_enc_load(state, BOOT_SLOT_SECONDARY, hdr, fap, bs);
-            assert(rc >= 0);
+            ASSERT(rc >= 0);
 
             if (rc == 0) {
                 rc = boot_enc_set_key(BOOT_CURR_ENC_SLOT(state, BOOT_SLOT_SECONDARY), bs->enckey[BOOT_SLOT_SECONDARY]);
-                assert(rc == 0);
+                ASSERT(rc == 0);
             } else {
                 rc = 0;
             }
@@ -1188,9 +1188,9 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
          */
 
         fap = boot_find_status(state, image_index);
-        assert(fap != NULL);
+        ASSERT(fap != NULL);
         rc = boot_read_swap_size(fap, &bs->swap_size);
-        assert(rc == 0);
+        ASSERT(rc == 0);
 
         copy_size = bs->swap_size;
 
@@ -1259,7 +1259,7 @@ boot_perform_update(struct boot_loader_state *state, struct boot_status *bs)
 #else
         rc = boot_swap_image(state, bs);
 #endif
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
 #ifndef MCUBOOT_OVERWRITE_ONLY
     /* The following state needs image_ok be explicitly set after the
@@ -1322,7 +1322,7 @@ boot_complete_partial_swap(struct boot_loader_state *state,
      * `swap-type` trailer field.
      */
     rc = boot_swap_image(state, bs);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
     BOOT_SWAP_TYPE(state) = bs->swap_type;
 
@@ -1346,7 +1346,7 @@ boot_complete_partial_swap(struct boot_loader_state *state,
 
     if (BOOT_SWAP_TYPE(state) == BOOT_SWAP_TYPE_PANIC) {
         BOOT_LOG_ERR("panic!");
-        assert(0);
+        ASSERT(0);
 
         /* Loop forever... */
         while (1) {}
@@ -1506,13 +1506,13 @@ boot_prepare_image_for_update(struct boot_loader_state *state,
             /* Should never arrive here, overwrite-only mode has
              * no swap state.
              */
-            assert(0);
+            ASSERT(0);
 #else
             /* Determine the type of swap operation being resumed from the
              * `swap-type` trailer field.
              */
             rc = boot_complete_partial_swap(state, bs);
-            assert(rc == 0);
+            ASSERT(rc == 0);
 #endif
             /* Attempt to read an image header from each slot. Ensure that image headers in slots
              * are aligned with headers in boot_data.
@@ -1529,7 +1529,7 @@ boot_prepare_image_for_update(struct boot_loader_state *state,
              * as boot status.
              */
             rc = boot_read_image_headers(state, false, NULL);
-            assert(rc == 0);
+            ASSERT(rc == 0);
 
             /* Swap has finished set to NONE */
             BOOT_SWAP_TYPE(state) = BOOT_SWAP_TYPE_NONE;
@@ -1838,7 +1838,7 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
             {
                 rc = boot_perform_update(state, &bs);
             }
-            assert(rc == 0);
+            ASSERT(rc == 0);
             break;
 
         case BOOT_SWAP_TYPE_FAIL:
@@ -1861,7 +1861,7 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
 
         if (BOOT_SWAP_TYPE(state) == BOOT_SWAP_TYPE_PANIC) {
             BOOT_LOG_ERR("panic!");
-            assert(0);
+            ASSERT(0);
 
             /* Loop forever... */
             FIH_PANIC;
@@ -1991,11 +1991,11 @@ split_go(int loader_slot, int split_slot, void **entry)
     loader_flash_id = flash_area_id_from_image_slot(loader_slot);
     rc = flash_area_open(loader_flash_id,
                          &BOOT_IMG_AREA(&boot_data, loader_slot));
-    assert(rc == 0);
+    ASSERT(rc == 0);
     split_flash_id = flash_area_id_from_image_slot(split_slot);
     rc = flash_area_open(split_flash_id,
                          &BOOT_IMG_AREA(&boot_data, split_slot));
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
     /* Determine the sector layout of the image slots and scratch area. */
     rc = boot_read_sectors(&boot_data, sectors);
@@ -2174,13 +2174,13 @@ boot_select_or_erase(struct boot_loader_state *state)
     active_slot = state->slot_usage[BOOT_CURR_IMG(state)].active_slot;
 
     fap = BOOT_IMG_AREA(state, active_slot);
-    assert(fap != NULL);
+    ASSERT(fap != NULL);
 
     active_swap_state = &(state->slot_usage[BOOT_CURR_IMG(state)].swap_state);
 
     memset(active_swap_state, 0, sizeof(struct boot_swap_state));
     rc = boot_read_swap_state(fap, active_swap_state);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
     if (active_swap_state->magic != BOOT_MAGIC_GOOD ||
         (active_swap_state->copy_done == BOOT_FLAG_SET &&
@@ -2193,7 +2193,7 @@ boot_select_or_erase(struct boot_loader_state *state)
         BOOT_LOG_DBG("Erasing faulty image in the %s slot.",
                      (active_slot == BOOT_SLOT_PRIMARY) ? "primary" : "secondary");
         rc = boot_scramble_region(fap, 0, flash_area_get_size(fap), false);
-        assert(rc == 0);
+        ASSERT(rc == 0);
         rc = -1;
     } else {
         if (active_swap_state->copy_done != BOOT_FLAG_SET) {

--- a/boot/bootutil/src/ram_load.c
+++ b/boot/bootutil/src/ram_load.c
@@ -141,7 +141,7 @@ boot_decrypt_and_copy_image_to_sram(struct boot_loader_state *state,
     uint8_t * ram_dst = (void *)(IMAGE_RAM_BASE + img_dst);
 
     fap_src = BOOT_IMG_AREA(state, slot);
-    assert(fap_src != NULL);
+    ASSERT(fap_src != NULL);
 
     tlv_off = BOOT_TLV_OFF(hdr);
 
@@ -213,7 +213,7 @@ boot_copy_image_to_sram(struct boot_loader_state *state, int slot,
 #endif
 
     fap_src = BOOT_IMG_AREA(state, slot);
-    assert(fap_src != NULL);
+    ASSERT(fap_src != NULL);
 
     /* Direct copy from flash to its new location in SRAM. */
     rc = flash_area_read(fap_src, 0, (void *)(IMAGE_RAM_BASE + img_dst), img_sz);
@@ -415,7 +415,7 @@ boot_remove_image_from_flash(struct boot_loader_state *state, uint32_t slot)
     BOOT_LOG_INF("Removing image %d slot %d from flash", BOOT_CURR_IMG(state),
                                                          slot);
     fap = BOOT_IMG_AREA(state, slot);
-    assert(fap != NULL);
+    ASSERT(fap != NULL);
 
     return boot_scramble_slot(fap, slot);
 }

--- a/boot/bootutil/src/swap_misc.c
+++ b/boot/bootutil/src/swap_misc.c
@@ -63,7 +63,7 @@ swap_erase_trailer_sectors(const struct boot_loader_state *state,
             uint32_t off = boot_img_sector_off(state, slot, sector);
 
             rc = boot_erase_region(fap, off, sz, false);
-            assert(rc == 0);
+            ASSERT(rc == 0);
 
             sector--;
             total_sz += sz;
@@ -122,26 +122,26 @@ swap_status_init(const struct boot_loader_state *state,
 
     rc = boot_read_swap_state(state->imgs[image_index][BOOT_SLOT_SECONDARY].area,
                               &swap_state);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
     if (bs->swap_type != BOOT_SWAP_TYPE_NONE) {
         rc = boot_write_swap_info(fap, bs->swap_type, image_index);
-        assert(rc == 0);
+        ASSERT(rc == 0);
     }
 
     if (swap_state.image_ok == BOOT_FLAG_SET) {
         rc = boot_write_image_ok(fap);
-        assert(rc == 0);
+        ASSERT(rc == 0);
     }
 
     rc = boot_write_swap_size(fap, bs->swap_size);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
 #ifdef MCUBOOT_SWAP_USING_OFFSET
     rc = boot_write_unprotected_tlv_sizes(fap,
                                    BOOT_IMG_UNPROTECTED_TLV_SIZE(state, BOOT_SLOT_PRIMARY),
                                    BOOT_IMG_UNPROTECTED_TLV_SIZE(state, BOOT_SLOT_SECONDARY));
-    assert(rc == 0);
+    ASSERT(rc == 0);
 #endif
 
 #ifdef MCUBOOT_ENC_IMAGES
@@ -149,7 +149,7 @@ swap_status_init(const struct boot_loader_state *state,
 #endif
 
     rc = boot_write_magic(fap);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
     return 0;
 }
@@ -178,11 +178,11 @@ swap_read_status(struct boot_loader_state *state, struct boot_status *bs)
         break;
 
     default:
-        assert(0);
+        ASSERT(0);
         return BOOT_EBADARGS;
     }
 
-    assert(fap != NULL);
+    ASSERT(fap != NULL);
 
     rc = swap_read_status_bytes(fap, state, bs);
     if (rc == 0) {

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -114,7 +114,7 @@ boot_read_image_header(struct boot_loader_state *state, int slot,
     }
 
     fap = BOOT_IMG_AREA(state, slot);
-    assert(fap != NULL);
+    ASSERT(fap != NULL);
 
     rc = flash_area_read(fap, off, out_hdr, sizeof *out_hdr);
     if (rc != 0) {
@@ -190,7 +190,7 @@ swap_read_status_bytes(const struct flash_area *fap,
         /* With validation of the primary slot disabled, there is no way
          * to be sure the swapped primary slot is OK, so abort!
          */
-        assert(0);
+        ASSERT(0);
 #endif
     }
 
@@ -324,13 +324,13 @@ swap_status_source(struct boot_loader_state *state)
 
     rc = boot_read_swap_state(state->imgs[image_index][BOOT_SLOT_PRIMARY].area,
                               &state_primary_slot);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
     BOOT_LOG_SWAP_STATE("Primary image", &state_primary_slot);
 
     rc = boot_read_swap_state(state->imgs[image_index][BOOT_SLOT_SECONDARY].area,
                               &state_secondary_slot);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
     BOOT_LOG_SWAP_STATE("Secondary image", &state_secondary_slot);
 
@@ -371,24 +371,24 @@ boot_move_sector_up(int idx, uint32_t sz, struct boot_loader_state *state,
         if (bs->source != BOOT_STATUS_SOURCE_PRIMARY_SLOT) {
             /* Remove data and prepare for write on devices requiring erase */
             rc = swap_scramble_trailer_sectors(state, fap_pri);
-            assert(rc == 0);
+            ASSERT(rc == 0);
 
             rc = swap_status_init(state, fap_pri, bs);
-            assert(rc == 0);
+            ASSERT(rc == 0);
         }
 
         /* Remove status from secondary slot trailer, in case of device with
 	 * erase requirement this will also prepare traier for write.
 	 */
         rc = swap_scramble_trailer_sectors(state, fap_sec);
-        assert(rc == 0);
+        ASSERT(rc == 0);
     }
 
     rc = boot_erase_region(fap_pri, new_off, sz, false);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
     rc = boot_copy_region(state, fap_pri, fap_pri, old_off, new_off, sz);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
     rc = boot_write_status(state, bs);
 
@@ -412,10 +412,10 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
 
     if (bs->state == BOOT_STATUS_STATE_0) {
         rc = boot_erase_region(fap_pri, pri_off, sz, false);
-        assert(rc == 0);
+        ASSERT(rc == 0);
 
         rc = boot_copy_region(state, fap_sec, fap_pri, sec_off, pri_off, sz);
-        assert(rc == 0);
+        ASSERT(rc == 0);
 
         rc = boot_write_status(state, bs);
         bs->state = BOOT_STATUS_STATE_1;
@@ -424,10 +424,10 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
 
     if (bs->state == BOOT_STATUS_STATE_1) {
         rc = boot_erase_region(fap_sec, sec_off, sz, false);
-        assert(rc == 0);
+        ASSERT(rc == 0);
 
         rc = boot_copy_region(state, fap_pri, fap_sec, pri_up_off, sec_off, sz);
-        assert(rc == 0);
+        ASSERT(rc == 0);
 
         rc = boot_write_status(state, bs);
         bs->idx++;
@@ -465,23 +465,23 @@ fixup_revert(const struct boot_loader_state *state, struct boot_status *bs,
     }
 
     rc = boot_read_swap_state(fap_sec, &swap_state);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
     BOOT_LOG_SWAP_STATE("Secondary image", &swap_state);
 
     if (swap_state.magic == BOOT_MAGIC_UNSET) {
         /* Remove trailer and prepare area for write on devices requiring erase */
         rc = swap_scramble_trailer_sectors(state, fap_sec);
-        assert(rc == 0);
+        ASSERT(rc == 0);
 
         rc = boot_write_image_ok(fap_sec);
-        assert(rc == 0);
+        ASSERT(rc == 0);
 
         rc = boot_write_swap_size(fap_sec, bs->swap_size);
-        assert(rc == 0);
+        ASSERT(rc == 0);
 
         rc = boot_write_magic(fap_sec);
-        assert(rc == 0);
+        ASSERT(rc == 0);
     }
 }
 
@@ -530,10 +530,10 @@ swap_run(struct boot_loader_state *state, struct boot_status *bs,
     }
 
     fap_pri = BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY);
-    assert(fap_pri != NULL);
+    ASSERT(fap_pri != NULL);
 
     fap_sec = BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY);
-    assert(fap_sec != NULL);
+    ASSERT(fap_sec != NULL);
 
     fixup_revert(state, bs, fap_sec);
 

--- a/boot/bootutil/src/swap_offset.c
+++ b/boot/bootutil/src/swap_offset.c
@@ -175,7 +175,7 @@ int boot_read_image_header(struct boot_loader_state *state, int slot,
         }
     }
 
-    assert(fap != NULL);
+    ASSERT(fap != NULL);
 
     rc = flash_area_read(fap, off, out_hdr, sizeof *out_hdr);
     if (rc != 0) {
@@ -275,7 +275,7 @@ int swap_read_status_bytes(const struct flash_area *fap, struct boot_loader_stat
         /* With validation of the primary slot disabled, there is no way to be sure the swapped
          * primary slot is OK, so abort!
          */
-        assert(0);
+        ASSERT(0);
 #endif
     }
 
@@ -397,12 +397,12 @@ int swap_status_source(struct boot_loader_state *state)
     image_index = BOOT_CURR_IMG(state);
     rc = boot_read_swap_state(state->imgs[image_index][BOOT_SLOT_PRIMARY].area,
                               &state_primary_slot);
-    assert(rc == 0);
+    ASSERT(rc == 0);
     BOOT_LOG_SWAP_STATE("Primary image", &state_primary_slot);
 
     rc = boot_read_swap_state(state->imgs[image_index][BOOT_SLOT_SECONDARY].area,
                               &state_secondary_slot);
-    assert(rc == 0);
+    ASSERT(rc == 0);
     BOOT_LOG_SWAP_STATE("Secondary image", &state_secondary_slot);
 
     if (state_primary_slot.magic == BOOT_MAGIC_GOOD &&
@@ -439,11 +439,11 @@ static void boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *st
             /* Copy from slot 0 X to slot 1 X */
             BOOT_LOG_DBG("Erasing secondary 0x%x of 0x%x", sec_off, sz);
             rc = boot_erase_region(fap_sec, sec_off, sz, false);
-            assert(rc == 0);
+            ASSERT(rc == 0);
 
             BOOT_LOG_DBG("Copying primary 0x%x -> secondary 0x%x of 0x%x", pri_off, sec_off, sz);
             rc = BOOT_COPY_REGION(state, fap_pri, fap_sec, pri_off, sec_off, sz, 0);
-            assert(rc == 0);
+            ASSERT(rc == 0);
         }
 
         rc = boot_write_status(state, bs);
@@ -459,13 +459,13 @@ static void boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *st
             /* Erase slot 0 X */
             BOOT_LOG_DBG("Erasing primary 0x%x of 0x%x", pri_off, sz);
             rc = boot_erase_region(fap_pri, pri_off, sz, false);
-            assert(rc == 0);
+            ASSERT(rc == 0);
 
             /* Copy from slot 1 (X + 1) to slot 0 X */
             BOOT_LOG_DBG("Copying secondary 0x%x -> primary 0x%x of 0x%x", sec_up_off, pri_off,
                          sz);
             rc = BOOT_COPY_REGION(state, fap_sec, fap_pri, sec_up_off, pri_off, sz, 0);
-            assert(rc == 0);
+            ASSERT(rc == 0);
         }
 
         rc = boot_write_status(state, bs);
@@ -500,11 +500,11 @@ static void boot_swap_sectors_revert(int idx, uint32_t sz, struct boot_loader_st
             /* Copy from slot 0 X to slot 1 X */
             BOOT_LOG_DBG("Erasing secondary 0x%x of 0x%x", sec_off, sz);
             rc = boot_erase_region(fap_sec, sec_off, sz, false);
-            assert(rc == 0);
+            ASSERT(rc == 0);
 
             BOOT_LOG_DBG("Copying primary 0x%x -> secondary 0x%x of 0x%x", pri_off, sec_off, sz);
             rc = BOOT_COPY_REGION(state, fap_pri, fap_sec, pri_off, sec_off, sz, sector_sz);
-            assert(rc == 0);
+            ASSERT(rc == 0);
         }
 
         rc = boot_write_status(state, bs);
@@ -520,13 +520,13 @@ static void boot_swap_sectors_revert(int idx, uint32_t sz, struct boot_loader_st
             /* Erase slot 0 X */
             BOOT_LOG_DBG("Erasing primary 0x%x of 0x%x", pri_off, sz);
             rc = boot_erase_region(fap_pri, pri_off, sz, false);
-            assert(rc == 0);
+            ASSERT(rc == 0);
 
             /* Copy from slot 1 (X + 1) to slot 0 X */
             BOOT_LOG_DBG("Copying secondary 0x%x -> primary 0x%x of 0x%x", sec_up_off, pri_off,
                          sz);
             rc = BOOT_COPY_REGION(state, fap_sec, fap_pri, sec_up_off, pri_off, sz, 0);
-            assert(rc == 0);
+            ASSERT(rc == 0);
         }
 
         rc = boot_write_status(state, bs);
@@ -563,19 +563,19 @@ void fixup_revert(const struct boot_loader_state *state, struct boot_status *bs,
     }
 
     rc = boot_read_swap_state(fap_sec, &swap_state);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
     BOOT_LOG_SWAP_STATE("Secondary image", &swap_state);
 
     if (swap_state.magic == BOOT_MAGIC_UNSET) {
         rc = swap_scramble_trailer_sectors(state, fap_sec);
-        assert(rc == 0);
+        ASSERT(rc == 0);
 
         rc = boot_write_copy_done(fap_sec);
-        assert(rc == 0);
+        ASSERT(rc == 0);
 
         rc = swap_status_init(state, fap_sec, bs);
-        assert(rc == 0);
+        ASSERT(rc == 0);
     }
 }
 
@@ -602,10 +602,10 @@ void swap_run(struct boot_loader_state *state, struct boot_status *bs,
     sector_sz = boot_img_sector_size(state, BOOT_SLOT_PRIMARY, 0);
 
     fap_pri = BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY);
-    assert(fap_pri != NULL);
+    ASSERT(fap_pri != NULL);
 
     fap_sec = BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY);
-    assert(fap_sec != NULL);
+    ASSERT(fap_sec != NULL);
 
     /* When starting a new swap upgrade, check that there is enough space */
     if (boot_status_is_reset(bs)) {
@@ -639,14 +639,14 @@ void swap_run(struct boot_loader_state *state, struct boot_status *bs,
 
         if (bs->source != BOOT_STATUS_SOURCE_PRIMARY_SLOT) {
             rc = swap_scramble_trailer_sectors(state, fap_pri);
-            assert(rc == 0);
+            ASSERT(rc == 0);
 
             rc = swap_status_init(state, fap_pri, bs);
-            assert(rc == 0);
+            ASSERT(rc == 0);
         }
 
         rc = swap_scramble_trailer_sectors(state, fap_sec);
-        assert(rc == 0);
+        ASSERT(rc == 0);
     }
 
     /* Read the unprotected TLV sizes from the boot swap status area, this information might get
@@ -691,9 +691,9 @@ void swap_run(struct boot_loader_state *state, struct boot_status *bs,
          */
         rc = boot_scramble_region(fap_sec, boot_img_sector_off(state, BOOT_SLOT_SECONDARY, 0),
                                   sector_sz, false);
-        assert(rc == 0);
+        ASSERT(rc == 0);
         rc = swap_scramble_trailer_sectors(state, fap_sec);
-        assert(rc == 0);
+        ASSERT(rc == 0);
     } else {
         while (idx <= last_idx) {
             if (idx >= (bs->idx - BOOT_STATUS_IDX_0)) {
@@ -743,8 +743,8 @@ int boot_read_image_size(struct boot_loader_state *state, int slot, uint32_t *si
 #endif
 
     fap = BOOT_IMG_AREA(state, slot);
-    assert(fap != NULL);
-    assert(size != NULL);
+    ASSERT(fap != NULL);
+    ASSERT(size != NULL);
 
     *size = 0;
 

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -236,7 +236,7 @@ swap_read_status_bytes(const struct flash_area *fap,
         /* With validation of the primary slot disabled, there is no way
          * to be sure the swapped primary slot is OK, so abort!
          */
-        assert(0);
+        ASSERT(0);
 #endif
     }
 
@@ -488,11 +488,11 @@ swap_status_source(struct boot_loader_state *state)
     image_index = BOOT_CURR_IMG(state);
     rc = boot_read_swap_state(state->imgs[image_index][BOOT_SLOT_PRIMARY].area,
                               &state_primary_slot);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 
 #if MCUBOOT_SWAP_USING_SCRATCH
     rc = boot_read_swap_state(state->scratch.area, &state_scratch);
-    assert(rc == 0);
+    ASSERT(rc == 0);
 #endif
 
     BOOT_LOG_SWAP_STATE("Primary image", &state_primary_slot);
@@ -695,13 +695,13 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
     image_index = BOOT_CURR_IMG(state);
 
     fap_primary_slot = BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY);
-    assert(fap_primary_slot != NULL);
+    ASSERT(fap_primary_slot != NULL);
 
     fap_secondary_slot = BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY);
-    assert(fap_secondary_slot != NULL);
+    ASSERT(fap_secondary_slot != NULL);
 
     fap_scratch = state->scratch.area;
-    assert(fap_scratch != NULL);
+    ASSERT(fap_scratch != NULL);
 
     /* Calculate offset from start of image area. */
     img_off = boot_img_sector_off(state, BOOT_SLOT_PRIMARY, idx);
@@ -748,7 +748,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
     if (bs->state == BOOT_STATUS_STATE_0) {
         BOOT_LOG_DBG("erasing scratch area");
         rc = boot_erase_region(fap_scratch, 0, flash_area_get_size(fap_scratch), false);
-        assert(rc == 0);
+        ASSERT(rc == 0);
 
         if (bs->idx == BOOT_STATUS_IDX_0) {
             /* Write a trailer to the scratch area, even if we don't need the
@@ -756,7 +756,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
              * `swap-type` while we erase the primary trailer.
              */
             rc = swap_status_init(state, fap_scratch, bs);
-            assert(rc == 0);
+            ASSERT(rc == 0);
 
             if (!bs->use_scratch) {
                 /* Prepare the primary status area... here it is known that the
@@ -764,21 +764,21 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
                  * to erase.
                  */
                 rc = swap_scramble_trailer_sectors(state, fap_primary_slot);
-                assert(rc == 0);
+                ASSERT(rc == 0);
 
                 rc = swap_status_init(state, fap_primary_slot, bs);
-                assert(rc == 0);
+                ASSERT(rc == 0);
 
                 /* Erase the temporary trailer from the scratch area. */
                 rc = boot_erase_region(fap_scratch, 0,
                         flash_area_get_size(fap_scratch), false);
-                assert(rc == 0);
+                ASSERT(rc == 0);
             }
         }
 
         rc = boot_copy_region(state, fap_secondary_slot, fap_scratch,
                               img_off, 0, copy_sz);
-        assert(rc == 0);
+        ASSERT(rc == 0);
 
         rc = boot_write_status(state, bs);
         bs->state = BOOT_STATUS_STATE_1;
@@ -796,7 +796,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
              * img_off + sz) might not erase the entire trailer.
               */
             rc = swap_scramble_trailer_sectors(state, fap_secondary_slot);
-            assert(rc == 0);
+            ASSERT(rc == 0);
 
             if (bs->use_scratch) {
                 /* If the area being swapped contains the trailer or part of it, ensure the
@@ -814,12 +814,12 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
 
         if (erase_sz > 0) {
             rc = boot_erase_region(fap_secondary_slot, img_off, erase_sz, false);
-            assert(rc == 0);
+            ASSERT(rc == 0);
         }
 
         rc = boot_copy_region(state, fap_primary_slot, fap_secondary_slot,
                               img_off, img_off, copy_sz);
-        assert(rc == 0);
+        ASSERT(rc == 0);
 
         rc = boot_write_status(state, bs);
         bs->state = BOOT_STATUS_STATE_2;
@@ -836,7 +836,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
              * img_off + sz) range when the trailer spreads across multiple sectors.
              */
             rc = swap_scramble_trailer_sectors(state, fap_primary_slot);
-            assert(rc == 0);
+            ASSERT(rc == 0);
 
             /* Ensure the sector(s) containing the beginning of the trailer won't be erased twice */
             uint32_t trailer_sector_off =
@@ -847,7 +847,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
 
         if (erase_sz > 0) {
             rc = boot_erase_region(fap_primary_slot, img_off, erase_sz, false);
-            assert(rc == 0);
+            ASSERT(rc == 0);
         }
 
         /* NOTE: If this is the final sector, we exclude the image trailer from
@@ -855,7 +855,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
          */
         rc = boot_copy_region(state, fap_scratch, fap_primary_slot,
                               0, img_off, copy_sz);
-        assert(rc == 0);
+        ASSERT(rc == 0);
 
         if (bs->use_scratch) {
             scratch_trailer_off = boot_status_off(fap_scratch);
@@ -867,27 +867,27 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
             BOOT_STATUS_ASSERT(rc == 0);
 
             rc = boot_read_swap_state(fap_scratch, &swap_state);
-            assert(rc == 0);
+            ASSERT(rc == 0);
 
             if (swap_state.image_ok == BOOT_FLAG_SET) {
                 rc = boot_write_image_ok(fap_primary_slot);
-                assert(rc == 0);
+                ASSERT(rc == 0);
             }
 
             if (swap_state.swap_type != BOOT_SWAP_TYPE_NONE) {
                 rc = boot_write_swap_info(fap_primary_slot,
                         swap_state.swap_type, image_index);
-                assert(rc == 0);
+                ASSERT(rc == 0);
             }
 
             rc = boot_write_swap_size(fap_primary_slot, bs->swap_size);
-            assert(rc == 0);
+            ASSERT(rc == 0);
 
 #ifdef MCUBOOT_ENC_IMAGES
             rc = boot_write_enc_keys(fap_primary_slot, bs);
 #endif
             rc = boot_write_magic(fap_primary_slot);
-            assert(rc == 0);
+            ASSERT(rc == 0);
         }
 
         /* If we wrote a trailer to the scratch area, erase it after we persist
@@ -910,7 +910,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
             * primary slot, causing a corrupt unbootable image
             */
             rc = boot_scramble_region(fap_scratch, 0, flash_area_get_size(fap_scratch), true);
-            assert(rc == 0);
+            ASSERT(rc == 0);
         }
     }
 }
@@ -1036,7 +1036,7 @@ int app_max_size(struct boot_loader_state *state)
     active_slot = state->slot_usage[BOOT_CURR_IMG(state)].active_slot;
 
     fap = BOOT_IMG_AREA(state, active_slot);
-    assert(fap != NULL);
+    ASSERT(fap != NULL);
     primary_sz = flash_area_get_size(fap);
 
     if (active_slot == BOOT_SLOT_PRIMARY) {
@@ -1046,7 +1046,7 @@ int app_max_size(struct boot_loader_state *state)
     }
 
     fap = BOOT_IMG_AREA(state, active_slot);
-    assert(fap != NULL);
+    ASSERT(fap != NULL);
     secondary_sz = flash_area_get_size(fap);
 
     return (secondary_sz < primary_sz ? secondary_sz : primary_sz);
@@ -1128,7 +1128,7 @@ boot_read_image_header(struct boot_loader_state *state, int slot,
 #else
     fap = BOOT_IMG_AREA(state, hdr_slot);
 #endif
-    assert(fap != NULL);
+    ASSERT(fap != NULL);
 
     rc = flash_area_read(fap, 0, out_hdr, sizeof *out_hdr);
 


### PR DESCRIPTION
MCUboot has an assert handler macro which is used from the simulator, align usage of assert calls to match it