### PR TITLE
boot: boards: add board conf file for frdm_mcxl255

### DIFF
--- a/boot/zephyr/boards/frdm_mcxl255_mcxl255_cpu0.conf
+++ b/boot/zephyr/boards/frdm_mcxl255_mcxl255_cpu0.conf
@@ -1,0 +1,5 @@
+# Copyright 2026 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BOOT_GO_HOOKS=y
+CONFIG_MCUBOOT_ACTION_HOOKS=y


### PR DESCRIPTION
Add board config for frdm_mcxl255 with configuration to enable build with mcuboot hooks. They are used to setup appropriate flash access control before image update and before image boot.