### PR TITLE
boot: zephyr: board: Add M5stack Unit C6L overlay

### DIFF
--- a/boot/zephyr/boards/m5stack_unitc6l_esp32c6_hpcore.overlay
+++ b/boot/zephyr/boards/m5stack_unitc6l_esp32c6_hpcore.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* MCUboot builds without multithreading, so the I2C buses and the I2C GPIO
+ * expander (none of which the bootloader needs) must be kept out of the image.
+ */
+
+&i2c0 {
+	status = "disabled";
+};
+
+&gpio_exp {
+	status = "disabled";
+};
+
+&grove_i2c {
+	status = "disabled";
+};


### PR DESCRIPTION
The PI4IOE5V6408 expander driver selects I2C, overriding MCUboot CONFIG_I2C=n, and its polling work queue fails to link without multithreading. Disable the expander node, and the unused I2C buses with it. Related board PR https://github.com/zephyrproject-rtos/zephyr/pull/113221 