### PR TITLE
boot: bootutil: fixes for image encryption support with PSA crypto

### DIFF
--- a/boot/bootutil/CMakeLists.txt
+++ b/boot/bootutil/CMakeLists.txt
@@ -41,10 +41,10 @@ target_sources(bootutil
 )
 
 # Select the FIH delay RNG implementation.
-# When the bootloader uses PSA Crypto (CONFIG_BOOT_USE_PSA_CRYPTO), use
+# When the bootloader uses PSA Crypto (MCUBOOT_USE_PSA_CRYPTO), use
 # psa_generate_random() instead of the legacy mbedTLS entropy + CTR-DRBG
 # APIs that were removed in tf-psa-crypto 1.0.
-if(CONFIG_BOOT_USE_PSA_CRYPTO)
+if(MCUBOOT_USE_PSA_CRYPTO)
   target_sources(bootutil PRIVATE src/fault_injection_hardening_delay_rng_psa.c)
 else()
   target_sources(bootutil PRIVATE src/fault_injection_hardening_delay_rng_mbedtls.c)

--- a/boot/bootutil/CMakeLists.txt
+++ b/boot/bootutil/CMakeLists.txt
@@ -49,3 +49,10 @@ if(MCUBOOT_USE_PSA_CRYPTO)
 else()
   target_sources(bootutil PRIVATE src/fault_injection_hardening_delay_rng_mbedtls.c)
 endif()
+
+# When the bootloader uses PSA Crypto (MCUBOOT_USE_PSA_CRYPTO), include
+# encrypted_psa.c in addition to encrypted.c, which still provides the common
+# encrypted image support, when using the PSA Crypto APIs.
+if(MCUBOOT_USE_PSA_CRYPTO)
+  target_sources(bootutil PRIVATE src/encrypted_psa.c)
+endif()

--- a/boot/bootutil/include/bootutil/crypto/aes_ctr.h
+++ b/boot/bootutil/include/bootutil/crypto/aes_ctr.h
@@ -4,8 +4,12 @@
  *
  * At this point, there are four choices: MCUBOOT_USE_MBED_TLS,
  * MCUBOOT_USE_TINYCRYPT, MCUBOOT_USE_PSA_CRYPTO, or
- * MCUBOOT_USE_CUSTOM_CRYPTO.  It is a compile error if there is not
- * exactly one of these defined.
+ * MCUBOOT_USE_CUSTOM_CRYPTO.
+ * Note that support for MCUBOOT_USE_PSA_CRYPTO is still experimental and it
+ * might not support all the crypto abstractions that MCUBOOT_USE_MBED_TLS
+ * supports. For this reason, it's allowed to have both of them defined, and
+ * for crypto modules that support both abstractions, the MCUBOOT_USE_PSA_CRYPTO
+ * will take precedence.
  */
 
 #ifndef __BOOTUTIL_CRYPTO_AES_CTR_H_
@@ -13,14 +17,18 @@
 
 #include "mcuboot_config/mcuboot_config.h"
 
-#if (defined(MCUBOOT_USE_MBED_TLS) + \
+#if defined(MCUBOOT_USE_PSA_CRYPTO) || defined(MCUBOOT_USE_MBED_TLS)
+#define MCUBOOT_USE_PSA_OR_MBED_TLS
+#endif /* MCUBOOT_USE_PSA_CRYPTO || MCUBOOT_USE_MBED_TLS */
+
+#if (defined(MCUBOOT_USE_PSA_OR_MBED_TLS) + \
      defined(MCUBOOT_USE_TINYCRYPT) + \
-     defined(MCUBOOT_USE_PSA_CRYPTO) + \
      defined(MCUBOOT_USE_CUSTOM_CRYPTO)) != 1
     #error "One crypto backend must be defined: either MBED_TLS or TINYCRYPT or PSA or CUSTOM_CRYPTO"
 #endif
 
