### PR TITLE
fix: corrected vid/cid tag in docs/design.md 

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -149,8 +149,8 @@ struct image_tlv {
                                              * ...
                                              * 0xffa0 - 0xfffe
                                              */
-#define IMAGE_TLV_UUID_VID          0x80    /* Vendor unique identifier */
-#define IMAGE_TLV_UUID_CID          0x81    /* Device class unique identifier */
+#define IMAGE_TLV_UUID_VID          0x74    /* Vendor unique identifier */
+#define IMAGE_TLV_UUID_CID          0x75    /* Device class unique identifier */
 ```
 
 Optional type-length-value records (TLVs) containing image metadata are placed

--- a/docs/imgtool.md
+++ b/docs/imgtool.md
@@ -224,3 +224,26 @@ public key is incorporated into the bootloader). When the `full` option is used
 instead, the TLV area will contain the whole public key and thus the bootloader
 can be independent from the key(s). For more information on the additional
 requirements of this option, see the [design](design.md) document.
+
+## VID/CID Calculation
+VID and CID are generated using UUIDv5 (SHA-1).   
+VID: Generated using the standard DNS namespace:   
+`VID = UUIDv5(NAMESPACE_DNS, VID_String)`
+
+where `NAMESPACE_DNS = 6ba7b810-9dad-11d1-80b4-00c04fd430c8`.   
+
+CID: When VID is available, the generated 16-byte VID UUID is used as the namespace:     
+`CID = UUIDv5(VID_UUID, CID_String)`
+
+### UUIDv5 calculation:
+```txt
+SHA1(Namespace_UUID || UTF-8(Name))
+        ↓
+Take first 16 bytes
+        ↓
+Set UUID version = 5 and RFC 4122 variant
+        ↓
+16-byte UUID
+```
+The resulting 16-byte VID and CID are stored directly as the payload of the UUID_VID and UUID_CID TLVs.
+If VID/CID is already provided in raw UUID or 32-character hexadecimal format, it is directly converted to 16 bytes without UUIDv5 calculation

--- a/docs/imgtool.md
+++ b/docs/imgtool.md
@@ -225,7 +225,7 @@ instead, the TLV area will contain the whole public key and thus the bootloader
 can be independent from the key(s). For more information on the additional
 requirements of this option, see the [design](design.md) document.
 
-## VID/CID Calculation
+## [VID/CID Calculation](#VID/CID-Calculation)
 VID and CID are generated using UUIDv5 (SHA-1).   
 VID: Generated using the standard DNS namespace:   
 `VID = UUIDv5(NAMESPACE_DNS, VID_String)`
@@ -235,8 +235,8 @@ where `NAMESPACE_DNS = 6ba7b810-9dad-11d1-80b4-00c04fd430c8`.
 CID: When VID is available, the generated 16-byte VID UUID is used as the namespace:     
 `CID = UUIDv5(VID_UUID, CID_String)`
 
-### UUIDv5 calculation:
-```txt
+### [UUIDv5 calculation](#UUIDv5-calculation):
+```
 SHA1(Namespace_UUID || UTF-8(Name))
         ↓
 Take first 16 bytes
@@ -244,6 +244,6 @@ Take first 16 bytes
 Set UUID version = 5 and RFC 4122 variant
         ↓
 16-byte UUID
-```
+```   
 The resulting 16-byte VID and CID are stored directly as the payload of the UUID_VID and UUID_CID TLVs.
 If VID/CID is already provided in raw UUID or 32-character hexadecimal format, it is directly converted to 16 bytes without UUIDv5 calculation


### PR DESCRIPTION
# Description

This PR updates the MCUboot design documentation to align the VID/CID TLV definitions with the current implementation.

# Changes
- Update UUID_VID TLV from 0x80 to 0x74.
- Update UUID_CID TLV from 0x81 to 0x75.
- Document the VID/CID validation and calculation details consistently with the current imgtool and bootloader implementation.

This resolves the discrepancy reported in [#2847](https://github.com/mcu-tools/mcuboot/issues/2847).

# Reference
The current imgtool implementation and bootutil/image.h define:
IMAGE_TLV_UUID_VID = 0x74
IMAGE_TLV_UUID_CID = 0x75

The documentation is updated to reflect these values.

Fixes #2847