### PR TITLE
boot: serial: charge the whole read loop against the timeout

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -1620,6 +1620,13 @@ boot_serial_read_console(const struct boot_uart_funcs *f,int timeout_in_ms)
     int full_line;
     int max_input;
     int elapsed_in_ms = 0;
+#ifdef MCUBOOT_SERIAL_WAIT_FOR_DFU
+    /* Start of the iteration charged against the timeout; rolled forward at
+     * the loop's end so every ms in the loop counts, not just f->read().
+     */
+    uint32_t start = k_uptime_get_32();
+    uint32_t now;
+#endif
 #ifdef MCUBOOT_SERIAL_RAW_PROTOCOL_INPUT_TIMEOUT
     uint32_t raw_input_start = 0;
 #endif
@@ -1653,9 +1660,6 @@ boot_serial_read_console(const struct boot_uart_funcs *f,int timeout_in_ms)
         }
 #endif
         MCUBOOT_WATCHDOG_FEED();
-#ifdef MCUBOOT_SERIAL_WAIT_FOR_DFU
-        uint32_t start = k_uptime_get_32();
-#endif
         rc = f->read(in_buf + off, sizeof(in_buf) - off, &full_line);
         if (rc <= 0 && !full_line) {
 #ifndef MCUBOOT_SERIAL_WAIT_FOR_DFU
@@ -1714,7 +1718,9 @@ check_timeout:
 #endif
         /* Subtract elapsed time */
 #ifdef MCUBOOT_SERIAL_WAIT_FOR_DFU
-        elapsed_in_ms = (k_uptime_get_32() - start);
+        now = k_uptime_get_32();
+        elapsed_in_ms = (int)(now - start);
+        start = now;
 #endif
         timeout_in_ms -= elapsed_in_ms;
     }


### PR DESCRIPTION
Fixes #2841.

`boot_serial_read_console()` sampled a timestamp just before `f->read()` and took a second one right after it, so the only thing subtracted from `timeout_in_ms` was the time spent inside the read. Everything else in the iteration went uncharged: the watchdog feed, the decode and dispatch of a received line, the loop overhead, and the two `k_uptime_get_32()` calls themselves. On a core without a hardware divider the uptime read is a 64-bit software division, and that pair of calls is what dominates a loop that mostly finds no input.

The result is a window that runs several times longer than the configured timeout, and the overshoot grows the slower the core is.

This patch samples the timestamp once before the loop and rolls it forward at the bottom of each iteration. The iteration is charged in full, including the timekeeping, and one uptime read per iteration replaces two. `timeout_in_ms -= elapsed_in_ms;` is left in place, so this does not conflict with #2830.

### Measured

STM32C071 (Cortex-M0+, 48 MHz), same image before and after, boot time about 1 s. Elapsed is measured from the host as the time until the application answers on its own bus.

| scenario | before | after | expected |
| --- | --- | --- | --- |
| `CONFIG_BOOT_SERIAL_WAIT_FOR_DFU_TIMEOUT=5000`, no serial activity at all | 22.6 s | 6.0 s | ~6 s |

The other two cases need `CONFIG_BOOT_SERIAL_INACTIVITY_TIMEOUT` from #2830, which is not merged, so they are listed separately rather than as evidence for this patch on its own. Both used a 30000 ms inactivity timeout:

| scenario | before | after | expected |
| --- | --- | --- | --- |
| boot mode entered, session abandoned | 165.2 s | 34.6 s | ~33 s |
| session started in the every-boot window, then silence | 184.8 s | 36.1 s | ~38 s |

Both configurations above were also built and run on hardware with this patch applied. A build with `MCUBOOT_SERIAL_WAIT_FOR_DFU` undefined was not exercised, but that path is unchanged: `start` lives in the same `#ifdef` as its uses, and `elapsed_in_ms` stays 0 exactly as before.
