### PR TITLE
sim: Test power loss tearing the interrupted flash write

### DIFF
--- a/docs/release-notes.d/sim-torn-writes.md
+++ b/docs/release-notes.d/sim-torn-writes.md
@@ -1,0 +1,5 @@
+- Added a torn-write mode to the simulator's power-loss testing: the
+  interrupted flash write can now be left partially programmed instead
+  of always aborting atomically, and a new revert sweep uses it to
+  cover interrupted-write states such as a partially written trailer
+  magic.

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -48,6 +48,8 @@ extern int sim_flash_read(uint8_t flash_id, uint32_t offset, uint8_t *dest,
         uint32_t size);
 extern int sim_flash_write(uint8_t flash_id, uint32_t offset, const uint8_t *src,
         uint32_t size);
+extern int sim_flash_write_torn(uint8_t flash_id, uint32_t offset,
+        const uint8_t *src, uint32_t size);
 extern uint32_t sim_flash_align(uint8_t flash_id);
 extern uint8_t sim_flash_erased_val(uint8_t flash_id);
 
@@ -56,6 +58,7 @@ struct sim_context {
     int jumped;
     uint8_t c_asserts;
     uint8_t c_catch_asserts;
+    int flash_torn_write;
     jmp_buf boot_jmpbuf;
 };
 
@@ -416,6 +419,16 @@ int flash_area_write(const struct flash_area *area, uint32_t off, const void *sr
                  area->fa_id, off, len);
     struct sim_context *ctx = sim_get_context();
     if (--(ctx->flash_counter) == 0) {
+        if (ctx->flash_torn_write && len > 1) {
+            /* Power failed partway through programming: all but the last
+             * byte of the payload reaches the flash.  Write alignment is a
+             * driver interface requirement, not a power-fail atomicity
+             * guarantee, so the tear point can fall inside a write unit.
+             */
+            int rc = sim_flash_write_torn(area->fa_device_id,
+                                          area->fa_off + off, src, len - 1);
+            assert(rc == 0);
+        }
         ctx->jumped++;
         longjmp(ctx->boot_jmpbuf, 1);
     }

--- a/sim/mcuboot-sys/src/api.rs
+++ b/sim/mcuboot-sys/src/api.rs
@@ -96,6 +96,7 @@ pub struct CSimContext {
     pub jumped: libc::c_int,
     pub c_asserts: u8,
     pub c_catch_asserts: u8,
+    pub flash_torn_write: libc::c_int,
     // NOTE: Always leave boot_jmpbuf declaration at the end; this should
     // store a "jmp_buf" which is arch specific and not defined by libc crate.
     // The size below is enough to store data on a x86_64 machine.
@@ -109,6 +110,7 @@ impl Default for CSimContext {
             jumped: 0,
             c_asserts: 0,
             c_catch_asserts: 0,
+            flash_torn_write: 0,
             boot_jmpbuf: [0; 48],
         }
     }
