### PR TITLE
boot: zephyr: Allow a custom do_boot implementation

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -73,7 +73,9 @@ target_sources(app PRIVATE
   watchdog.c
 )
 
-if(CONFIG_ARM)
+if(CONFIG_BOOT_CUSTOM_BOOT)
+  # No implementation of do_boot
+elseif(CONFIG_ARM)
   target_sources(app PRIVATE arch/arm.c)
 elseif(CONFIG_SOC_FAMILY_ESPRESSIF_ESP32)
   target_sources(app PRIVATE arch/esp32.c)

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -137,6 +137,12 @@ endif # BOOT_USE_PSA_CRYPTO
 
 menu "MCUBoot settings"
 
+config BOOT_CUSTOM_BOOT
+	bool
+	help
+	  Hidden option that should be selected when the platform implements
+	  the do_boot function and wants to avoid using the provided implementations.
+
 config BOOT_SOMETHING_USES_SHA256
 	bool
 	help


### PR DESCRIPTION
Let a platform define do_boot for itself.

### Suggested implementation in zephyr, in modules/Kconfig.mcuboot:

```
# Toggle BOOT_CUSTOM_BOOT to indicate Zephyr platform code provides do_boot
config MCUBOOT_CUSTOM_BOOT
	bool
	select BOOT_CUSTOM_BOOT
```

### Example implementation for a soc:

soc/thesoc/CMakeLists.txt:
```
if (CONFIG_MCUBOOT)
  zephyr_include_directories(${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/bootutil/include)
  zephyr_sources(do_boot.c)
endif()
```
soc/thesoc/Kconfig.defconfig:
```
if MCUBOOT

configdefault MCUBOOT_CUSTOM_BOOT
	default y

endif # MCUBOOT
```

ESP32 likely should use that method if this is merged.