### PR TITLE
boot_serial: detect the secondary slot by flash area id, not direct-image id

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -158,7 +158,6 @@ BOOT_LOG_MODULE_DECLARE(mcuboot);
 #endif
 
 #define SWAP_USING_OFFSET_SECTOR_UPDATE_BEGIN 1
-#define BOOT_DIRECT_UPLOAD_SECONDARY_SLOT_ID_REMAINDER 0
 
 static char in_buf[MCUBOOT_SERIAL_MAX_RECEIVE_SIZE + 1];
 #ifndef MCUBOOT_SERIAL_RAW_PROTOCOL
@@ -993,6 +992,7 @@ bs_upload(char *buf, int len)
 #if defined(MCUBOOT_SWAP_USING_OFFSET) && defined(MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD)
         uint32_t num_sectors = SWAP_USING_OFFSET_SECTOR_UPDATE_BEGIN;
         struct flash_sector sector_data;
+        bool is_secondary = false;
 #endif
 
         curr_off = 0;
@@ -1038,8 +1038,19 @@ bs_upload(char *buf, int len)
         img_size = img_size_tmp;
 
 #if defined(MCUBOOT_SWAP_USING_OFFSET) && defined(MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD)
-        if (img_num > 0 &&
-            (img_num % BOOT_NUM_SLOTS) == BOOT_DIRECT_UPLOAD_SECONDARY_SLOT_ID_REMAINDER) {
+        /* The direct-image id numbering is defined by the port, in
+         * flash_area_id_from_direct_image(), so the resolved flash area id --
+         * not the id itself -- decides whether this upload targets a secondary
+         * slot.
+         */
+        for (uint8_t i = 0; i < BOOT_IMAGE_NUMBER; i++) {
+            if (fap->fa_id == FLASH_AREA_IMAGE_SECONDARY(i)) {
+                is_secondary = true;
+                break;
+            }
+        }
+
+        if (is_secondary) {
             rc = flash_area_get_sectors(fap->fa_id, &num_sectors, &sector_data);
 
             if ((rc != 0 && rc != -ENOMEM) ||


### PR DESCRIPTION
Under MCUBOOT_SWAP_USING_OFFSET, bs_upload() has to know whether a direct image upload targets a secondary slot, because only then does the image start one sector into the slot.  It decided this from the id's parity:

    img_num > 0 && (img_num % BOOT_NUM_SLOTS) == 0

which holds only for the numbering used by the Zephyr port, where 0 and 1 are image 0's primary, 2 is image 0's secondary, 3 is image 1's primary, and so on.

That numbering is not part of the interface.  flash_area_id_from_direct_ image() is supplied by the port, so a port is free to order the ids differently -- and one that does gets a silently wrong offset for some slots while others happen to work, which is awkward to track down.

Use the information the port has already given us: flash_area_open() has resolved the id to a flash area, so compare that area against the port's own FLASH_AREA_IMAGE_SECONDARY() for each image.  This is correct for any numbering and needs no new port API.  BOOT_DIRECT_UPLOAD_SECONDARY_SLOT_ ID_REMAINDER has no remaining users and is removed.

No functional change for ports that follow the Zephyr numbering.

Addresses #2810 