@@ -301,6 +303,19 @@ pub extern "C" fn sim_flash_write(dev_id: u8, offset: u32, src: *const u8, size:
             let buf: &[u8] = unsafe { slice::from_raw_parts(src, size as usize) };
             let dev = unsafe { &mut *(flash.ptr) };
             rc = map_err(dev.write(offset as usize, &buf));
+        }
+    });
+    rc
+}
+
+#[no_mangle]
+pub extern "C" fn sim_flash_write_torn(dev_id: u8, offset: u32, src: *const u8, size: u32) -> libc::c_int {
+    let mut rc: libc::c_int = -19;
+    THREAD_CTX.with(|ctx| {
+        if let Some(flash) = ctx.borrow().flash_map.get(&dev_id) {
+            let buf: &[u8] = unsafe { slice::from_raw_parts(src, size as usize) };
+            let dev = unsafe { &mut *(flash.ptr) };
+            rc = map_err(dev.write_torn(offset as usize, &buf));
         }
     });
     rc

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -83,6 +83,24 @@ pub const fn logical_sector_size() -> usize {
 pub fn boot_go(multiflash: &mut SimMultiFlash, areadesc: &AreaDesc,
                counter: Option<&mut i32>, image_index: Option<i32>,
                catch_asserts: bool) -> BootGoResult {
+    boot_go_impl(multiflash, areadesc, counter, image_index, catch_asserts,
+                 false)
+}
+
+/// Invoke the bootloader on this flash device, with the interruption
+/// configured by `counter` performing a torn write: the interrupted flash
+/// write programs a prefix of its payload before the simulated power loss,
+/// instead of aborting atomically.
+pub fn boot_go_torn(multiflash: &mut SimMultiFlash, areadesc: &AreaDesc,
+                    counter: Option<&mut i32>, image_index: Option<i32>,
+                    catch_asserts: bool) -> BootGoResult {
+    boot_go_impl(multiflash, areadesc, counter, image_index, catch_asserts,
+                 true)
+}
+
+fn boot_go_impl(multiflash: &mut SimMultiFlash, areadesc: &AreaDesc,
+                counter: Option<&mut i32>, image_index: Option<i32>,
+                catch_asserts: bool, torn_write: bool) -> BootGoResult {
     init_crypto();
 
     for (&dev_id, flash) in multiflash.iter_mut() {
@@ -94,6 +112,7 @@ pub fn boot_go(multiflash: &mut SimMultiFlash, areadesc: &AreaDesc,
             Some(ref c) => **c as libc::c_int
         },
         c_catch_asserts: if catch_asserts { 1 } else { 0 },
+        flash_torn_write: if torn_write { 1 } else { 0 },
         .. Default::default()
     };
     let mut rsp = api::BootRsp {

--- a/sim/simflash/src/lib.rs
+++ b/sim/simflash/src/lib.rs
@@ -54,6 +54,7 @@ unsafe impl Send for FlashPtr {}
 pub trait Flash {
     fn erase(&mut self, offset: usize, len: usize) -> Result<()>;
     fn write(&mut self, offset: usize, payload: &[u8]) -> Result<()>;
+    fn write_torn(&mut self, offset: usize, payload: &[u8]) -> Result<()>;
     fn read(&self, offset: usize, data: &mut [u8]) -> Result<()>;
 
     fn add_bad_region(&mut self, offset: usize, len: usize, rate: f32) -> Result<()>;
@@ -88,6 +89,10 @@ fn esimulatedwrite<T: AsRef<str>>(message: T) -> FlashError {
 pub struct SimFlash {
     data: Vec<u8>,
     write_safe: Vec<bool>,
+    // Bytes programmed by a torn write.  These may be written once more
+    // with the same value, as recovery from an interrupted write replays
+    // the whole operation.
+    retryable: Vec<bool>,
     sectors: Vec<usize>,
     bad_region: Vec<(usize, usize, f32)>,
     // Alignment required for writes.
@@ -107,6 +112,7 @@ impl SimFlash {
         SimFlash {
             data: vec![erased_val; total],
             write_safe: vec![true; total],
+            retryable: vec![false; total],
             sectors,
             bad_region: Vec::new(),
             align,
@@ -168,6 +174,10 @@ impl Flash for SimFlash {
             *x = true;
         }
 
+        for x in &mut self.retryable[offset .. offset + len] {
+            *x = false;
+        }
+
         Ok(())
     }
 
@@ -205,10 +215,49 @@ impl Flash for SimFlash {
         }
 
         for (i, x) in &mut self.write_safe[offset .. offset + payload.len()].iter_mut().enumerate() {
-            if self.verify_writes && !(*x) {
-                panic!("Write to unerased location at 0x{:x}", offset + i);
+            if !(*x) {
+                // A byte programmed by a torn write may be written once
+                // more, with the same value, as recovery replays the
+                // interrupted operation.
+                if self.retryable[offset + i] && payload[i] == self.data[offset + i] {
+                    self.retryable[offset + i] = false;
+                } else if self.verify_writes {
+                    panic!("Write to unerased location at 0x{:x}", offset + i);
+                }
             }
             *x = false;
+        }
+
+        let sub = &mut self.data[offset .. offset + payload.len()];
+        sub.copy_from_slice(payload);
+        Ok(())
+    }
+
+    /// A write interrupted by power loss: program only the given prefix of
+    /// the intended payload.  Unlike `write`, the length does not have to be
+    /// a multiple of the write alignment, since power can fail partway
+    /// through programming a single write unit.  The programmed bytes are
+    /// marked so that one subsequent write of the same values is allowed,
+    /// as recovery replays the interrupted operation.
+    fn write_torn(&mut self, offset: usize, payload: &[u8]) -> Result<()> {
+        if offset + payload.len() > self.data.len() {
+            panic!("Write outside of device");
+        }
+
+        // Verify the alignment (which must be a power of two).
+        if offset & (self.align - 1) != 0 {
+            panic!("Misaligned write address");
+        }
+
+        for (i, x) in &mut self.write_safe[offset .. offset + payload.len()].iter_mut().enumerate() {
+            if self.verify_writes && !(*x) {
+                panic!("Torn write to unerased location at 0x{:x}", offset + i);
+            }
+            *x = false;
+        }
+
+        for x in &mut self.retryable[offset .. offset + payload.len()] {
+            *x = true;
         }
 
         let sub = &mut self.data[offset .. offset + payload.len()];
@@ -320,6 +369,50 @@ mod test {
                                     128 * 1024, 128 * 1024, 128 * 1024], 1, erased_val);
             test_device(&mut f2, erased_val);
         }
+    }
+
+    #[test]
+    fn test_torn_write() {
+        let mut flash = SimFlash::new(vec![4096usize; 4], 8, 0xff);
+        flash.erase(0, 4096).unwrap();
+        let payload = [0x5A; 16];
+
+        // Tear the write after 15 of 16 bytes.
+        flash.write_torn(0, &payload[..15]).unwrap();
+        let mut buf = [0; 16];
+        flash.read(0, &mut buf).unwrap();
+        assert_eq!(&buf[..15], &payload[..15]);
+        assert_eq!(buf[15], 0xff);
+
+        // Recovery may replay the interrupted write once with the same data.
+        flash.write(0, &payload).unwrap();
+        flash.read(0, &mut buf).unwrap();
+        assert_eq!(buf, payload);
+
+        // Erase restores normal write-once behavior.
+        flash.erase(0, 4096).unwrap();
+        flash.write(0, &payload).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Write to unerased location")]
+    fn test_torn_write_replay_once_only() {
+        let mut flash = SimFlash::new(vec![4096usize; 4], 8, 0xff);
+        flash.erase(0, 4096).unwrap();
+        let payload = [0x5A; 16];
+        flash.write_torn(0, &payload[..15]).unwrap();
+        flash.write(0, &payload).unwrap();
+        // The retry exemption is consumed; another rewrite must fail.
+        flash.write(0, &payload).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Write to unerased location")]
+    fn test_torn_write_replay_must_match() {
+        let mut flash = SimFlash::new(vec![4096usize; 4], 8, 0xff);
+        flash.erase(0, 4096).unwrap();
+        flash.write_torn(0, &[0x5A; 15]).unwrap();
+        flash.write(0, &[0xA5; 16]).unwrap();
     }
 
     fn test_device(flash: &mut dyn Flash, erased_val: u8) {

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -1042,6 +1042,94 @@ impl Images {
         fails > 0
     }
 
+    /// Sweep power loss over the revert path with the interrupted flash
+    /// write torn: all but the last byte of its payload is programmed.
+    /// This reaches states an interruption between whole operations cannot,
+    /// such as a partially written trailer magic (`BOOT_MAGIC_BAD`) after
+    /// power loss inside `boot_write_magic` during revert fixup, the
+    /// failure reported in issue #1966.
+    pub fn run_revert_with_torn_writes(&self) -> bool {
+        if !Caps::SwapUsingMove.present() || !Caps::modifies_flash() {
+            return false;
+        }
+
+        if skip_slow_test() {
+            return false;
+        }
+
+        let mut fails = 0;
+
+        // Perform a normal test upgrade; the unconfirmed image makes the
+        // next boot start a revert.
+        let mut upgraded = self.flash.clone();
+        if !c::boot_go(&mut upgraded, &self.areadesc, None, None,
+                       false).success() {
+            error!("Failed upgrade before torn-write revert");
+            return true;
+        }
+        if !self.verify_images(&upgraded, 0, 1) {
+            error!("Image mismatch after upgrade before torn-write revert");
+            return true;
+        }
+
+        // Count the flash operations of an uninterrupted revert.
+        let mut clean = upgraded.clone();
+        let mut counter = 0;
+        if !c::boot_go(&mut clean, &self.areadesc, Some(&mut counter), None,
+                       false).success() {
+            error!("Failed uninterrupted revert");
+            return true;
+        }
+        let total = -counter;
+
+        for stop in 1 ..= total {
+            info!("Try interruption {} with torn-write mode", stop);
+            let mut flash = upgraded.clone();
+            let mut counter = stop;
+            if !c::boot_go_torn(&mut flash, &self.areadesc, Some(&mut counter),
+                                None, false).interrupted() {
+                warn!("Should have stopped revert at interruption point");
+                fails += 1;
+            }
+
+            if !c::boot_go(&mut flash, &self.areadesc, None, None,
+                           false).success() {
+                warn!("Should have finished revert after torn write at {}",
+                      stop);
+                fails += 1;
+            }
+
+            if !self.verify_images(&flash, 0, 0) {
+                warn!("Image in the primary slot after revert is invalid \
+                       at torn write {}", stop);
+                fails += 1;
+            }
+            if !self.verify_images(&flash, 1, 1) {
+                warn!("Image in the secondary slot after revert is invalid \
+                       at torn write {}", stop);
+                fails += 1;
+            }
+            if !self.verify_trailers(&flash, 0, BOOT_MAGIC_GOOD,
+                                     BOOT_FLAG_SET, BOOT_FLAG_SET) {
+                warn!("Mismatched trailer for the primary slot after revert \
+                       at torn write {}", stop);
+                fails += 1;
+            }
+            if !self.verify_trailers(&flash, 1, BOOT_MAGIC_UNSET,
+                                     BOOT_FLAG_UNSET, BOOT_FLAG_UNSET) {
+                warn!("Mismatched trailer for the secondary slot after \
+                       revert at torn write {}", stop);
+                fails += 1;
+            }
+        }
+
+        if fails > 0 {
+            error!("Error testing torn-write revert with {} fails", fails);
+        }
+
+        fails > 0
+    }
+
     pub fn run_norevert(&self) -> bool {
         if Caps::OverwriteUpgrade.present() || !Caps::modifies_flash() {
             return false;

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -219,6 +219,7 @@ impl RunStatus {
 
         failed |= images.run_basic_revert();
         failed |= images.run_revert_with_fails();
+        failed |= images.run_revert_with_torn_writes();
         failed |= images.run_perm_with_fails();
         failed |= images.run_perm_with_random_fails(5);
         failed |= images.run_norevert();

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -56,6 +56,7 @@ sim_test!(oversized_bootstrap, make_oversized_bootstrap_image(), run_oversized_b
 sim_test!(norevert_newimage, make_no_upgrade_image(&NO_DEPS, ImageManipulation::None), run_norevert_newimage());
 sim_test!(basic_revert, make_image(&NO_DEPS, true), run_basic_revert());
 sim_test!(revert_with_fails, make_image(&NO_DEPS, false), run_revert_with_fails());
+sim_test!(revert_with_torn_writes, make_image(&NO_DEPS, false), run_revert_with_torn_writes());
 sim_test!(perm_with_fails, make_image(&NO_DEPS, true), run_perm_with_fails());
 sim_test!(perm_with_random_fails, make_image(&NO_DEPS, true), run_perm_with_random_fails(5));
 sim_test!(norevert, make_image(&NO_DEPS, true), run_norevert());


### PR DESCRIPTION
The simulator's power-loss testing interrupts `boot_go` between whole flash operations: when the flash counter expires, `flash_area_write` in `sim/mcuboot-sys/csupport/run.c` returns via longjmp before calling the simulated flash write. Every simulated power cut is therefore write-atomic, so states left by a write torn partway through are unreachable. That is why the revert interruption sweep did not catch #1966: that failure needs power loss inside `boot_write_magic` during swap-move revert fixup, leaving a partially written magic that reads back as `BOOT_MAGIC_BAD` and matches no swap table row.

This PR adds a torn-write mode:

- When the interruption counter expires in torn mode, the write programs all but the last byte of its payload before the simulated power loss. Write alignment is a driver interface requirement, not a power-fail atomicity guarantee, so the tear point falls inside the final write unit regardless of `max-align`.
- The simulated flash marks torn bytes as retryable: one subsequent write of the same values is allowed, since recovery replays the interrupted operation. The write-once discipline stays enforced everywhere else, and unit tests cover the tear, the single replay, a mismatched replay, and erase restoring normal behavior.
- `run_revert_with_torn_writes` sweeps the revert path: perform a test upgrade, count the flash operations of an uninterrupted revert, then for each operation clone the post-upgrade state, tear that write during revert, and verify the device recovers to the original image with clean trailers. Gated to swap-using-move.

Validation:

- On current main, both the existing `revert_with_fails` sweep and the new torn-write sweep pass (`--features swap-move`, and `swap-move,max-align-32`).
- With the one-word fix from 4f393563 reverted (`BOOT_MAGIC_ANY` back to `BOOT_MAGIC_UNSET` in the revert row), the new sweep fails at the fixup_revert magic write, including under `max-align-32`, while the existing whole-operation sweep still passes. That reproduces #1966 offline in the simulator.

Follow-up candidates, intentionally out of scope: torn erases, multiple power cuts in one recovery chain, and non-prefix corruption patterns.

Context: this addresses the simulator question raised in the review of #2648.