### PR TITLE
boot: serial: end serial recovery on inactivity

### DIFF
--- a/boot/boot_serial/include/boot_serial/boot_serial.h
+++ b/boot/boot_serial/include/boot_serial/boot_serial.h
@@ -20,6 +20,8 @@
 #ifndef __BOOT_SERIAL_H__
 #define __BOOT_SERIAL_H__
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -51,6 +53,15 @@ void boot_serial_start(const struct boot_uart_funcs *f);
  * function is similar to boot_serial_start
  */
 void boot_serial_check_start(const struct boot_uart_funcs *f, int timeout_in_ms);
+
+/**
+ * Start processing MCUmgr commands for uploading image0 over serial.
+ * Returns once timeout_in_ms pass with no MCUmgr command. Unlike
+ * boot_serial_check_start, each command received restarts the countdown
+ * with rearm_in_ms. Returns true if any command was received.
+ */
+bool boot_serial_start_inactivity(const struct boot_uart_funcs *f,
+                                  int timeout_in_ms, int rearm_in_ms);
 
 #ifdef __cplusplus
 }

--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -168,6 +168,15 @@ const struct boot_uart_funcs *boot_uf;
 static struct nmgr_hdr *bs_hdr;
 static bool bs_entry;
 
+#ifdef MCUBOOT_SERIAL_INACTIVITY_TIMEOUT
+/* Restart value and progress flags for the inactivity countdown, at file
+ * scope because the command handler observes progress, not the read loop.
+ */
+static int bs_rearm_ms;
+static bool bs_rearm_pending;
+static bool bs_rearm_seen;
+#endif
+
 static char bs_obuf[BOOT_SERIAL_OUT_MAX];
 
 static void boot_serial_output(void);
@@ -1409,7 +1418,18 @@ boot_serial_input(char *buf, int len)
         bs_rc_rsp(MGMT_ERR_ENOTSUP);
     }
 #ifdef MCUBOOT_SERIAL_WAIT_FOR_DFU
-    bs_entry = true;
+#ifdef MCUBOOT_SERIAL_INACTIVITY_TIMEOUT
+    if (bs_rearm_ms > 0) {
+        /* Restart the countdown: the loop should end on silence, not on a
+         * finished transfer.
+         */
+        bs_rearm_pending = true;
+        bs_rearm_seen = true;
+    } else
+#endif
+    {
+        bs_entry = true;
+    }
 #endif
 }
 
@@ -1717,6 +1737,12 @@ check_timeout:
         elapsed_in_ms = (k_uptime_get_32() - start);
 #endif
         timeout_in_ms -= elapsed_in_ms;
+#ifdef MCUBOOT_SERIAL_INACTIVITY_TIMEOUT
+        if (bs_rearm_pending) {
+            bs_rearm_pending = false;
+            timeout_in_ms = bs_rearm_ms;
+        }
+#endif
     }
 }
 
@@ -1727,6 +1753,9 @@ check_timeout:
 void
 boot_serial_start(const struct boot_uart_funcs *f)
 {
+#ifdef MCUBOOT_SERIAL_INACTIVITY_TIMEOUT
+    bs_rearm_ms = 0;
+#endif
     bs_entry = true;
     boot_serial_read_console(f,0);
 }
@@ -1740,9 +1769,32 @@ boot_serial_start(const struct boot_uart_funcs *f)
 void
 boot_serial_check_start(const struct boot_uart_funcs *f, int timeout_in_ms)
 {
+#ifdef MCUBOOT_SERIAL_INACTIVITY_TIMEOUT
+    bs_rearm_ms = 0;
+#endif
     bs_entry = false;
     boot_serial_read_console(f,timeout_in_ms);
 }
+
+#ifdef MCUBOOT_SERIAL_INACTIVITY_TIMEOUT
+/*
+ * Returns once timeout_in_ms pass without an MCUmgr command; each command
+ * restarts the countdown with rearm_in_ms. Return value tells an aborted
+ * session apart from a window that simply expired.
+ */
+bool
+boot_serial_start_inactivity(const struct boot_uart_funcs *f, int timeout_in_ms,
+                             int rearm_in_ms)
+{
+    bs_rearm_ms = rearm_in_ms;
+    bs_rearm_pending = false;
+    bs_rearm_seen = false;
+    bs_entry = false;
+    boot_serial_read_console(f,timeout_in_ms);
+
+    return bs_rearm_seen;
+}
+#endif
 #endif
 
 #ifdef MCUBOOT_SERIAL_IMG_GRP_HASH

--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -225,13 +225,49 @@ config BOOT_SERIAL_WAIT_FOR_DFU_TIMEOUT
 	help
 	  Timeout in ms for MCUboot to wait to allow for DFU to be invoked.
 
