### PR TITLE
MCUBOOT_SWAP_STATUS_HOOKS provider-overlay seam

### DIFF
--- a/boot/bootutil/include/bootutil/boot_hooks.h
+++ b/boot/bootutil/include/bootutil/boot_hooks.h
@@ -36,6 +36,7 @@
 
 #include "bootutil/bootutil.h"
 #include "bootutil/fault_injection_hardening.h"
+#include <limits.h>
 
 #define DO_HOOK_CALL(f, ret_default, ...) \
     f(__VA_ARGS__)
@@ -283,5 +284,183 @@ int flash_area_get_device_id_hook(const struct flash_area *fa,
  *         BOOT_HOOK_REGULAR follow the normal execution path.
  */
 int boot_find_next_slot_hook(struct boot_loader_state *state, uint8_t image, enum boot_slot *active_slot);
+
+/* Swap-state hook family.  Uses the same DO_HOOK_CALL / HOOK_CALL_NOP dispatch
+ * machinery as the other hook families (image-access, boot-go, find-slot, ...):
+ * when MCUBOOT_SWAP_STATE_HOOKS is enabled BOOT_SWAP_STATE_HOOK_CALL invokes the
+ * hook and yields its return value; when disabled it evaluates to ret_default
+ * with no call (and no link dependency on the hook symbol).
+ *
+ * Semantics are REPLACE: a compiled-in hook implementation fully owns status
+ * bookkeeping, so a hook, once present, always handles the call -- it never
+ * defers to the built-in path.  Callers use the idiom:
+ *
+ *     int rc = BOOT_SWAP_STATE_HOOK_CALL(f, BOOT_SWAP_STATE_HOOK_REGULAR, ...);
+ *     if (rc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+ *         return rc;              // hook owned it: success or a real error
+ *     }
+ *     ... built-in implementation ...
+ *
+ * The amend variant (built-in runs first, hook augments at a defined point)
+ * passes ret_default = 0, i.e. "nothing to amend" when the family is disabled:
+ *
+ *     rc = BOOT_SWAP_STATE_HOOK_CALL(f, 0, ...);
+ *
+ * BOOT_SWAP_STATE_HOOK_REGULAR is the family's "not handled" sentinel.  It is NOT
+ * BOOT_HOOK_REGULAR: BOOT_HOOK_REGULAR == BOOT_EFLASH == 1 (bootutil_public.h)
+ * and these hooks return BOOT_EFLASH on real flash errors, so reusing it would
+ * misread a flash error as "defer to the built-in status-byte path" and run it
+ * after a flash fault.  INT_MIN is distinct from 0 and every BOOT_E* code, so no
+ * hook return value can collide with it. */
+#define BOOT_SWAP_STATE_HOOK_REGULAR  INT_MIN
+
+#ifdef MCUBOOT_SWAP_STATE_HOOKS
+#define BOOT_SWAP_STATE_HOOK_CALL(f, ret_default, ...) \
+    DO_HOOK_CALL(f, ret_default, __VA_ARGS__)
+#else
+#define BOOT_SWAP_STATE_HOOK_CALL(f, ret_default, ...) \
+    HOOK_CALL_NOP(f, ret_default, __VA_ARGS__)
+#endif
+
+/* boot_hooks.h is a PUBLIC header with consumers that never include the private
+ * bootutil_priv.h (e.g. boot/zephyr/flash_map_extended.c) -- struct boot_status
+ * is defined only there, so forward-declare it or the prototypes below create
+ * prototype-scope tags (warning / incompatible-declaration risk). */
+struct boot_status;
+
+/**
+ * Swap-state hook implementations are strong symbols that MUST be linked
+ * whenever MCUBOOT_SWAP_STATE_HOOKS is defined.
+ *
+ * @return 0 on success, or a BOOT_E* error which the caller returns verbatim.
+ *         BOOT_HOOK_REGULAR has no meaning for this family because there is no
+ *         runtime fallthrough.
+ */
+int boot_write_status_hook(const struct boot_loader_state *state,
+                           struct boot_status *bs);
+int swap_status_init_hook(struct boot_loader_state *state,
+                          const struct flash_area *fap,
+                          const struct boot_status *bs);
+int swap_read_status_bytes_hook(const struct flash_area *fap,
+                                struct boot_loader_state *state,
+                                struct boot_status *bs);
+
+/**
+ * Commit swap-state authority to its permanent home before the swap flow
+ * erases a staging area that may still hold it.  A downstream swap-state
+ * provider implements this to make its authority durable first, so an
+ * interruption after the erase still recovers.  The scratch swap flow
+ * (swap_scratch.c) is the only caller today; a future algorithm with a
+ * pre-swap staging erase can attach here.
+ *
+ * @return 0 on success, or a BOOT_E* error. The caller must not erase the
+ *         staging area after an error.
+ */
+int swap_status_before_erase_hook(const struct boot_loader_state *state,
+                                  const struct flash_area *fap_pri,
+                                  const struct flash_area *fap_staging,
+                                  struct boot_status *bs);
+
+/**
+ * Amends boot_swap_image() after swap_run(), for hook implementations that keep
+ * swap progress outside the image trailers.  It reconstructs any primary
+ * trailer field left uncommitted by an interrupted swap (the data copy may be
+ * complete while MAGIC was not yet written) and erases a stale scratch trailer
+ * that would otherwise re-enter the swap path on the next boot.
+ *
+ * @return 0 on success, or a BOOT_E* error which the caller asserts on.
+ */
+int boot_swap_complete_hook(struct boot_loader_state *state,
+                            struct boot_status *bs);
+
+/**
+ * Identifies a single field of the swap-state metadata record kept by a
+ * swap-state-metadata provider (read/written/committed by the hooks below).
+ * The encryption-key and IV identifiers are reserved: no caller passes them
+ * yet, and a hook implementation may reject them.
+ */
+enum boot_swap_meta_field {
+    BOOT_SWAP_META_MAGIC = 0,
+    BOOT_SWAP_META_IMAGE_OK,
+    BOOT_SWAP_META_COPY_DONE,
+    BOOT_SWAP_META_SWAP_INFO,
+    BOOT_SWAP_META_SWAP_SIZE,
+    BOOT_SWAP_META_ENC_KEY_0,   /* reserved */
+    BOOT_SWAP_META_ENC_KEY_1,   /* reserved */
+    BOOT_SWAP_META_IV           /* reserved */
+};
+
+/**
+ * Reports the physical constraints of a swap-state-metadata provider's
+ * backing store, as populated by boot_swap_meta_geometry_hook().
+ */
+struct boot_swap_meta_geometry {
+    /** Smallest unit the provider can write atomically. */
+    uint32_t atomic_io_size;
+    /** Bytes the provider reserves at the tail of the image slot. */
+    uint32_t image_tail_reserved;
+    /** True if the provider itself lays down a v1-style image trailer. */
+    bool materializes_trailer;
+};
+
+/**
+ * Reads the swap state (as swap_read_status_bytes_hook() would) from a
+ * swap-state-metadata provider's record instead of the native trailer.
+ *
+ * @return 0 on success, or a BOOT_E* error which the caller returns verbatim.
+ */
+int boot_read_swap_state_hook(const struct flash_area *fap,
+                              struct boot_swap_state *state);
+
+/**
+ * Reads a single field out of the provider's swap-state metadata record.
+ *
+ * @param field the field to read.
+ * @param out   buffer to receive the field's value.
+ * @param len   size of @p out, in bytes.
+ *
+ * @return 0 on success, or a BOOT_E* error.
+ */
+int boot_swap_meta_read_field_hook(const struct flash_area *fap,
+                                   enum boot_swap_meta_field field,
+                                   void *out, size_t len);
+
+/**
+ * Writes a single field into the provider's swap-state metadata record.
+ *
+ * @param field the field to write.
+ * @param in    buffer holding the field's new value.
+ * @param len   size of @p in, in bytes.
+ *
+ * @return 0 on success, or a BOOT_E* error.
+ */
+int boot_swap_meta_write_field_hook(const struct flash_area *fap,
+                                    enum boot_swap_meta_field field,
+                                    const void *in, size_t len);
+
+/**
+ * Commits the in-memory boot_status to the provider's metadata record.
+ *
+ * @return 0 on success, or a BOOT_E* error.
+ */
+int boot_swap_meta_commit_hook(const struct flash_area *fap,
+                               struct boot_status *bs);
+
+/**
+ * Resets/erases the provider's swap-state metadata record for a slot.
+ *
+ * @return 0 on success, or a BOOT_E* error.
+ */
+int boot_swap_meta_reset_hook(const struct boot_loader_state *state,
+                              const struct flash_area *fap, int slot);
+
+/**
+ * Reports the provider's backing-store geometry so the built-in swap logic
+ * can size scratch usage and atomic writes correctly.
+ *
+ * @return 0 on success, or a BOOT_E* error.
+ */
+int boot_swap_meta_geometry_hook(const struct flash_area *fap,
+                                 struct boot_swap_meta_geometry *geo);
 
 #endif /*H_BOOTUTIL_HOOKS*/

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -35,6 +35,7 @@
 
 #include "bootutil/image.h"
 #include "bootutil/bootutil.h"
+#include "bootutil/boot_hooks.h"
 #include "bootutil_priv.h"
 #include "bootutil_misc.h"
 #include "bootutil/bootutil_log.h"
@@ -130,6 +131,18 @@ boot_status_off(const struct flash_area *fap)
 
     elem_sz = flash_area_align(fap);
 
+#if defined(MCUBOOT_SWAP_STATE_HOOKS)
+    {
+        struct boot_swap_meta_geometry geo;
+        int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_geometry_hook, BOOT_SWAP_STATE_HOOK_REGULAR, fap, &geo);
+        if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR && geo.materializes_trailer) {
+            uint32_t off_from_end = geo.image_tail_reserved;
+            assert(off_from_end <= flash_area_get_size(fap));
+            return flash_area_get_size(fap) - off_from_end;
+        }
+    }
+#endif
+
 #if MCUBOOT_SWAP_USING_SCRATCH
     if (flash_area_get_id(fap) == FLASH_AREA_IMAGE_SCRATCH) {
         off_from_end = boot_scratch_trailer_sz(elem_sz);
@@ -189,7 +202,11 @@ boot_find_status(const struct boot_loader_state *state, int image_index)
         int rc = 0;
 
         fa_p = areas[i];
-        rc = flash_area_read(fa_p, boot_magic_off(fa_p), magic, BOOT_MAGIC_SZ);
+#if defined(MCUBOOT_SWAP_STATE_HOOKS)
+        int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_read_field_hook, BOOT_SWAP_STATE_HOOK_REGULAR, fa_p, BOOT_SWAP_META_MAGIC, magic, BOOT_MAGIC_SZ);
+        if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) { rc = hrc; } else
+#endif
+        { rc = flash_area_read(fa_p, boot_magic_off(fa_p), magic, BOOT_MAGIC_SZ); }
 
         if (rc != 0) {
             BOOT_LOG_ERR("Failed to read status from %d, err %d\n",
@@ -211,6 +228,14 @@ boot_read_swap_size(const struct flash_area *fap, uint32_t *swap_size)
 {
     uint32_t off;
     int rc;
+
+    int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_read_field_hook,
+                                             BOOT_SWAP_STATE_HOOK_REGULAR, fap,
+                                             BOOT_SWAP_META_SWAP_SIZE, swap_size,
+                                             sizeof *swap_size);
+    if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+        return hrc;
+    }
 
     off = boot_swap_size_off(fap);
     rc = flash_area_read(fap, off, swap_size, sizeof *swap_size);
@@ -298,6 +323,13 @@ int
 boot_write_swap_size(const struct flash_area *fap, uint32_t swap_size)
 {
     uint32_t off;
+
+    int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_write_field_hook,
+                                             BOOT_SWAP_STATE_HOOK_REGULAR, fap,
+                                             BOOT_SWAP_META_SWAP_SIZE, &swap_size, 4);
+    if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+        return hrc;
+    }
 
     off = boot_swap_size_off(fap);
     BOOT_LOG_DBG("writing swap_size; fa_id=%d off=0x%lx (0x%lx)",

--- a/boot/bootutil/src/bootutil_misc.h
+++ b/boot/bootutil/src/bootutil_misc.h
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (c) 2023 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Infineon Technologies AG
  *
  */
 #ifndef H_BOOTUTIL_MISC_

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -4,6 +4,7 @@
  * Copyright (c) 2017-2020 Linaro LTD
  * Copyright (c) 2017-2019 JUUL Labs
  * Copyright (c) 2019-2021 Arm Limited
+ * Copyright (c) 2026 Infineon Technologies AG
  *
  * Original license:
  *
@@ -344,6 +345,21 @@ int boot_slots_compatible(struct boot_loader_state *state);
 uint32_t boot_status_internal_off(const struct boot_status *bs, int elem_sz);
 int boot_read_image_header(struct boot_loader_state *state, int slot,
                            struct image_header *out_hdr, struct boot_status *bs);
+#ifdef MCUBOOT_ENC_IMAGES
+/*
+ * Apply, in place, the exact content transform boot_copy_region applies to one
+ * chunk being written to `fap_dst` at absolute offset `abs_off` within the
+ * destination image area (not a device address). The primitive recomputes
+ * encrypted_src / encrypted_dst / only_copy / source_slot from `state`,
+ * `fap_src`, and `fap_dst` and selects the governing header itself -- primary
+ * header when encrypting, secondary header when decrypting. No-op for a
+ * non-encrypted image or a same-slot (only_copy) move.
+ */
+void boot_transform_chunk(struct boot_loader_state *state,
+                          const struct flash_area *fap_src,
+                          const struct flash_area *fap_dst,
+                          uint32_t abs_off, uint8_t *buf, uint32_t chunk_sz);
+#endif
 #if defined(MCUBOOT_SWAP_USING_OFFSET) && defined(MCUBOOT_ENC_IMAGES)
 int boot_copy_region(struct boot_loader_state *state,
                      const struct flash_area *fap_src,

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -248,6 +248,12 @@ boot_read_swap_state(const struct flash_area *fap,
     uint8_t swap_info;
     int rc;
 
+    int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_read_swap_state_hook,
+                                             BOOT_SWAP_STATE_HOOK_REGULAR, fap, state);
+    if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+        return hrc;
+    }
+
     off = boot_magic_off(fap);
     rc = flash_area_read(fap, off, magic, BOOT_MAGIC_SZ);
     if (rc < 0) {
@@ -307,6 +313,13 @@ boot_write_magic(const struct flash_area *fap)
     int rc;
     uint8_t magic[BOOT_MAGIC_ALIGN_SIZE];
     uint8_t erased_val;
+
+    int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_write_field_hook,
+                                             BOOT_SWAP_STATE_HOOK_REGULAR, fap,
+                                             BOOT_SWAP_META_MAGIC, NULL, 0);
+    if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+        return hrc;
+    }
 
     off = boot_magic_off(fap);
 
