### PR TITLE
boot: boot_serial: Add check for image ID validity

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -975,6 +975,11 @@ bs_upload(char *buf, int len)
     }
 
 #if !defined(MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD)
+    if (img_num > BOOT_IMAGE_NUMBER) {
+        rc = MGMT_ERR_ENOENT;
+        goto out;
+    }
+
     rc = flash_area_open(flash_area_id_from_multi_image_slot(img_num, 0), &fap);
 #else
     rc = flash_area_open(flash_area_id_from_direct_image(img_num), &fap);


### PR DESCRIPTION
Checks that the supplied image ID is valid and returns the correct MCUmgr (v1) error if it does not