-config BOOT_SERIAL_BOOT_MODE
+config BOOT_SERIAL_INACTIVITY_TIMEOUT
+	int "Inactivity timeout for serial recovery in ms"
+	default 0
+	depends on BOOT_SERIAL_WAIT_FOR_DFU
+	depends on REBOOT
+
+menuconfig BOOT_SERIAL_BOOT_MODE
 	bool "Check boot mode via retention subsystem"
 	depends on RETENTION_BOOT_MODE
 	help
 	  Allows for entering serial recovery mode by using Zephyr's boot mode
 	  retention system (i.e. an application must set the boot mode to stay
 	  in serial recovery mode and reboot the module).
+
+config BOOT_SERIAL_INACTIVITY_TIMEOUT
+	int "Inactivity timeout for serial recovery in ms"
+	default 0
+	depends on BOOT_SERIAL_BOOT_MODE
+	depends on REBOOT
+	help
+	  Time in ms without a single MCUmgr command after which serial recovery
+	  resets the SoC, so the next boot runs the image that is installed by
+	  then. Every received command restarts the countdown, so an upload in
+	  progress is never interrupted, however slow the link is.
+
+	  It resets rather than returning into the boot path because the image
+	  was already selected before serial recovery was entered, so returning
+	  would jump to the image the upload has just replaced; nothing in the
+	  bootloader unwinds the state a finished MCUmgr session leaves behind
+	  either, and returning has been observed to lock up a Cortex-M0+. Hence
+	  the dependency on REBOOT.
+
+	  With BOOT_SERIAL_WAIT_FOR_DFU the SoC is reset only if at least one
+	  command was received; a window that expires with no command at all
+	  boots as it does today.
+
+	  The default of 0 keeps serial recovery running until the device is
+	  reset, which means an aborted upload leaves it there until someone
+	  power-cycles it. Set this to bound that, on a device whose recovery
+	  transport cannot be relied on to finish what it started.
+
+	  Does not affect BOOT_SERIAL_NO_APPLICATION: with no bootable image
+	  there is nothing to resume, so that wait stays unbounded.
 
 config BOOT_SERIAL_NO_APPLICATION
 	bool "Stay in bootloader if no application"

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -336,7 +336,17 @@
 #define MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD
 #endif
 
-#ifdef CONFIG_BOOT_SERIAL_WAIT_FOR_DFU
+#if defined(CONFIG_BOOT_SERIAL_INACTIVITY_TIMEOUT) && \
+    CONFIG_BOOT_SERIAL_INACTIVITY_TIMEOUT > 0
+#define MCUBOOT_SERIAL_INACTIVITY_TIMEOUT \
+        CONFIG_BOOT_SERIAL_INACTIVITY_TIMEOUT
+#endif
+
+/* Enables the elapsed-time accounting in boot_serial.c that both the
+ * every-boot wait and the inactivity timeout depend on.
+ */
+#if defined(CONFIG_BOOT_SERIAL_WAIT_FOR_DFU) || \
+    defined(MCUBOOT_SERIAL_INACTIVITY_TIMEOUT)
 #define MCUBOOT_SERIAL_WAIT_FOR_DFU
 #endif
 

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -38,6 +38,10 @@
 
 #include "do_boot.h"
 
+#ifdef MCUBOOT_SERIAL_INACTIVITY_TIMEOUT
+#include <zephyr/sys/reboot.h>
+#endif
+
 #if defined(CONFIG_MCUBOOT_UUID_VID) || defined(CONFIG_MCUBOOT_UUID_CID)
 #include "bootutil/mcuboot_uuid.h"
 #endif /* CONFIG_MCUBOOT_UUID_VID || CONFIG_MCUBOOT_UUID_CID */
@@ -160,7 +164,11 @@ void zephyr_boot_log_stop(void)
 
 #if defined(CONFIG_BOOT_SERIAL_ENTRANCE_GPIO) || defined(CONFIG_BOOT_SERIAL_PIN_RESET) \
     || defined(CONFIG_BOOT_SERIAL_BOOT_MODE) || defined(CONFIG_BOOT_SERIAL_NO_APPLICATION)
-static void boot_serial_enter()
+/* Enters serial recovery and never returns. inactivity_in_ms of 0 waits for
+ * a manual reset; a positive value resets the SoC after that much silence,
+ * so an aborted update doesn't strand a device with a valid image.
+ */
+static void boot_serial_enter(int inactivity_in_ms)
 {
     int rc;
 
@@ -176,6 +184,28 @@ static void boot_serial_enter()
         BOOT_LOG_DBG("Error initializing boot console. rc = %d", rc);
         FIH_PANIC;
     }
