### PR TITLE
boot: bootutil: Remove excess flash_area_close function calls

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1207,7 +1207,6 @@ boot_swap_image(struct boot_loader_state *state, struct boot_status *bs)
             }
         }
 #endif
-        flash_area_close(fap);
     }
 
     swap_run(state, bs, copy_size);

--- a/boot/bootutil/src/swap_offset.c
+++ b/boot/bootutil/src/swap_offset.c
@@ -791,7 +791,6 @@ int boot_read_image_size(struct boot_loader_state *state, int slot, uint32_t *si
     rc = 0;
 
 done:
-    flash_area_close(fap);
     return rc;
 }
 

--- a/boot/bootutil/src/swap_scratch.c
+++ b/boot/bootutil/src/swap_scratch.c
@@ -1089,7 +1089,6 @@ boot_read_image_header(struct boot_loader_state *state, int slot,
         }
 
         rc = boot_read_swap_size(fap, &swap_size);
-        flash_area_close(fap);
 
         if (rc != 0) {
             rc = BOOT_EFLASH;


### PR DESCRIPTION
Removes calling this function where it should not be called, as MCUboot cleans up all open slots when it finishes execution

Fixes #2815