@@ -386,6 +399,13 @@ boot_write_image_ok(const struct flash_area *fap)
 {
     uint32_t off;
 
+    int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_write_field_hook,
+                                             BOOT_SWAP_STATE_HOOK_REGULAR, fap,
+                                             BOOT_SWAP_META_IMAGE_OK, NULL, 0);
+    if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+        return hrc;
+    }
+
     off = boot_image_ok_off(fap);
     BOOT_LOG_DBG("writing image_ok; fa_id=%d off=0x%lx (0x%lx)",
                  flash_area_get_id(fap), (unsigned long)off,
@@ -412,6 +432,14 @@ boot_write_swap_info(const struct flash_area *fap, uint8_t swap_type,
     uint8_t swap_info;
 
     BOOT_SET_SWAP_INFO(swap_info, image_num, swap_type);
+
+    int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_write_field_hook,
+                                             BOOT_SWAP_STATE_HOOK_REGULAR, fap,
+                                             BOOT_SWAP_META_SWAP_INFO, &swap_info, 1);
+    if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+        return hrc;
+    }
+
     off = boot_swap_info_off(fap);
     BOOT_LOG_DBG("writing swap_info; fa_id=%d off=0x%lx (0x%lx), swap_type=0x%x"
                  " image_num=0x%x",
@@ -491,10 +519,40 @@ boot_swap_type_multi(int image_index)
     return BOOT_SWAP_TYPE_NONE;
 }
 