+
+#ifdef MCUBOOT_SERIAL_INACTIVITY_TIMEOUT
+    if (inactivity_in_ms > 0) {
+        (void)boot_serial_start_inactivity(&boot_funcs, inactivity_in_ms,
+                                           inactivity_in_ms);
+
+        /* Reset rather than return: nothing here unwinds a finished MCUmgr
+         * session, and returning has been observed to lock up a Cortex-M0+.
+         * The boot mode flag was cleared on entry, so the next boot goes
+         * straight to the app.
+         */
+        BOOT_LOG_INF("Serial recovery idle for %d ms, resetting",
+                     inactivity_in_ms);
+#ifdef CONFIG_MCUBOOT_INDICATION_LED
+        io_led_set(0);
+#endif
+        ZEPHYR_BOOT_LOG_STOP();
+        sys_reboot(SYS_REBOOT_COLD);
+    }
+#else
+    (void)inactivity_in_ms;
+#endif
 
     boot_serial_start(&boot_funcs);
     BOOT_LOG_DBG("Bootloader serial process was terminated unexpectedly");
@@ -227,14 +257,14 @@ int main(void)
     BOOT_LOG_DBG("Checking GPIO for serial recovery");
     if (io_detect_pin() &&
             !io_boot_skip_serial_recovery()) {
-        boot_serial_enter();
+        boot_serial_enter(0);
     }
 #endif
 
 #ifdef CONFIG_BOOT_SERIAL_PIN_RESET
     BOOT_LOG_DBG("Checking RESET pin for serial recovery");
     if (io_detect_pin_reset()) {
-        boot_serial_enter();
+        boot_serial_enter(0);
     }
 #endif
 
@@ -309,7 +339,11 @@ int main(void)
          * recovery mode
          */
         BOOT_LOG_DBG("Staying in serial recovery");
-        boot_serial_enter();
+#ifdef MCUBOOT_SERIAL_INACTIVITY_TIMEOUT
+        boot_serial_enter(MCUBOOT_SERIAL_INACTIVITY_TIMEOUT);
+#else
+        boot_serial_enter(0);
+#endif
     }
 #endif
 
@@ -319,7 +353,25 @@ int main(void)
         /* at least one check if time was expired */
         timeout_in_ms = 1;
     }
+#ifdef MCUBOOT_SERIAL_INACTIVITY_TIMEOUT
+    if (boot_serial_start_inactivity(&boot_funcs, timeout_in_ms,
+                                     MCUBOOT_SERIAL_INACTIVITY_TIMEOUT)) {
+        /* Reset rather than continue: boot_go() already selected an image
+         * before this window opened, so continuing would boot whatever the
+         * upload just replaced. A window with no command is not a session
+         * and boots as usual.
+         */
+        BOOT_LOG_INF("Serial recovery idle for %d ms, resetting",
+                     MCUBOOT_SERIAL_INACTIVITY_TIMEOUT);
+#ifdef CONFIG_MCUBOOT_INDICATION_LED
+        io_led_set(0);
+#endif
+        ZEPHYR_BOOT_LOG_STOP();
+        sys_reboot(SYS_REBOOT_COLD);
+    }
+#else
     boot_serial_check_start(&boot_funcs,timeout_in_ms);
+#endif
 
 #ifdef CONFIG_MCUBOOT_INDICATION_LED
     io_led_set(0);
@@ -335,7 +387,7 @@ int main(void)
         /* No bootable image and configuration set to remain in serial
          * recovery mode
          */
