### PR TITLE
boot: zephyr: use the generic mcuboot defaults on espressif socs

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -576,7 +576,7 @@ config BOOT_VALIDATE_SLOT0_ONCE
 
 config BOOT_PREFER_SWAP_OFFSET
 	bool "Prefer the newer swap offset algorithm"
-	default y if !$(dt_nodelabel_enabled,scratch_partition) && !SOC_FAMILY_ESPRESSIF_ESP32
+	default y if !$(dt_nodelabel_enabled,scratch_partition)
 	help
 	  If y, the BOOT_IMAGE_UPGRADE_MODE will default to using "offset" instead of "scratch".
 	  This is a separate bool config option, because Kconfig doesn't allow defaults to be

--- a/boot/zephyr/socs/esp32_procpu.conf
+++ b/boot/zephyr/socs/esp32_procpu.conf
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_VALIDATE_SLOT0=n
-CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n
 
 CONFIG_UART_CONSOLE=n

--- a/boot/zephyr/socs/esp32_procpu.conf
+++ b/boot/zephyr/socs/esp32_procpu.conf
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_UPGRADE_ONLY=y
 CONFIG_BOOT_VALIDATE_SLOT0=n
 CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n

--- a/boot/zephyr/socs/esp32c2.conf
+++ b/boot/zephyr/socs/esp32c2.conf
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_UPGRADE_ONLY=y
 CONFIG_BOOT_VALIDATE_SLOT0=n
 CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n

--- a/boot/zephyr/socs/esp32c2.conf
+++ b/boot/zephyr/socs/esp32c2.conf
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_VALIDATE_SLOT0=n
-CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n
 
 CONFIG_UART_CONSOLE=n

--- a/boot/zephyr/socs/esp32c3.conf
+++ b/boot/zephyr/socs/esp32c3.conf
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_VALIDATE_SLOT0=n
-CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n
 
 CONFIG_UART_CONSOLE=n

--- a/boot/zephyr/socs/esp32c3.conf
+++ b/boot/zephyr/socs/esp32c3.conf
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_UPGRADE_ONLY=y
 CONFIG_BOOT_VALIDATE_SLOT0=n
 CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n

--- a/boot/zephyr/socs/esp32c5_hpcore.conf
+++ b/boot/zephyr/socs/esp32c5_hpcore.conf
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_VALIDATE_SLOT0=n
-CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n
 
 CONFIG_UART_CONSOLE=n

--- a/boot/zephyr/socs/esp32c5_hpcore.conf
+++ b/boot/zephyr/socs/esp32c5_hpcore.conf
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_UPGRADE_ONLY=y
 CONFIG_BOOT_VALIDATE_SLOT0=n
 CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n

--- a/boot/zephyr/socs/esp32c61.conf
+++ b/boot/zephyr/socs/esp32c61.conf
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_VALIDATE_SLOT0=n
-CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n
 
 CONFIG_UART_CONSOLE=n

--- a/boot/zephyr/socs/esp32c61.conf
+++ b/boot/zephyr/socs/esp32c61.conf
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_UPGRADE_ONLY=y
 CONFIG_BOOT_VALIDATE_SLOT0=n
 CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n

--- a/boot/zephyr/socs/esp32c6_hpcore.conf
+++ b/boot/zephyr/socs/esp32c6_hpcore.conf
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_UPGRADE_ONLY=y
 CONFIG_BOOT_VALIDATE_SLOT0=n
 CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n

--- a/boot/zephyr/socs/esp32c6_hpcore.conf
+++ b/boot/zephyr/socs/esp32c6_hpcore.conf
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_VALIDATE_SLOT0=n
-CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n
 
 CONFIG_UART_CONSOLE=n

--- a/boot/zephyr/socs/esp32h2.conf
+++ b/boot/zephyr/socs/esp32h2.conf
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_VALIDATE_SLOT0=n
-CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n
 
 CONFIG_UART_CONSOLE=n

--- a/boot/zephyr/socs/esp32h2.conf
+++ b/boot/zephyr/socs/esp32h2.conf
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_UPGRADE_ONLY=y
 CONFIG_BOOT_VALIDATE_SLOT0=n
 CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n

--- a/boot/zephyr/socs/esp32p4_hpcore.conf
+++ b/boot/zephyr/socs/esp32p4_hpcore.conf
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_VALIDATE_SLOT0=n
-CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n
 
 CONFIG_UART_CONSOLE=n

--- a/boot/zephyr/socs/esp32p4_hpcore.conf
+++ b/boot/zephyr/socs/esp32p4_hpcore.conf
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_UPGRADE_ONLY=y
 CONFIG_BOOT_VALIDATE_SLOT0=n
 CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n

--- a/boot/zephyr/socs/esp32s2.conf
+++ b/boot/zephyr/socs/esp32s2.conf
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_VALIDATE_SLOT0=n
-CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n
 
 CONFIG_UART_CONSOLE=n

--- a/boot/zephyr/socs/esp32s2.conf
+++ b/boot/zephyr/socs/esp32s2.conf
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_UPGRADE_ONLY=y
 CONFIG_BOOT_VALIDATE_SLOT0=n
 CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n

--- a/boot/zephyr/socs/esp32s31_hpcore.conf
+++ b/boot/zephyr/socs/esp32s31_hpcore.conf
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_VALIDATE_SLOT0=n
-CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n
 
 CONFIG_UART_CONSOLE=n

--- a/boot/zephyr/socs/esp32s31_hpcore.conf
+++ b/boot/zephyr/socs/esp32s31_hpcore.conf
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_UPGRADE_ONLY=y
 CONFIG_BOOT_VALIDATE_SLOT0=n
 CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n

--- a/boot/zephyr/socs/esp32s3_procpu.conf
+++ b/boot/zephyr/socs/esp32s3_procpu.conf
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_VALIDATE_SLOT0=n
-CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n
 
 CONFIG_UART_CONSOLE=n

--- a/boot/zephyr/socs/esp32s3_procpu.conf
+++ b/boot/zephyr/socs/esp32s3_procpu.conf
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 
-CONFIG_BOOT_UPGRADE_ONLY=y
 CONFIG_BOOT_VALIDATE_SLOT0=n
 CONFIG_BOOT_SIGNATURE_TYPE_NONE=y
 CONFIG_BOOT_BANNER=n


### PR DESCRIPTION
Drop the Espressif-only overrides that forced overwrite-only, no signature check and no primary slot validation, so these SoCs follow the same defaults as every other target: swap using offset, RSA signatures and slot 0 validation.
