### PR TITLE
docs: PORTING: Document the remaining required flash APIs

### DIFF
--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -158,6 +158,15 @@ uint8_t  flash_area_erased_val(const struct flash_area *);
 /*< Given flash area ID, return info about sectors within the area. */
 int      flash_area_get_sectors(int fa_id, uint32_t *count,
                                 struct flash_sector *sectors);
+/*< Given a flash area and an offset within it, return info about the sector
+    that the offset falls in. Both `off` and the `fs_off` field written to
+    `fs` are relative to the start of the flash area. Returns -ERANGE if
+    `off` is beyond the end of the area. */
+int      flash_area_get_sector(const struct flash_area *fa, off_t off,
+                               struct flash_sector *fs);
+/*< Returns the `fa_id` for slot, where slot is 0 (primary) or 1 (secondary),
+    for the first image. */
+int      flash_area_id_from_image_slot(int slot);
 /*< Returns the `fa_id` for slot, where slot is 0 (primary) or 1 (secondary).
     `image_index` (0 or 1) is the index of the image. Image index is
     relevant only when multi-image support support is enabled */
@@ -166,7 +175,22 @@ int      flash_area_id_from_multi_image_slot(int image_index, int slot);
     `image_index` and `area_id`. `area_id` is unique and is represented by
     `fa_id` in the `flash_area` struct. */
 int      flash_area_id_to_multi_image_slot(int image_index, int area_id);
+/*< Writes to `ret` the base address of the device `fd_id`, that is the
+    address the offsets of flash areas residing on that device are relative
+    to. Returns 0 on success. */
+int      flash_device_base(uint8_t fd_id, uintptr_t *ret);
 ```
+
+---
+***Note***
+
+*Offsets passed to and returned by `flash_area_get_sector()` are relative to the
+start of the flash area, not to the start of the flash device. The `off`
+parameter is bounds-checked against the area size, and the `fs_off` field
+written to `fs` is the offset of the containing sector within the area.
+Implementing it in terms of device-absolute offsets instead prevents the sector
+walk in `boot_erase_region()` from reaching its termination condition. See
+`boot/zephyr/flash_map_extended.c` for a reference implementation.*
 
 ---
 ***Note***


### PR DESCRIPTION
### What

Adds three functions to the list of flash APIs a system must provide in
`docs/PORTING.md`, and a note on the offset semantics of one of them.

### Why

The document's "main, also required, set of API functions" is missing three
functions that common code in `boot/bootutil` calls unconditionally, and that
no implementation outside a port supplies:

| Function | Call sites in `boot/bootutil` |
| --- | --- |
| `flash_area_get_sector()` | 8 |
| `flash_device_base()` | 2 |
| `flash_area_id_from_image_slot()` | 2 |

All three are declared in `flash_map_backend.h` and implemented per port (see
`boot/zephyr/flash_map_extended.c`); none has a definition in `boot/bootutil`.
A port written against the current document therefore fails to link, and the
document gives no hint as to what is missing.

`flash_area_get_sector()` is worth more than a one-line entry, because it is
easy to implement in a way that links and then misbehaves: both the `off`
parameter and the `fs_off` written back are relative to the **flash area**, not
to the device. An implementation that treats them as device-absolute — which is
a natural first guess — leaves the sector walk in `boot_erase_region()` unable
to reach its termination condition. The added note states the convention and
points at the Zephyr implementation as a reference.

### Notes

- Documentation only; no code or behavioural change.
- No release note stub, per `docs/contributing.md` ("Release notes are generally
  not needed for: Some documentation improvements").
- `flash_area_id_to_image_slot()` was deliberately **not** added: it has no
  call sites in `boot/bootutil` and is not declared in `flash_map_backend.h`,
  so it does not appear to be required of a port.