-        boot_serial_enter();
+        boot_serial_enter(0);
 #elif defined(CONFIG_BOOT_USB_DFU_NO_APPLICATION)
         rc = usb_enable(NULL);
         if (rc && rc != -EALREADY) {


### PR DESCRIPTION
### What is broken today

Serial recovery has no way out once it is entered. `boot_serial_enter()`
calls `boot_serial_start()`, which sets `bs_entry` and never clears it, and
the every-boot wait (`CONFIG_BOOT_SERIAL_WAIT_FOR_DFU`) latches the same flag
on the first MCUmgr command, so the read loop in `boot_serial_read_console()`
runs until the device is reset by hand.

That is fine when a human is standing next to the board. It is not fine for a
field device whose only recovery transport is the same wire the application
talks on: an aborted upload strands a unit that has a perfectly good image to
fall back on, and no watchdog can rescue it, because `MCUBOOT_WATCHDOG_FEED()`
runs inside that very loop. A hung recovery is fed exactly like a busy one.

### Why a plain timeout is the wrong shape

`CONFIG_BOOT_SERIAL_WAIT_FOR_DFU` already has a timeout, but it is a
*pre-transfer* window: the first MCUmgr command latches `bs_entry` and the wait
becomes permanent. Bounding the whole session instead would cut a slow transfer
in half - a full image over a 9600 baud RS485 link takes minutes.

The discriminating signal is data, not elapsed time. A slow transfer keeps
delivering MCUmgr commands; an aborted one goes silent.

### The change

`boot_serial_start_inactivity()` counts down like `boot_serial_check_start()`,
but every received command restarts the countdown instead of latching
`bs_entry`, and it reports whether any command arrived at all. A transfer in
progress extends the wait for as long as it keeps making progress, however slow
the link; only silence ends recovery.

Exposed as `CONFIG_BOOT_SERIAL_INACTIVITY_TIMEOUT` (int, ms, **default 0**),
offered under both entrance methods that have an installed image to resume:
`BOOT_SERIAL_BOOT_MODE` and `BOOT_SERIAL_WAIT_FOR_DFU`.

Nothing existing is removed or re-gated:

- At the default of 0 nothing new is compiled in, and the image comes out the
  same size as one built without the patch (see the table below).
- `CONFIG_BOOT_SERIAL_NO_APPLICATION` stays unbounded on purpose - with no
  bootable image there is nothing to resume, so ending recovery there would be
  strictly worse. The GPIO and pin-reset entrances stay unbounded too.

### Why it exits by resetting the SoC

The image was selected by `boot_go()` before recovery was entered, so returning
into the boot path after an upload would jump to the image that upload has just
replaced. Nothing in the bootloader unwinds the state a finished MCUmgr session
leaves behind either. Returning was tried first and locks the CPU up on a
Cortex-M0+ (STM32C071): a variant that returns instead of resetting ends in
lockup once a single MCUmgr command has been received before the silence, with
PC `0xFFFFFFFE`, S_LOCKUP set in DHCSR, and MSP loaded from the image header
magic `0x96F3B83D` instead of a vector table. The same image with no command
received boots the application normally. A reset costs one boot, starts from a state the
bootloader already knows how to handle, and is the same exit MCUmgr's own reset
command takes.

Under `BOOT_SERIAL_WAIT_FOR_DFU` the reset is taken **only if at least one
command was received**. A window that expires with no command at all is not a
session, and boots exactly as it does today.

A non-zero timeout therefore requires `CONFIG_REBOOT`, expressed as a Kconfig
dependency.

`boot_serial_enter()` takes the timeout as an argument rather than being
duplicated, so the status callback, the indication LED, the log line and the
`boot_console_init()` error check stay in one place for every entrance method.

### Verification

Size, on `pic32cm_gc00_cpro/pic32cm5112gc00100` (Cortex-M23), `WAIT_FOR_DFU`
entrance, this branch against its merge base:

- `BOOT_SERIAL_INACTIVITY_TIMEOUT=0`: the MCUboot binary is byte for byte
  identical to one built without this patch, and `boot_serial_start_inactivity`
  is not linked in.
- `BOOT_SERIAL_INACTIVITY_TIMEOUT=30000`: 41000 B against 40836 B, so 164 B.

A build with `REBOOT=n` was checked too: the symbol falls back to 0 and the
image matches the timeout-unset one. No new warnings in any of the builds.

On hardware: STM32C071 (Cortex-M0+), MCUmgr and Modbus sharing one RS485 line
at 9600 baud, `BOOT_SERIAL_INACTIVITY_TIMEOUT=30000`, and for the last two runs
`BOOT_SERIAL_WAIT_FOR_DFU=y` with `BOOT_SERIAL_WAIT_FOR_DFU_TIMEOUT=5000`. Time
is measured from the last byte the host sent to the first answer from the
application.

| Run | Entrance | Measured | What it shows |
|---|---|---|---|
| Idle abort | boot mode | 165 s | recovery ends on its own, running the image it already had |
| Full upload | boot mode | 35027/35027 B in 77.9 s | a transfer far longer than the timeout is not cut short |
| Empty window | `WAIT_FOR_DFU` | 22.6 s | an empty window is not a session, plain return into the boot path |
| One command, then silence | `WAIT_FOR_DFU` | 184.8 s | a session takes the reset exit |

The 165 s against a 30 s setting is not this patch. `boot_serial_read_console()`
charges the timeout for `f->read()` only, while the two `k_uptime_get_32()`
calls that do the measuring fall outside the measured window, and on a core
without hardware divide they dominate: sampling the PC over SWD through a whole
window put 72% of the samples in `__udivmoddi4`, `__udivsi3` and
`sys_clock_tick_get`, against 4.8% in `console_read`. The same effect measures
3.2x on the Cortex-M23 board above. It is pre-existing and reported as #2841;
the countdown stays proportional, and every run in the table is consistent with
one factor.

- **Known limitation, unchanged by this patch:** in a configuration with no
  staging slot, an upload aborted *mid-transfer* has already overwritten the
  primary slot. The timeout fires and the device resets, but with no valid
  image it lands in `BOOT_SERIAL_NO_APPLICATION` and waits there for a retry.
  That is the intended behaviour; no timeout value can conjure back an image
  that was overwritten.

