### PR TITLE
boot: zephyr: fix image selection in flash write block size checks

### DIFF
--- a/boot/zephyr/flash_check.c
+++ b/boot/zephyr/flash_check.c
@@ -26,8 +26,7 @@ bool swap_write_block_size_check(struct boot_loader_state *state)
 #endif
 
 #ifdef MCUBOOT_SLOT0_EXPECTED_WRITE_SIZE
-    flash_write_block_size_pri = flash_get_write_block_size(
-                                              state->imgs[0][BOOT_SLOT_PRIMARY].area->fa_dev);
+    flash_write_block_size_pri = flash_get_write_block_size(BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY)->fa_dev);
 
     if (flash_write_block_size_pri != MCUBOOT_SLOT0_EXPECTED_WRITE_SIZE) {
         BOOT_LOG_DBG("Discrepancy, slot0 expected write block size: %d, actual: %d",
@@ -36,8 +35,7 @@ bool swap_write_block_size_check(struct boot_loader_state *state)
 #endif
 
 #ifdef MCUBOOT_SLOT1_EXPECTED_WRITE_SIZE
-    flash_write_block_size_sec = flash_get_write_block_size(
-                                              state->imgs[0][BOOT_SLOT_SECONDARY].area->fa_dev);
+    flash_write_block_size_sec = flash_get_write_block_size(BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY)->fa_dev);
 
     if (flash_write_block_size_sec != MCUBOOT_SLOT1_EXPECTED_WRITE_SIZE) {
         BOOT_LOG_DBG("Discrepancy, slot1 expected write block size: %d, actual: %d",


### PR DESCRIPTION
Firstly, this pr don't matter the control flow, since the `swap_write_block_size_check` always return true.

Using BOOT_IMG_AREA ensures the flash_get_write_block_size calls follow the current image index in state->curr_img_idx.

```c
#if (BOOT_IMAGE_NUMBER > 1)
#define BOOT_CURR_IMG(state) ((state)->curr_img_idx)
#else
#define BOOT_CURR_IMG(state) 0
#endif

#define BOOT_IMG(state, slot) ((state)->imgs[BOOT_CURR_IMG(state)][(slot)])
#define BOOT_IMG_AREA(state, slot) (BOOT_IMG(state, slot).area)
```