### PR TITLE
boot: treat a slot with no valid image as having no dependencies

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -309,6 +309,13 @@ boot_verify_slot_dependencies(struct boot_loader_state *state, uint32_t slot)
     assert(fap != NULL);
 
     BOOT_LOG_DBG("boot_verify_slot_dependencies");
+
+    /* A slot with no valid image has no dependencies to satisfy or violate. */
+    if (boot_img_hdr(state, slot)->ih_magic != IMAGE_MAGIC) {
+        rc = 0;
+        goto done;
+    }
+
 #if defined(MCUBOOT_SWAP_USING_OFFSET)
     it.start_off = boot_get_state_secondary_offset(state, fap);
 #endif


### PR DESCRIPTION
boot_verify_dependencies() runs once per boot whenever any image has an upgrade pending, and walks every image's active slot -- the secondary if that image is upgrading, otherwise its primary -- looking for IMAGE_TLV_DEPENDENCY entries. If reading any single slot's dependencies fails, it cancels the pending upgrade for every image, not just the one whose slot failed.

On a device where a given image has never been provisioned, that image's primary slot is erased flash: the header fields are garbage, and bootutil_tlv_iter_begin() correctly rejects it (ih_protect_tlv_size reads back nonzero, the following read doesn't find IMAGE_TLV_PROT_INFO_MAGIC or IMAGE_TLV_INFO_MAGIC at the computed offset). That rc gets propagated up by boot_verify_slot_dependencies() as "dependencies not satisfied", which is not what happened -- there was no image to have dependencies at all -- but boot_verify_dependencies() cannot tell the two apart, and cancels the upgrade of every other, unrelated image as a result.

Concretely: image 0 (already correctly resolved to swap type TEST) never gets swapped in, because image 1's primary slot -- which was never written to, and has no pending upgrade of its own -- fails this check.

A slot with no valid image can't have violated a dependency, since it has no TLV area to read one from. Check the image magic before attempting to read the TLV area, and treat an absent image the same as an image with no IMAGE_TLV_DEPENDENCY entries at all: trivially satisfied.

Resolves #2812