### PR TITLE
boot: cypress: bound flash access by area size

### DIFF
--- a/boot/cypress/cy_flash_pal/cy_flash_map.c
+++ b/boot/cypress/cy_flash_pal/cy_flash_map.c
@@ -228,9 +228,10 @@ int flash_area_read(const struct flash_area *fa, uint32_t off, void *dst,
     int rc = 0;
     size_t addr;
 
-    /* check if requested offset not less then flash area (fa) start */
-    assert(off < fa->fa_off);
-    assert(off + len < fa->fa_off);
+    /* check that the requested range lies inside the flash area (fa) */
+    if (off > fa->fa_size || len > fa->fa_size - off) {
+        return -1;
+    }
     /* convert to absolute address inside a device*/
         addr = fa->fa_off + off;
 
@@ -268,8 +269,10 @@ int flash_area_write(const struct flash_area *fa, uint32_t off,
     size_t write_end_addr;
     const uint32_t * row_ptr = NULL;
 
-    assert(off < fa->fa_off);
-    assert(off + len < fa->fa_off);
+    /* check that the requested range lies inside the flash area (fa) */
+    if (off > fa->fa_size || len > fa->fa_size - off) {
+        return -1;
+    }
 
     /* convert to absolute address inside a device */
     write_start_addr = fa->fa_off + off;
@@ -318,8 +321,11 @@ int flash_area_erase(const struct flash_area *fa, uint32_t off, uint32_t len)
     size_t erase_start_addr;
     size_t erase_end_addr;
 
-    assert(off < fa->fa_off);
-    assert(off + len < fa->fa_off);
+    /* check that the requested range lies inside the flash area (fa) */
+    if (off > fa->fa_size || len > fa->fa_size - off) {
+        return -1;
+    }
+
     assert(!(len % CY_FLASH_SIZEOF_ROW));
 
     /* convert to absolute address inside a device*/


### PR DESCRIPTION
The Cypress flash map backend bounds every flash access against the wrong
field of `struct flash_area`.

`flash_area_read()`, `flash_area_write()` and `flash_area_erase()` all check
the requested offset against `fa->fa_off`, the partition's absolute base
address, rather than `fa->fa_size`, its length. Since `off` is relative to
the start of the area and `fa_off` is a large device address, the check
accepts offsets well past the end of the partition and rejects only
absurdly large ones. The offset is then converted to `fa->fa_off + off` and
used, so an out-of-range request is followed instead of refused.

The checks are also `assert()`s, so they compile out entirely under
`NDEBUG`.

This matters because the bootutil core does not range-check image offsets
itself; it relies on `flash_area_read()` returning an error for anything
outside the area, which is what the other backends (Zephyr, mynewt, sim) do.

Replace all three with an unconditional range check against `fa_size`,
written as

```c
if (off > fa->fa_size || len > fa->fa_size - off) {
    return -1;
}
```

so the arithmetic cannot wrap (`off`, `len` and `fa_size` are all
`uint32_t`). `-1` is what these functions already return from their
bad-device-id path. The row alignment assert in `flash_area_erase()`
expresses a separate caller contract and is left alone.

Inspection only: `boot/cypress/` is not built by the simulator and has no CI
workflow, so this has not been compiled. A review from someone who can build
MCUBootApp for PSoC6 would be welcome.
