### PR TITLE
docs: release-notes: Add note on the USB DFU entrance rework

### DIFF
--- a/docs/release-notes.d/zephyr-usb-dfu-entrance-config.md
+++ b/docs/release-notes.d/zephyr-usb-dfu-entrance-config.md
@@ -1,0 +1,6 @@
+- Zephyr: USB DFU is now configured like serial recovery. `BOOT_USB_DFU`
+  enables USB DFU support and pulls in the USB stack, while
+  `BOOT_USB_DFU_WAIT` and `BOOT_USB_DFU_GPIO` are now independent and can
+  be enabled together. Existing configurations must be updated:
+  `BOOT_USB_DFU` has to be set alongside an entrance method, and
+  `BOOT_USB_DFU_NO` no longer exists.


### PR DESCRIPTION
The rework was merged without a release note, but it breaks old configs: BOOT_USB_DFU_NO is gone and BOOT_USB_DFU must now be enabled together with an entrance method.