### PR TITLE
boot: zepyhr: boards: add MR-NAVQ95B overlay

### DIFF
--- a/boot/zephyr/boards/mr_navq95b_mimx9596_m7.overlay
+++ b/boot/zephyr/boards/mr_navq95b_mimx9596_m7.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2026 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This overlay allows users to embed the mcuboot image into the boot
+ * container. The boot ROM will take care of placing the mcuboot image
+ * in ITCM. The M7 core can then be started by system manager.
+ */
+
+/ {
+	chosen {
+		zephyr,code-partition = &itcm;
+	};
+};


### PR DESCRIPTION
Add an overlay for the mr_navq95b//m7 board variant, which will allow the users to embed the mcuboot image into the boot container. With this configuration, the boot ROM will take care of placing the mcuboot image into ITCM. Later on, the M7 core can be started by the system manager.

This becomes the default configuration because NXP's robotics BSP requires mcuboot be placed in ITCM. If there's users interested in placing the mcuboot image in flash then they can do so by manually applying mcuboot's app.overlay while building the bootloader image.