### PR TITLE
boot_serial: Increase unaligned buffer default value for renesas RA family

### DIFF
--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -101,6 +101,7 @@ config BOOT_SERIAL_UNALIGNED_BUFFER_SIZE
 	int "Stack buffer for unaligned memory writes"
 	default 512 if SOC_SERIES_LPC55XXX
 	default 128 if SOC_SERIES_MCXN
+	default 128 if SOC_FAMILY_RENESAS_RA
 	default 64
 	range 0 1024
 	help


### PR DESCRIPTION
Set the default unaligned buffer size for the renesas RA family to 128

The RA family has to write flash 128 bytes at a time, so the buffer needs to be large enough to hold the entire write