### PR TITLE
boot_serial: check flash_area_get_sector() return in decrypt_image_inplace()

### DIFF
--- a/boot/boot_serial/src/boot_serial_encryption.c
+++ b/boot/boot_serial/src/boot_serial_encryption.c
@@ -233,6 +233,9 @@ decrypt_image_inplace(const struct flash_area *fa_p,
 
     /* Get size from last sector to know page/sector erase size */
     rc = flash_area_get_sector(fa_p, boot_status_off(fa_p), &sector);
+    if (rc != 0) {
+        goto total_out;
+    }
 
     if(IS_ENCRYPTED(hdr)) {
 #if 0 //Skip this step?, the image will just not boot if it's not decrypted properly

--- a/docs/release-notes.d/serial-recovery-decrypt-sector-rc.md
+++ b/docs/release-notes.d/serial-recovery-decrypt-sector-rc.md
@@ -1,0 +1,7 @@
+- Fixed a bug in ``decrypt_image_inplace()`` (serial recovery, encrypted
+  image upload) where the return value of ``flash_area_get_sector()`` was
+  not checked. On a flash driver that fails this call, the ``sector``
+  struct is left unpopulated and its ``fs_size`` field is later used as a
+  divisor, which could result in a division by zero. The return value is
+  now checked and the function bails out on failure, matching the same
+  check already performed in ``bs_upload()``.


### PR DESCRIPTION
## Problem

In `decrypt_image_inplace()` (`boot/boot_serial/src/boot_serial_encryption.c`), the return value of

```c
rc = flash_area_get_sector(fa_p, boot_status_off(fa_p), &sector);
```

was never checked (`rc` is subsequently overwritten by `boot_enc_load()`'s return value a few lines later). The `sector` struct populated by this call is later used as the divisor for the sector-count calculation:

```c
sect_size = sector.fs_size;
sect_count = fa_p->fa_size / sect_size;
```

If `flash_area_get_sector()` fails, `sector` is left unpopulated (confirmed against the Zephyr backend implementation in `boot/zephyr/flash_map_extended.c`, which returns nonzero without writing to the output struct on both of its failure branches), so `sector.fs_size` is used uninitialized. Depending on its value this can lead to a division by zero, or otherwise silently corrupt the decrypt geometry, instead of returning a clean error.

This function is reachable from the live serial-recovery encrypted-image upload path (`boot_handle_enc_fw()` -> `decrypt_image_inplace()`) whenever `MCUBOOT_ENC_IMAGES` is enabled and a full image has been received into the primary slot, so it is not dead code.

## Fix

Check the return value immediately and bail out on failure, mirroring the sibling function `bs_upload()` in `boot_serial.c`, which performs the exact same `flash_area_get_sector(fap, boot_status_off(fap), &status_sector)` call and already checks its return value:

```c
rc = flash_area_get_sector(fa_p, boot_status_off(fa_p), &sector);
if (rc != 0) {
    goto total_out;
}
```

## Testing

Since reproducing a real flash-driver failure requires target hardware, I extracted the relevant statement shapes into a standalone C harness with a mock `flash_area_get_sector()` that faithfully models the real failure semantics (returns nonzero without writing to the output struct). Results:
- Baseline success case: identical behavior before/after the fix (`sect_count` computed correctly).
- Simulated `flash_area_get_sector()` failure: the current code reaches the `fa_p->fa_size / sect_size` division with an uninitialized `sect_size` and crashes with SIGFPE (integer division by zero); with the fix applied, the function safely returns before reaching that statement.

Added a release-note stub in `docs/release-notes.d/` per `docs/contributing.md`.