-#if defined(MCUBOOT_USE_MBED_TLS)
+/* PSA_CRYPTO takes precedence over MBED_TLS */
+#if defined(MCUBOOT_USE_MBED_TLS) && !defined(MCUBOOT_USE_PSA_CRYPTO)
     #include "bootutil/crypto/aes_ctr_mbedtls.h"
 #endif /* MCUBOOT_USE_MBED_TLS */
 

--- a/boot/bootutil/src/encrypted.c
+++ b/boot/bootutil/src/encrypted.c
@@ -39,6 +39,7 @@
 #endif
 
 #if defined(MCUBOOT_ENCRYPT_EC256) || defined(MCUBOOT_ENCRYPT_X25519)
+#include "bootutil/crypto/common.h"
 #include "bootutil/crypto/sha.h"
 #include "bootutil/crypto/hmac_sha256.h"
 #include "mbedtls/oid.h"
@@ -49,7 +50,6 @@
 #include "bootutil/image.h"
 #include "bootutil/enc_key.h"
 #include "bootutil/sign_key.h"
-#include "bootutil/crypto/common.h"
 #include "bootutil/bootutil_log.h"
 
 BOOT_LOG_MODULE_DECLARE(mcuboot);

--- a/boot/bootutil/src/encrypted_psa.c
+++ b/boot/bootutil/src/encrypted_psa.c
@@ -12,9 +12,11 @@
 #include <inttypes.h>
 #include <string.h>
 
+#if defined(MCUBOOT_ENCRYPT_EC256) || defined(MCUBOOT_ENCRYPT_X25519)
 /* We are not really using the MBEDTLS but need the ASN.1 parsing functions */
 #define MBEDTLS_ASN1_PARSE_C
 
+#include "bootutil/crypto/common.h"
 #include "bootutil/crypto/sha.h"
 #include "mbedtls/build_info.h"
 #include "mbedtls/oid.h"
@@ -36,11 +38,11 @@
 #if !defined(MBEDTLS_OID_EC_GRP_SECP256R1)
 #define MBEDTLS_OID_EC_GRP_SECP256R1    "\x2a\x86\x48\xce\x3d\x03\x01\x07"
 #endif
+#endif /* defined(MCUBOOT_ENCRYPT_EC256) || defined(MCUBOOT_ENCRYPT_X25519) */
 
 #include "bootutil/image.h"
 #include "bootutil/enc_key.h"
 #include "bootutil/sign_key.h"
-#include "bootutil/crypto/common.h"
 
 #include "bootutil_priv.h"
 #include "bootutil/bootutil_log.h"
@@ -252,6 +254,7 @@ int bootutil_aes_ctr_set_key(bootutil_aes_ctr_context *ctx, const uint8_t *k)
 }
 
 #if defined(MCUBOOT_ENC_IMAGES)
+#if defined(MCUBOOT_ENCRYPT_EC256) || defined(MCUBOOT_ENCRYPT_X25519)
 extern const struct bootutil_key bootutil_enc_key;
 /*
  * Decrypt an encryption key TLV.
@@ -441,6 +444,7 @@ boot_decrypt_key(const uint8_t *buf, uint8_t *enckey)
 
     return 0;
 }
+#endif /* defined(MCUBOOT_ENCRYPT_EC256) || defined(MCUBOOT_ENCRYPT_X25519) */
 
 int bootutil_aes_ctr_encrypt(bootutil_aes_ctr_context *ctx, uint8_t *counter,
         const uint8_t *m, uint32_t mlen, size_t blk_off, uint8_t *c)


### PR DESCRIPTION
Trusted Firmware-M (TF-M) starting with v2.3.0 is utilizing purely the PSA crypto API. This PR contains fixes for the image encryption support (MCUBOOT_ENC_IMAGES) that have been discovered while working with TF-M v2.3.0+.

`bootutil: crypto: aes_ctr: allow PSA_CRYPTO together with MBED_TLS` is included to maintain support for older TF-M versions which utilize a mixture of PSA crypto and mbedtls.

For details, see the commit messages of the individual commits.