### PR TITLE
boot: bootutil: swap_offset: Abort attempted swap on inaccessible image

### DIFF
--- a/boot/bootutil/src/swap_offset.c
+++ b/boot/bootutil/src/swap_offset.c
@@ -402,15 +402,18 @@ int swap_status_source(struct boot_loader_state *state)
 
     rc = boot_read_swap_state(state->imgs[image_index][BOOT_SLOT_SECONDARY].area,
                               &state_secondary_slot);
-    assert(rc == 0);
-    BOOT_LOG_SWAP_STATE("Secondary image", &state_secondary_slot);
+    if (rc == 0) {
+        BOOT_LOG_SWAP_STATE("Secondary image", &state_secondary_slot);
 
-    if (state_primary_slot.magic == BOOT_MAGIC_GOOD &&
-        state_primary_slot.copy_done == BOOT_FLAG_UNSET &&
-        state_secondary_slot.magic != BOOT_MAGIC_GOOD) {
+        if (state_primary_slot.magic == BOOT_MAGIC_GOOD &&
+            state_primary_slot.copy_done == BOOT_FLAG_UNSET &&
+            state_secondary_slot.magic != BOOT_MAGIC_GOOD) {
 
-        BOOT_LOG_INF("Boot source: primary slot");
-        return BOOT_STATUS_SOURCE_PRIMARY_SLOT;
+            BOOT_LOG_INF("Boot source: primary slot");
+            return BOOT_STATUS_SOURCE_PRIMARY_SLOT;
+        }
+    } else {
+        BOOT_LOG_INF("Secondary image of pair %d inaccessible, refusing to swap", image_index);
     }
 
     BOOT_LOG_INF("Boot source: none");


### PR DESCRIPTION
I recently ran into a double bit flash error when writing firmware to the secondary image slot while preparing for a firmware upgrade. When using the swap using offset algorithm, such an error occurring in the secondary slot causes the `boot_read_swap_state` call for said slot in `swap_status_source` to fail with `BOOT_EFLASH`, triggering the subsequent assertion. When resetting the system, the problem - unsurprisingly - persists, causing the bootloader to trigger the same assertion over and over again. The only way out appears to be to erase the secondary slot using a programmer, something that can prove rather cumbersome should the device be far away.

This PR alters the behavior of `swap_status_source` such that, rather than triggering the assertion, it falls back on booting the primary image should the secondary prove inaccessible. This should allow users to reattempt the DFU using their upload method of choice.