### PR TITLE
boot_serial: honour MCUBOOT_LOGICAL_SECTOR_SIZE for the secondary slot offset

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -990,11 +990,6 @@ bs_upload(char *buf, int len)
          */
         const size_t area_size = flash_area_get_size(fap);
 
-#if defined(MCUBOOT_SWAP_USING_OFFSET) && defined(MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD)
-        uint32_t num_sectors = SWAP_USING_OFFSET_SECTOR_UPDATE_BEGIN;
-        struct flash_sector sector_data;
-#endif
-
         curr_off = 0;
 #if defined(MCUBOOT_ERASE_PROGRESSIVELY) && defined(BOOT_IMAGE_HAS_STATUS_FIELDS)
         /* Get trailer sector information; this is done early because inability to get
@@ -1040,6 +1035,16 @@ bs_upload(char *buf, int len)
 #if defined(MCUBOOT_SWAP_USING_OFFSET) && defined(MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD)
         if (img_num > 0 &&
             (img_num % BOOT_NUM_SLOTS) == BOOT_DIRECT_UPLOAD_SECONDARY_SLOT_ID_REMAINDER) {
+#if defined(MCUBOOT_LOGICAL_SECTOR_SIZE) && MCUBOOT_LOGICAL_SECTOR_SIZE != 0
+            /* The swap algorithms position slots by logical sectors, so the image
+             * in the secondary slot starts one logical sector in; the physical
+             * sector reported by the flash driver may be smaller.
+             */
+            start_off = MCUBOOT_LOGICAL_SECTOR_SIZE;
+#else
+            uint32_t num_sectors = SWAP_USING_OFFSET_SECTOR_UPDATE_BEGIN;
+            struct flash_sector sector_data;
+
             rc = flash_area_get_sectors(fap->fa_id, &num_sectors, &sector_data);
 
             if ((rc != 0 && rc != -ENOMEM) ||
@@ -1049,6 +1054,7 @@ bs_upload(char *buf, int len)
             }
 
             start_off = sector_data.fs_size;
+#endif
         } else {
             start_off = 0;
         }


### PR DESCRIPTION
Under MCUBOOT_SWAP_USING_OFFSET the image in the secondary slot starts one sector in, and bs_upload() derives that offset from the first sector reported by flash_area_get_sectors().

When MCUBOOT_LOGICAL_SECTOR_SIZE is configured the swap algorithms no longer work in physical sectors: boot_img_sector_size() and boot_img_ sector_off() return the logical size unconditionally, and boot_header_ scramble_off_sz() uses MCUBOOT_LOGICAL_SECTOR_SIZE for exactly this offset.  boot_serial.c was the one place still asking the flash driver.

On a device whose physical sector is smaller than the logical one -- the case MCUBOOT_LOGICAL_SECTOR_SIZE exists for -- a serial-recovery upload therefore lands the image header at the physical sector size while the loader looks for it at the logical sector size, and the upgrade is never seen.  With a 4K physical sector and a 32K logical sector the header is written at 0x1000 and read at 0x8000.

Take the offset from MCUBOOT_LOGICAL_SECTOR_SIZE when it is configured, mirroring boot_header_scramble_off_sz(), and keep the flash_area_get_ sectors() probe for the physical-sector case.  The probe's locals move into that branch so they are not declared unused when logical sectors are in use.

Addresses #2810