### PR TITLE
boot: bootutil: bound the hashed span to the image's area

### DIFF
--- a/boot/bootutil/src/bootutil_img_hash.c
+++ b/boot/bootutil/src/bootutil_img_hash.c
@@ -68,9 +68,8 @@ bootutil_img_hash(struct boot_loader_state *state,
 #if defined(MCUBOOT_ENC_IMAGES)
     int image_index;
 #endif
-#if defined(MCUBOOT_SWAP_USING_OFFSET)
     uint32_t sector_off = 0;
-#endif
+    uint32_t end;
 
 #if (BOOT_IMAGE_NUMBER == 1) || !defined(MCUBOOT_ENC_IMAGES) || \
     defined(MCUBOOT_RAM_LOAD)
@@ -111,6 +110,30 @@ bootutil_img_hash(struct boot_loader_state *state,
     sector_off = boot_get_state_secondary_offset(state, fap);
 #endif
 
+    /* Hash is computed over image header and image itself, and over the
+     * protected TLVs when they are present. The sizes of all three come from
+     * the image header, which is not authenticated at this point, so add them
+     * up without overflowing and check that the resulting span lies within the
+     * area holding the image before any of it is read. The header check done
+     * before an image is validated leaves the protected TLVs out of the size
+     * it compares against the slot when the image is to be decompressed, and
+     * several callers reach this point without performing it at all.
+     */
+    hdr_size = hdr->ih_hdr_size;
+
+    if (!boot_u32_safe_add(&size, hdr->ih_img_size, hdr_size)) {
+        return -1;
+    }
+
+    tlv_off = size;
+
+    if (!boot_u32_safe_add(&size, size, hdr->ih_protect_tlv_size) ||
+        !boot_u32_safe_add(&end, size, sector_off) ||
+        end > flash_area_get_size(fap)) {
+        BOOT_LOG_DBG("bootutil_img_hash: image does not fit the flash area");
+        return -1;
+    }
+
     bootutil_sha_init(&sha_ctx);
 
     /* in some cases (split image) the hash is seeded with data from
@@ -118,14 +141,6 @@ bootutil_img_hash(struct boot_loader_state *state,
     if (seed && (seed_len > 0)) {
         bootutil_sha_update(&sha_ctx, seed, seed_len);
     }
-
-    /* Hash is computed over image header and image itself. */
-    size = hdr_size = hdr->ih_hdr_size;
-    size += hdr->ih_img_size;
-    tlv_off = size;
-
-    /* If protected TLVs are present they are also hashed. */
-    size += hdr->ih_protect_tlv_size;
 
 #ifdef MCUBOOT_HASH_STORAGE_DIRECTLY
     /* No chunk loading, storage is mapped to address space and can


### PR DESCRIPTION
`bootutil_img_hash()` takes the header size, the image size and the protected
TLV size out of the image header and hashes that many bytes from the slot,
without checking the total against the area it is reading from.

Nothing upstream of it guarantees that span fits:

- `boot_check_header_valid()` does not cover the same span — it deliberately
  leaves `ih_protect_tlv_size` out of the size it compares against the slot when
  the image is to be decompressed;
- several callers of `bootutil_img_validate()` — the serial recovery, single
  slot and firmware loader paths — never run that check at all.

The three sizes come from an image header that has not been authenticated at
this point, so a malformed header can describe up to 64KB more data than the
slot holds. The hash then reads past the end of the area, which on
`MCUBOOT_HASH_STORAGE_DIRECTLY` configurations is an unchecked read straight out
of the mapped flash device. The accumulation is unchecked as well and can wrap a
32-bit size.

This adds the three sizes up with `boot_u32_safe_add()` and rejects an image
whose span — including the sector offset used in swap-using-offset mode — does
not fit in the area, before any of it is hashed.

Bounding the read where the bytes are read, rather than extending the header
check, leaves what that check accepts for a compressed image alone. Those bytes
are read out of the slot either way, so an image that fails the new check could
not have validated regardless: a bounds-checking `flash_area_read()` already
returns an error partway through, and a backend that does not bounds-check
already hashes whatever follows the slot into a mismatch. The change makes that
rejection explicit and moves it ahead of the read.

### Testing

- `cargo test` — 25/25
- `cargo test --features swap-offset` — 25/25
- `cargo test --features ram-load` — 25/25

The change is outside any `MCUBOOT_DECOMPRESS_IMAGES` conditional, so every
changed line is compiled by the simulator — but the simulator has no
decompression support, so the compressed-image case itself is not exercised
there. That path was checked separately with `cc -fsyntax-only -Wall -Wextra`
over `bootutil_img_hash.c` using the simulator's defines plus
`-DMCUBOOT_DECOMPRESS_IMAGES`, on its own and combined with swap-offset,
hash-storage-directly, and encryption with two images.
