### PR TITLE
boot: bootutil: size split_image_check hash by digest

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -40,6 +40,7 @@
 #include "bootutil/bootutil.h"
 #include "bootutil/bootutil_public.h"
 #include "bootutil/image.h"
+#include "bootutil/crypto/sha.h"
 #include "bootutil_priv.h"
 #include "swap_priv.h"
 #include "bootutil/bootutil_log.h"
@@ -468,7 +469,7 @@ split_image_check(struct image_header *app_hdr,
                   const struct flash_area *loader_fap)
 {
     static void *tmpbuf;
-    uint8_t loader_hash[32];
+    uint8_t loader_hash[IMAGE_HASH_SIZE];
     FIH_DECLARE(fih_rc, FIH_FAILURE);
 
     if (!tmpbuf) {
@@ -486,7 +487,7 @@ split_image_check(struct image_header *app_hdr,
     }
 
     FIH_CALL(bootutil_img_validate, fih_rc, NULL, app_hdr, app_fap,
-             tmpbuf, BOOT_TMPBUF_SZ, loader_hash, 32, NULL);
+             tmpbuf, BOOT_TMPBUF_SZ, loader_hash, IMAGE_HASH_SIZE, NULL);
 
 out:
     FIH_RET(fih_rc);


### PR DESCRIPTION
`split_image_check()` declares its `loader_hash` buffer as a fixed 32 bytes and
passes a hardcoded seed length of 32. That buffer is the `out_hash` target of
`bootutil_img_validate()`, which copies `IMAGE_HASH_SIZE` bytes into it.

`IMAGE_HASH_SIZE` follows the configured digest, so it is 48 under
`MCUBOOT_SIGN_EC384` and 64 under `MCUBOOT_SHA512` — both larger than the
32-byte buffer, which is overrun by 16 or 32 bytes. Only the default SHA-256
configuration happens to line up.

This declares the buffer as `uint8_t loader_hash[IMAGE_HASH_SIZE]` and passes
`IMAGE_HASH_SIZE` as the seed length of the second validation call, so both the
write target and the seed length track the digest length that
`image_validate.c` actually uses.

`IMAGE_HASH_SIZE` comes from `bootutil/crypto/sha.h`, which `loader.c` did not
include, so that include is added alongside the other bootutil headers. It is
safe unconditionally: every build description that compiles `loader.c` also
compiles `image_validate.c`, which already includes `sha.h`, so the header's
"one crypto backend must be defined" check cannot newly fire.

### Testing

`split_go()` has no in-tree caller — it is the Mynewt split-image feature — so
the simulator does not exercise this function at runtime. Verified by building
and running the sim in both the matching and the mismatching digest
configuration:

- `cargo test --features "multiimage sig-ecdsa"` — 27 passed, 0 failed
- `cargo test --features "sig-p384"` (the `IMAGE_HASH_SIZE == 48` case) — 25
  passed, 0 failed
