### PR TITLE
boot: bootutil: require exact hash TLV length

### DIFF
--- a/boot/bootutil/src/boot_record.c
+++ b/boot/bootutil/src/boot_record.c
@@ -179,8 +179,11 @@ boot_save_boot_status(uint8_t sw_module,
             boot_record_found = true;
 
         } else if (type == EXPECTED_HASH_TLV) {
-            /* Get the image's hash value from the manifest section. */
-            if (len > sizeof(image_hash)) {
+            /* Get the image's hash value from the manifest section. The
+             * whole buffer is copied into the boot record below, so the
+             * TLV must fill it exactly.
+             */
+            if (len != sizeof(image_hash)) {
                 return -1;
             }
             rc = flash_area_read(fap, offset, image_hash, len);


### PR DESCRIPTION
`boot_save_boot_status()` reads the image hash out of the manifest into a
fixed-size stack buffer, `uint8_t image_hash[IMAGE_HASH_SIZE]`. The only length
check on the hash TLV was an upper bound:

```c
if (len > sizeof(image_hash)) {
    return -1;
}
rc = flash_area_read(fap, offset, image_hash, len);
```

So a TLV shorter than the configured hash length was accepted, and
`flash_area_read()` filled only the first `len` bytes. The rest of `image_hash`
was left holding whatever happened to be on the stack.

Further down, the copy into the boot record uses the buffer size rather than
`len`:

```c
memcpy(buf + offset, image_hash, sizeof(image_hash));
```

so that stale stack content is copied into the record that
`boot_add_data_to_shared_area()` places in the shared data area, and a
consumer of the record sees it as part of the measurement.

A hash TLV shorter than the hash size is malformed, so this rejects it outright
instead of reading it partially. `bootutil_img_validate()` already applies the
same exact-length check (`if (len != sizeof(hash))`), so an image that passes
validation is unaffected by this change; it only tightens the path taken when
the slot is not hash-validated.

Only compiled under `MCUBOOT_MEASURED_BOOT`.

Testing: `cargo test` in `sim/` passes (25 passed, 0 failed). Note that the sim
does not build `boot/bootutil/src/boot_record.c` and never defines
`MCUBOOT_MEASURED_BOOT`, so that is a no-regression run rather than coverage of
this code; the edited file was additionally compiled standalone with measured
boot enabled, with no diagnostics.
