### PR TITLE
ci: update actions/checkout from v2 to v4

### DIFF
--- a/.github/workflows/espressif.yaml
+++ b/.github/workflows/espressif.yaml
@@ -35,7 +35,7 @@ jobs:
       MCUBOOT_FEATURES: ${{ matrix.features }}
       MCUBOOT_IMG_NUM: ${{ matrix.img }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: recursive

--- a/.github/workflows/fih_tests.yaml
+++ b/.github/workflows/fih_tests.yaml
@@ -32,7 +32,7 @@ jobs:
         - "MINSIZEREL 8,10 SIGNATURE MEDIUM"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         # Uses Mbed TLS from TFM, and nothing else from here.

--- a/.github/workflows/mynewt.yaml
+++ b/.github/workflows/mynewt.yaml
@@ -16,7 +16,7 @@ jobs:
   environment:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: actions/setup-go@v3

--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -89,7 +89,7 @@ jobs:
     env:
       MULTI_FEATURES: ${{ matrix.features }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: recursive

--- a/.github/workflows/zephyr_build.yaml
+++ b/.github/workflows/zephyr_build.yaml
@@ -58,7 +58,7 @@ jobs:
           echo "MCUBOOT_VERSION=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
       - name: Checkout Zephyr
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: 'zephyrproject-rtos/zephyr'
           ref: ${{ env.ZEPHYR_VERSION }}
@@ -79,7 +79,7 @@ jobs:
           ccache-max-size: 768MB
 
       - name: Checkout MCUBoot
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: 'mcu-tools/mcuboot'
           ref: ${{ env.MCUBOOT_VERSION }}


### PR DESCRIPTION
actions/checkout@v2 targets Node.js 20, which GitHub Actions runners have deprecated, so every job using it emits a deprecation warning (visible on any recent run of the Espressif, Sim, Mynewt, FIH, and Zephyr Twister workflows). This bumps the five remaining v2 references to v4. No workflow logic changes.