### PR TITLE
cypress: make the security counter stub fail closed

### DIFF
--- a/boot/cypress/MCUBootApp/README.md
+++ b/boot/cypress/MCUBootApp/README.md
@@ -4,6 +4,11 @@
 
 Given solution demonstrates operation of MCUboot on Cypress' PSoC6 device.
 
+The bundled `cy_security_cnt.c` does not implement persistent security counter
+storage and fails closed. Replace it with a monotonic, power-fail-safe backend,
+as required by `boot/bootutil/include/bootutil/security_cnt.h`, before enabling
+`MCUBOOT_HW_ROLLBACK_PROT`.
+
 There are two applications implemented:
 * MCUBootApp - PSoC6 MCUboot-based bootloading application;
 * BlinkyApp - simple PSoC6 blinking LED application which is a target of BOOT/UPGRADE;

--- a/boot/cypress/MCUBootApp/cy_security_cnt.c
+++ b/boot/cypress/MCUBootApp/cy_security_cnt.c
@@ -17,20 +17,21 @@
 #include "bootutil/security_cnt.h"
 #include <stdint.h>
 
+/* No persistent counter storage; see README.md. */
+
 fih_ret
 boot_nv_security_counter_init(void)
 {
-    /* Do nothing. */
-    return FIH_SUCCESS;
+    return FIH_FAILURE;
 }
 
 fih_ret
 boot_nv_security_counter_get(uint32_t image_id, fih_int *security_cnt)
 {
     (void)image_id;
-    *security_cnt = 30;
+    (void)security_cnt;
 
-    return FIH_SUCCESS;
+    FIH_RET(FIH_FAILURE);
 }
 
 int32_t
@@ -39,6 +40,5 @@ boot_nv_security_counter_update(uint32_t image_id, uint32_t img_security_cnt)
     (void)image_id;
     (void)img_security_cnt;
 
-    /* Do nothing. */
-    return 0;
+    return -1;
 }

--- a/docs/release-notes.d/cypress-security-counter-fail-closed.md
+++ b/docs/release-notes.d/cypress-security-counter-fail-closed.md
@@ -1,0 +1,4 @@
+- The Cypress security counter example backend now fails closed. It
+  previously reported a fixed counter value and discarded updates while
+  reporting success, so `MCUBOOT_HW_ROLLBACK_PROT` builds using it ran with
+  a rollback floor that never advanced.


### PR DESCRIPTION
Hi!

The example backend returned a fixed counter value and discarded updates while reporting success. It linked and ran with a rollback floor that never advanced with no error at build or boot time because a build that enables MCUBOOT_HW_ROLLBACK_PROT picks this file up automatically.

This PR proposes to return errors instead and document that a persistent platform backend is required before enabling MCUBOOT_HW_ROLLBACK_PROT.

Thanks!
Flavien