+#if defined(MCUBOOT_SWAP_STATE_HOOKS)
+static bool flash_area_is_primary(const struct flash_area *fap)
+{
+    uint8_t id = flash_area_get_id(fap);
+    for (int i = 0; i < BOOT_IMAGE_NUMBER; i++) {
+        if (FLASH_AREA_IMAGE_PRIMARY(i) == id) {
+            return true;
+        }
+    }
+    return false;
+}
+#endif
+
 int
 boot_write_copy_done(const struct flash_area *fap)
 {
     uint32_t off;
+
+#if defined(MCUBOOT_SWAP_STATE_HOOKS)
+    if (flash_area_is_primary(fap)) {
+        int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_commit_hook,
+                                                 BOOT_SWAP_STATE_HOOK_REGULAR, fap, NULL);
+        if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+            return hrc;
+        }
+    } else {
+        int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_write_field_hook,
+                                                 BOOT_SWAP_STATE_HOOK_REGULAR, fap,
+                                                 BOOT_SWAP_META_COPY_DONE, NULL, 0);
+        if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+            return hrc;
+        }
+    }
+#endif
 
     off = boot_copy_done_off(fap);
     BOOT_LOG_DBG("writing copy_done; fa_id=%d off=0x%lx (0x%lx)",

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -5,6 +5,7 @@
  * Copyright (c) 2016-2019 JUUL Labs
  * Copyright (c) 2019-2023 Arm Limited
  * Copyright (c) 2024-2025 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Infineon Technologies AG
  *
  * Original license:
  *
@@ -413,6 +414,11 @@ boot_status_is_reset(const struct boot_status *bs)
 int
 boot_write_status(const struct boot_loader_state *state, struct boot_status *bs)
 {
+    int hook_rc = BOOT_SWAP_STATE_HOOK_CALL(boot_write_status_hook,
+                                                        BOOT_SWAP_STATE_HOOK_REGULAR, state, bs);
+    if (hook_rc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+        return hook_rc;
+    }
     const struct flash_area *fap;
     uint32_t off;
     int rc = 0;
@@ -624,7 +630,20 @@ boot_validate_slot(struct boot_loader_state *state, int slot,
                 &boot_img_hdr(state, BOOT_SLOT_PRIMARY)->ih_ver);
         if (rc < 0 && !boot_check_header_erased(state, BOOT_SLOT_PRIMARY)) {
             BOOT_LOG_ERR("Insufficient version in secondary slot");
+#if defined(MCUBOOT_SWAP_STATE_HOOKS)
+            {
+                int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_reset_hook,
+                                                         BOOT_SWAP_STATE_HOOK_REGULAR, state,
+                                                         fap, slot);
+                if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+                    /* provider owned the reset */
+                } else {
+                    boot_scramble_slot(fap, slot);
+                }
+            }
+#else
             boot_scramble_slot(fap, slot);
+#endif
             /* Image in the secondary slot does not satisfy version requirement.
              * Erase the image and continue booting from the primary slot.
              */
@@ -652,7 +671,20 @@ check_validity:
                      (slot == BOOT_SLOT_PRIMARY) ? "primary" : "secondary");
 #endif
         if ((slot != BOOT_SLOT_PRIMARY) || ARE_SLOTS_EQUIVALENT()) {
+#if defined(MCUBOOT_SWAP_STATE_HOOKS)
+            {
+                int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_reset_hook,
+                                                         BOOT_SWAP_STATE_HOOK_REGULAR, state,
+                                                         fap, slot);
+                if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+                    /* provider owned the reset */
+                } else {
+                    boot_scramble_slot(fap, slot);
+                }
+            }
+#else
             boot_scramble_slot(fap, slot);
