### PR TITLE
boot: bootutil: Allow ports to size the image hash buffer

### DIFF
--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -69,7 +69,22 @@ _Static_assert((MCUBOOT_LOGICAL_SECTOR_SIZE &
 #error "MCUBOOT_VERIFY_LOGICAL_SECTORS requires a non-zero MCUBOOT_LOGICAL_SECTOR_SIZE"
 #endif
 
+/* Size of the buffer used to read the image in chunks while its hash is
+ * computed.  The number of flash reads over an image is
+ * ceil(image_size / BOOT_TMPBUF_SZ), so on flash that is not memory mapped
+ * (QSPI, SPI NOR, eMMC, ...), where every read is a bus transaction with a
+ * fixed cost, this size can dominate validation time.  Ports that are short
+ * on RAM may equally want to lower it.  The buffer is allocated by the
+ * callers of bootutil_img_validate(), so it cannot be sized by a port that
+ * uses the in-tree loaders.
+ */
+#ifdef MCUBOOT_BOOT_TMPBUF_SZ
+_Static_assert(MCUBOOT_BOOT_TMPBUF_SZ > 0,
+               "MCUBOOT_BOOT_TMPBUF_SZ must be greater than zero");
+#define BOOT_TMPBUF_SZ  MCUBOOT_BOOT_TMPBUF_SZ
+#else
 #define BOOT_TMPBUF_SZ  256
+#endif
 
 /** Number of image slots in flash; currently limited to two. */
 #if defined(MCUBOOT_SINGLE_APPLICATION_SLOT) || defined(MCUBOOT_SINGLE_APPLICATION_SLOT_RAM_LOAD)

--- a/docs/release-notes.d/configurable-hash-buf-size.md
+++ b/docs/release-notes.d/configurable-hash-buf-size.md
@@ -1,0 +1,5 @@
+- Added `MCUBOOT_BOOT_TMPBUF_SZ`, allowing a port to override the size of the
+  buffer used to read the image in chunks while its hash is computed. The
+  default remains 256 bytes. Raising it reduces the number of `flash_area_read()`
+  calls over an image, which is significant on flash that is not memory mapped;
+  lowering it reduces the statically allocated buffer.

--- a/samples/mcuboot_config/mcuboot_config.template.h
+++ b/samples/mcuboot_config/mcuboot_config.template.h
@@ -138,6 +138,13 @@
  * multiple images. */
 #define MCUBOOT_IMAGE_NUMBER 1
 
+/* Uncomment and set to override the size of the buffer used to read the
+ * image in chunks while its hash is computed (default 256).  Raising it
+ * reduces the number of flash reads over an image, which matters on flash
+ * that is not memory mapped; lowering it saves RAM.  The buffer is
+ * statically allocated. */
+/* #define MCUBOOT_BOOT_TMPBUF_SZ 256 */
+
 /*
  * Logging
  */


### PR DESCRIPTION
### What

Adds `MCUBOOT_BOOT_TMPBUF_SZ`, letting a port override the size of the buffer
used to read an image in chunks while computing its hash. The default stays at
256 bytes.

### Why

`BOOT_TMPBUF_SZ` determines the chunk size in `bootutil_img_hash()`, so the
number of `flash_area_read()` calls over an image is
`ceil(image_size / BOOT_TMPBUF_SZ)`.

On flash that is memory mapped the per-call cost is small. On flash that is not
— QSPI, SPI NOR, eMMC — each read is a bus transaction with a fixed
command/address overhead, so the read *count* rather than the byte count can
dominate validation time. At the 256 byte default a 1 MiB image is 4096
sequential reads.

The converse also applies: the buffer is statically allocated, so a
RAM-constrained port may want it *smaller* than 256.

### Why not just pass a different `tmp_buf_sz`?

`bootutil_img_hash()` already takes the buffer and its size as parameters, but
every caller lives in `boot/bootutil` or in a port:

- `boot/bootutil/src/bootutil_loader.c`
- `boot/bootutil/src/loader.c`
- `boot/boot_serial/src/boot_serial_encryption.c`
- `boot/zephyr/single_loader.c`, `boot/zephyr/firmware_loader.c`
- `boot/mynewt/src/single_loader.c`

A port that uses the in-tree loaders therefore has no way to reach it short of
forking those files. `bootutil_priv.h` already includes
`mcuboot_config/mcuboot_config.h` above the definition, so a guard is all that
is needed.

### Design

Mirrors the existing `MCUBOOT_BOOT_MAX_ALIGN` -> `BOOT_MAX_ALIGN` pattern in
`boot/bootutil/include/bootutil/bootutil_public.h` — same `#ifdef` /
`_Static_assert` / `#else` default shape, and the option name is the existing
internal name with the usual `MCUBOOT_` prefix, so no new vocabulary is
introduced.

Happy to rename it, or to add a corresponding Zephyr Kconfig option, if
maintainers prefer — note that this guard is a prerequisite for such a Kconfig
option working at all.

### Impact

- No behavioural change in any existing configuration; the default is unchanged
  and the new macro is defined nowhere in tree.
- The simulator does not set it, so simulator behaviour is unchanged.
- Documented in `samples/mcuboot_config/mcuboot_config.template.h`.
- Release note stub included.
