### PR TITLE
boot: bootutil: feed watchdog in bootutil_img_hash

### DIFF
--- a/boot/bootutil/src/bootutil_img_hash.c
+++ b/boot/bootutil/src/bootutil_img_hash.c
@@ -187,6 +187,8 @@ bootutil_img_hash(struct boot_loader_state *state,
         }
 #endif
         bootutil_sha_update(&sha_ctx, tmp_buf, blk_sz);
+
+        MCUBOOT_WATCHDOG_FEED();
     }
 #endif /* MCUBOOT_RAM_LOAD */
 #endif /* MCUBOOT_HASH_STORAGE_DIRECTLY */


### PR DESCRIPTION
If the image is large and/or stored on slow memory, e.g. external flash, reading the image to calculate its hash can take a significant amount of time. Feed the watchdog while hashing is in progress to prevent a reset from happening under these conditions.