+#endif
             /* Image is invalid, erase it to prevent further unnecessary
              * attempts to validate and boot it.
              */
@@ -706,7 +738,20 @@ check_validity:
              *
              * Erase the image and continue booting from the primary slot.
              */
+#if defined(MCUBOOT_SWAP_STATE_HOOKS)
+            {
+                int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_reset_hook,
+                                                         BOOT_SWAP_STATE_HOOK_REGULAR, state,
+                                                         fap, slot);
+                if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+                    /* provider owned the reset */
+                } else {
+                    boot_scramble_slot(fap, slot);
+                }
+            }
+#else
             boot_scramble_slot(fap, slot);
+#endif
             fih_rc = FIH_NO_BOOTABLE_IMAGE;
             goto out;
         }
@@ -754,6 +799,96 @@ boot_validated_swap_type(struct boot_loader_state *state,
 
 #if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)
 
+#ifdef MCUBOOT_ENC_IMAGES
+void
+boot_transform_chunk(struct boot_loader_state *state,
+                     const struct flash_area *fap_src,
+                     const struct flash_area *fap_dst,
+                     uint32_t abs_off, uint8_t *buf, uint32_t chunk_sz)
+{
+    uint32_t tlv_off;
+    size_t blk_off;
+    struct image_header *hdr;
+    uint16_t idx;
+    uint32_t blk_sz;
+    uint8_t image_index = BOOT_CURR_IMG(state);
+    bool encrypted_src;
+    bool encrypted_dst;
+    /* Assuming the secondary slot is source; note that 0 here not only
+     * means that primary slot is source, but also that there will be
+     * encryption happening, if it is 1 then there is decryption from
+     * secondary slot.
+     */
+    int source_slot = 1;
+    /* In case of encryption enabled, we may have to do more work than
+     * just copy bytes */
+    bool only_copy = false;
+
+    encrypted_src = (flash_area_get_id(fap_src) != FLASH_AREA_IMAGE_PRIMARY(image_index));
+    encrypted_dst = (flash_area_get_id(fap_dst) != FLASH_AREA_IMAGE_PRIMARY(image_index));
+
+    if (encrypted_src != encrypted_dst) {
+        if (encrypted_dst) {
+            /* Need encryption, metadata from the primary slot */
+            hdr = boot_img_hdr(state, BOOT_SLOT_PRIMARY);
+            source_slot = 0;
+        } else {
+            /* Need decryption, metadata from the secondary slot */
+            hdr = boot_img_hdr(state, BOOT_SLOT_SECONDARY);
+            source_slot = 1;
+        }
+    } else {
+        /* In case when source and targe is the same area, this means that we
+         * only have to copy bytes, no encryption or decryption.
+         */
+        only_copy = true;
+    }
+
+    /* If only copy, then does not matter if header indicates need for
+     * encryption/decryption, we just copy data. */
+    if (!only_copy && IS_ENCRYPTED(hdr)) {
+        if (abs_off < hdr->ih_hdr_size) {
+            /* do not decrypt header */
+            if (abs_off + chunk_sz > hdr->ih_hdr_size) {
+                /* The lower part of the chunk contains header data */
+                blk_off = 0;
+                blk_sz = chunk_sz - (hdr->ih_hdr_size - abs_off);
+                idx = hdr->ih_hdr_size  - abs_off;
+            } else {
+                /* The chunk contains exclusively header data */
+                blk_sz = 0; /* nothing to decrypt */
+            }
+        } else {
+            idx = 0;
+            blk_sz = chunk_sz;
+            blk_off = (abs_off - hdr->ih_hdr_size) & 0xf;
+        }
+
+        if (blk_sz > 0)
+        {
+            tlv_off = BOOT_TLV_OFF(hdr);
+            if (abs_off + chunk_sz > tlv_off) {
+                /* do not decrypt TLVs */
+                if (abs_off >= tlv_off) {
+                    blk_sz = 0;
+                } else {
+                    blk_sz = tlv_off - abs_off - idx;
+                }
+            }
+            if (source_slot == 0) {
+                boot_enc_encrypt(BOOT_CURR_ENC_SLOT(state, source_slot),
+                        (abs_off + idx) - hdr->ih_hdr_size, blk_sz,
+                        blk_off, &buf[idx]);
+            } else {
+                boot_enc_decrypt(BOOT_CURR_ENC_SLOT(state, source_slot),
+                        (abs_off + idx) - hdr->ih_hdr_size, blk_sz,
+                        blk_off, &buf[idx]);
+            }
+        }
+    }
+}
+#endif
+
 /**
  * Copies the contents of one flash region to another.  You must erase the
  * destination region prior to calling this function.
@@ -788,50 +923,11 @@ boot_copy_region(struct boot_loader_state *state,
     int rc;
 #ifdef MCUBOOT_ENC_IMAGES
     uint32_t off = off_dst;
-    uint32_t tlv_off;
-    size_t blk_off;
-    struct image_header *hdr;
-    uint16_t idx;
-    uint32_t blk_sz;
-    uint8_t image_index = BOOT_CURR_IMG(state);
-    bool encrypted_src;
-    bool encrypted_dst;
-    /* Assuming the secondary slot is source; note that 0 here not only
-     * means that primary slot is source, but also that there will be
-     * encryption happening, if it is 1 then there is decryption from
-     * secondary slot.
-     */
-    int source_slot = 1;
-    /* In case of encryption enabled, we may have to do more work than
-     * just copy bytes */
-    bool only_copy = false;
 #else
     (void)state;
 #endif
 
     TARGET_STATIC uint8_t buf[BUF_SZ] __attribute__((aligned(4)));
-
-#ifdef MCUBOOT_ENC_IMAGES
-    encrypted_src = (flash_area_get_id(fap_src) != FLASH_AREA_IMAGE_PRIMARY(image_index));
-    encrypted_dst = (flash_area_get_id(fap_dst) != FLASH_AREA_IMAGE_PRIMARY(image_index));
-
-    if (encrypted_src != encrypted_dst) {
-        if (encrypted_dst) {
-            /* Need encryption, metadata from the primary slot */
-            hdr = boot_img_hdr(state, BOOT_SLOT_PRIMARY);
-            source_slot = 0;
-        } else {
-            /* Need decryption, metadata from the secondary slot */
-            hdr = boot_img_hdr(state, BOOT_SLOT_SECONDARY);
-            source_slot = 1;
-        }
-    } else {
-        /* In case when source and targe is the same area, this means that we
-         * only have to copy bytes, no encryption or decryption.
-         */
-        only_copy = true;
-    }
-#endif
 
     bytes_copied = 0;
     while (bytes_copied < sz) {
@@ -847,53 +943,12 @@ boot_copy_region(struct boot_loader_state *state,
         }
 
 #ifdef MCUBOOT_ENC_IMAGES
-        /* If only copy, then does not matter if header indicates need for
-         * encryption/decryption, we just copy data. */
-        if (!only_copy && IS_ENCRYPTED(hdr)) {
 #if defined(MCUBOOT_SWAP_USING_OFFSET)
-            uint32_t abs_off = off - sector_off + bytes_copied;
+        uint32_t abs_off = off - sector_off + bytes_copied;
 #else
-            uint32_t abs_off = off + bytes_copied;
+        uint32_t abs_off = off + bytes_copied;
 #endif
-            if (abs_off < hdr->ih_hdr_size) {
-                /* do not decrypt header */
-                if (abs_off + chunk_sz > hdr->ih_hdr_size) {
-                    /* The lower part of the chunk contains header data */
-                    blk_off = 0;
-                    blk_sz = chunk_sz - (hdr->ih_hdr_size - abs_off);
-                    idx = hdr->ih_hdr_size  - abs_off;
-                } else {
-                    /* The chunk contains exclusively header data */
-                    blk_sz = 0; /* nothing to decrypt */
-                }
-            } else {
-                idx = 0;
-                blk_sz = chunk_sz;
-                blk_off = (abs_off - hdr->ih_hdr_size) & 0xf;
-            }
-
-            if (blk_sz > 0)
-            {
-                tlv_off = BOOT_TLV_OFF(hdr);
-                if (abs_off + chunk_sz > tlv_off) {
-                    /* do not decrypt TLVs */
-                    if (abs_off >= tlv_off) {
-                        blk_sz = 0;
-                    } else {
-                        blk_sz = tlv_off - abs_off - idx;
-                    }
-                }
-                if (source_slot == 0) {
-                    boot_enc_encrypt(BOOT_CURR_ENC_SLOT(state, source_slot),
-                            (abs_off + idx) - hdr->ih_hdr_size, blk_sz,
-                            blk_off, &buf[idx]);
-                } else {
-                    boot_enc_decrypt(BOOT_CURR_ENC_SLOT(state, source_slot),
-                            (abs_off + idx) - hdr->ih_hdr_size, blk_sz,
-                            blk_off, &buf[idx]);
-                }
-            }
-        }
+        boot_transform_chunk(state, fap_src, fap_dst, abs_off, buf, chunk_sz);
 #endif
 
         rc = flash_area_write(fap_dst, off_dst + bytes_copied, buf, chunk_sz);
@@ -1192,6 +1247,15 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
     }
 
     swap_run(state, bs, copy_size);
+
+    /* Post-swap finalization for hook implementations that keep swap progress
+     * outside the image trailers: reconstruct any primary trailer field left
+     * uncommitted by an interrupted swap and erase a stale scratch trailer.
+     * BOOT_SWAP_STATE_HOOK_CALL evaluates to its ret_default (0, no-op) when
+     * MCUBOOT_SWAP_STATE_HOOKS is not defined, so builds without the hook
+     * family are unaffected. */
+    rc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_complete_hook, 0, state, bs);
+    assert(rc == 0);
 
 #ifdef MCUBOOT_VALIDATE_PRIMARY_SLOT
     extern int boot_status_fails;
@@ -1668,7 +1732,20 @@ check_downgrade_prevention(struct boot_loader_state *state)
     if (rc < 0) {
         /* Image in slot 0 prevents downgrade, delete image in slot 1 */
         BOOT_LOG_INF("Image %d in slot 1 erased due to downgrade prevention", BOOT_CURR_IMG(state));
+#if defined(MCUBOOT_SWAP_STATE_HOOKS)
+        {
+            int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_reset_hook,
+                                                     BOOT_SWAP_STATE_HOOK_REGULAR, state,
+                                                     BOOT_IMG_AREA(state, 1), BOOT_SLOT_SECONDARY);
+            if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+                /* provider owned the reset */
+            } else {
+                boot_scramble_slot(BOOT_IMG_AREA(state, 1), BOOT_SLOT_SECONDARY);
+            }
+        }
+#else
         boot_scramble_slot(BOOT_IMG_AREA(state, 1), BOOT_SLOT_SECONDARY);
+#endif
     } else {
         rc = 0;
     }

--- a/boot/bootutil/src/swap_misc.c
+++ b/boot/bootutil/src/swap_misc.c
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2019 JUUL Labs
  * Copyright (c) 2025 Nordic Semiconductor ASA
+ * Copyright (c) 2026 Infineon Technologies AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "bootutil/bootutil.h"
+#include "bootutil/boot_hooks.h"
 #include "bootutil_priv.h"
 #include "swap_priv.h"
 #include "bootutil/bootutil_log.h"
@@ -37,6 +39,14 @@ swap_erase_trailer_sectors(const struct boot_loader_state *state,
                            const struct flash_area *fap)
 {
     int rc = 0;
+
+    int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_reset_hook,
+                                             BOOT_SWAP_STATE_HOOK_REGULAR, state, fap,
+                                             (fap == BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY)) ?
+                                                 BOOT_SLOT_SECONDARY : BOOT_SLOT_PRIMARY);
+    if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+        return hrc;
+    }
 
     /* Intention is to prepare slot for write, if device does not require/support
      * erase, there is nothing to do here.
@@ -81,6 +91,14 @@ swap_scramble_trailer_sectors(const struct boot_loader_state *state,
     size_t off;
     int rc;
 
+    int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_reset_hook,
+                                             BOOT_SWAP_STATE_HOOK_REGULAR, state, fap,
+                                             (fap == BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY)) ?
+                                                 BOOT_SLOT_SECONDARY : BOOT_SLOT_PRIMARY);
+    if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+        return hrc;
+    }
+
     BOOT_LOG_DBG("swap_scramble_trailer_sectors: fa_id=%d", flash_area_get_id(fap));
 
     /* Delete starting from last sector and moving to beginning */
@@ -104,10 +122,15 @@ swap_scramble_trailer_sectors(const struct boot_loader_state *state,
  * twice on these devices.
  */
 int
-swap_status_init(const struct boot_loader_state *state,
+swap_status_init(struct boot_loader_state *state,
                  const struct flash_area *fap,
                  const struct boot_status *bs)
 {
+    int hook_rc = BOOT_SWAP_STATE_HOOK_CALL(swap_status_init_hook,
+                                                        BOOT_SWAP_STATE_HOOK_REGULAR, state, fap, bs);
+    if (hook_rc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+        return hook_rc;
+    }
     struct boot_swap_state swap_state;
     uint8_t image_index;
     int rc;
@@ -186,8 +209,16 @@ swap_read_status(struct boot_loader_state *state, struct boot_status *bs)
 
     rc = swap_read_status_bytes(fap, state, bs);
     if (rc == 0) {
-        off = boot_swap_info_off(fap);
-        rc = flash_area_read(fap, off, &swap_info, sizeof swap_info);
+        int hrc = BOOT_SWAP_STATE_HOOK_CALL(boot_swap_meta_read_field_hook,
+                                                 BOOT_SWAP_STATE_HOOK_REGULAR, fap,
+                                                 BOOT_SWAP_META_SWAP_INFO, &swap_info,
+                                                 sizeof swap_info);
+        if (hrc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+            rc = hrc;
+        } else {
+            off = boot_swap_info_off(fap);
+            rc = flash_area_read(fap, off, &swap_info, sizeof swap_info);
+        }
         if (rc != 0) {
             rc = BOOT_EFLASH;
             goto done;

--- a/boot/bootutil/src/swap_move.c
+++ b/boot/bootutil/src/swap_move.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "bootutil/bootutil.h"
+#include "bootutil/boot_hooks.h"
 #include "bootutil_priv.h"
 #include "swap_priv.h"
 #include "bootutil/bootutil_log.h"
@@ -138,6 +139,11 @@ int
 swap_read_status_bytes(const struct flash_area *fap,
         struct boot_loader_state *state, struct boot_status *bs)
 {
+    int hook_rc = BOOT_SWAP_STATE_HOOK_CALL(swap_read_status_bytes_hook,
+                                                        BOOT_SWAP_STATE_HOOK_REGULAR, fap, state, bs);
+    if (hook_rc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+        return hook_rc;
+    }
     uint32_t off;
     uint8_t status;
     int max_entries;
@@ -447,7 +453,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
  * upgrade (by initializing the secondary slot).
  */
 void
-fixup_revert(const struct boot_loader_state *state, struct boot_status *bs,
+fixup_revert(struct boot_loader_state *state, struct boot_status *bs,
         const struct flash_area *fap_sec)
 {
     struct boot_swap_state swap_state;

--- a/boot/bootutil/src/swap_offset.c
+++ b/boot/bootutil/src/swap_offset.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "bootutil/bootutil.h"
+#include "bootutil/boot_hooks.h"
 #include "bootutil_priv.h"
 #include "swap_priv.h"
 #include "bootutil/bootutil_log.h"
@@ -223,6 +224,11 @@ done:
 int swap_read_status_bytes(const struct flash_area *fap, struct boot_loader_state *state,
                            struct boot_status *bs)
 {
+    int hook_rc = BOOT_SWAP_STATE_HOOK_CALL(swap_read_status_bytes_hook,
+                                                        BOOT_SWAP_STATE_HOOK_REGULAR, fap, state, bs);
+    if (hook_rc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+        return hook_rc;
+    }
     uint32_t off;
     uint8_t status;
     int max_entries;
@@ -546,7 +552,7 @@ static void boot_swap_sectors_revert(int idx, uint32_t sz, struct boot_loader_st
  * This function handles the issue by making the revert look like a permanent
  * upgrade (by initializing the secondary slot).
  */
-void fixup_revert(const struct boot_loader_state *state, struct boot_status *bs,
+void fixup_revert(struct boot_loader_state *state, struct boot_status *bs,
                   const struct flash_area *fap_sec)
 {
     struct boot_swap_state swap_state;

--- a/boot/bootutil/src/swap_priv.h
+++ b/boot/bootutil/src/swap_priv.h
@@ -45,7 +45,7 @@ int swap_scramble_trailer_sectors(const struct boot_loader_state *state,
  * Initialize the given flash_area with the metadata required to start a new
  * swap upgrade.
  */
-int swap_status_init(const struct boot_loader_state *state,
+int swap_status_init(struct boot_loader_state *state,
                      const struct flash_area *fap,
                      const struct boot_status *bs);
 
@@ -108,6 +108,30 @@ static inline size_t boot_scratch_area_size(const struct boot_loader_state *stat
 {
     return flash_area_get_size(BOOT_SCRATCH_AREA(state));
 }
+
+/**
+ * Calculates the number of bytes to copy in a single swap step, grouping
+ * contiguous sectors that fit within the scratch area size.
+ *
+ * @param state              Current bootloader's state.
+ * @param last_sector_idx    Index of the last sector in the group (inclusive).
+ * @param out_first_sector_idx  Output: index of the first sector (inclusive).
+ *
+ * @return  The number of bytes comprised by the [first, last] sector range.
+ */
+uint32_t boot_copy_sz(const struct boot_loader_state *state,
+                      int last_sector_idx, int *out_first_sector_idx);
+
+/**
+ * Finds the index of the last sector in the primary slot that needs swapping.
+ *
+ * @param state      Current bootloader's state.
+ * @param copy_size  Total number of bytes to swap.
+ *
+ * @return  Index of the last sector that needs swapping.
+ */
+int find_last_sector_idx(const struct boot_loader_state *state,
+                         uint32_t copy_size);
 #endif
 
 #endif /* defined(MCUBOOT_SWAP_USING_SCRATCH) || defined(MCUBOOT_SWAP_USING_MOVE) || defined(MCUBOOT_SWAP_USING_OFFSET) */

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (c) 2019 JUUL Labs
+ * Copyright (c) 2026 Infineon Technologies AG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "bootutil/bootutil.h"
+#include "bootutil/boot_hooks.h"
 #include "bootutil_priv.h"
 #include "swap_priv.h"
 #include "bootutil/bootutil_log.h"
@@ -187,6 +189,11 @@ int
 swap_read_status_bytes(const struct flash_area *fap,
         struct boot_loader_state *state, struct boot_status *bs)
 {
+    int hook_rc = BOOT_SWAP_STATE_HOOK_CALL(swap_read_status_bytes_hook,
+                                                        BOOT_SWAP_STATE_HOOK_REGULAR, fap, state, bs);
+    if (hook_rc != BOOT_SWAP_STATE_HOOK_REGULAR) {
+        return hook_rc;
+    }
     uint32_t off;
     uint8_t status;
     int max_entries;
@@ -489,10 +496,12 @@ swap_status_source(struct boot_loader_state *state)
     rc = boot_read_swap_state(state->imgs[image_index][BOOT_SLOT_PRIMARY].area,
                               &state_primary_slot);
     assert(rc == 0);
+    (void)rc;
 
 #if MCUBOOT_SWAP_USING_SCRATCH
     rc = boot_read_swap_state(state->scratch.area, &state_scratch);
     assert(rc == 0);
+    (void)rc;
 #endif
 
     BOOT_LOG_SWAP_STATE("Primary image", &state_primary_slot);
@@ -551,7 +560,7 @@ swap_status_source(struct boot_loader_state *state)
  * @return                      The number of bytes comprised by the
  *                                  [first-sector, last-sector] range.
  */
-static uint32_t
+uint32_t
 boot_copy_sz(const struct boot_loader_state *state, int last_sector_idx,
              int *out_first_sector_idx)
 {
@@ -591,7 +600,7 @@ boot_copy_sz(const struct boot_loader_state *state, int last_sector_idx,
  *
  * @return          Index of the last sector in the primary slot that needs swapping.
  */
-static int
+int
 find_last_sector_idx(const struct boot_loader_state *state, uint32_t copy_size)
 {
     int last_sector_idx_primary;
@@ -746,6 +755,11 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
     bs->use_scratch = (bs->idx == BOOT_STATUS_IDX_0 && copy_sz != sz);
 
     if (bs->state == BOOT_STATUS_STATE_0) {
+        rc = BOOT_SWAP_STATE_HOOK_CALL(
+                swap_status_before_erase_hook, 0,
+                state, fap_primary_slot, fap_scratch, bs);
+        assert(rc == 0);
+
         BOOT_LOG_DBG("erasing scratch area");
         rc = boot_erase_region(fap_scratch, 0, flash_area_get_size(fap_scratch), false);
         assert(rc == 0);
@@ -794,9 +808,20 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_loader_state *state,
              * This is necessary even though the current area being swapped contains part of the
              * trailer since in case the trailer spreads over multiple sector erasing the [img_off,
              * img_off + sz) might not erase the entire trailer.
-              */
+             *
+             * Under MCUBOOT_SWAP_STATE_HOOKS the swap state lives outside the
+             * image trailers, so the secondary trailer is not the status
+             * authority and scrambling it is unnecessary.  Skipping it also
+             * avoids destroying image data (TLVs) sharing the trailer sector,
+             * which would leave the secondary image unvalidatable if power is
+             * lost before the swap copies any sector.  The guard is keyed on the
+             * generic hook macro, so this file carries no coupling to any
+             * particular hook implementation.
+             */
+#ifndef MCUBOOT_SWAP_STATE_HOOKS
             rc = swap_scramble_trailer_sectors(state, fap_secondary_slot);
             assert(rc == 0);
+#endif
 
             if (bs->use_scratch) {
                 /* If the area being swapped contains the trailer or part of it, ensure the
@@ -1083,7 +1108,7 @@ boot_read_image_header(struct boot_loader_state *state, int slot,
     if (bs && !boot_status_is_reset(bs)) {
         fap = boot_find_status(state, BOOT_CURR_IMG(state));
 
-        if (rc != 0) {
+        if (fap == NULL) {
             rc = BOOT_EFLASH;
             goto done;
         }


### PR DESCRIPTION
Adds a new hook family, `MCUBOOT_SWAP_STATUS_HOOKS`, that lets a downstream
provider take ownership of swap-status bookkeeping without editing the portable
core. `boot/` stays provider-agnostic — this MR adds only the seam, no provider.

### What it does
- New `BOOT_STATUS_HOOK_CALL(f, ret_default, ...)` in `boot_hooks.h`, built on
  the existing `DO_HOOK_CALL` / `HOOK_CALL_NOP` machinery, same as every other
  hook family. When the gate is undefined it compiles to `ret_default` — no
  call, no link dependency, vanilla path unchanged.
- Dispatch preambles over intact upstream bodies (override style):
  `boot_write_status` (loader.c), `swap_status_init` (swap_misc.c), and
  `swap_read_status_bytes` (swap_offset/move/scratch). Two amend-style sites:
  before the scratch-area erase (swap_scratc
  (loader.c `boot_swap_image`).
- Dedicated sentinel `BOOT_STATUS_HOOK_REGULAR = INT_MIN` instead of reusing
  `BOOT_HOOK_REGULAR`: that constant equals nd
  these hooks legitimately return `BOOT_EFLASH` — reusing it would misread a
  real flash error as "run the built-in path". `INT_MIN` collides with nothing.
- Semantics are REPLACE: an enabled provider
  built-in status-byte path runs only when the family is compiled out.

### Notes
- With `MCUBOOT_SWAP_STATUS_HOOKS` undefined, behavior is identical to                                                upstream by construction.
- Hook implementations are strong symbols the enabling build must link; a
  `#error` guard in `bootutil_priv.h` turns a feature-without-gate
  misconfiguration into a compile-time failure.