### PR TITLE
boot: board: nxp: Fix mimxrt1050_evk RAM overflow

### DIFF
--- a/boot/zephyr/boards/mimxrt1050_evk_mimxrt1052_hyperflash_ram_load.overlay
+++ b/boot/zephyr/boards/mimxrt1050_evk_mimxrt1052_hyperflash_ram_load.overlay
@@ -44,11 +44,11 @@
 
 	mcuboot_sdram: memory@0 {
 		compatible = "mmio-sram";
-		reg = <0x0 DT_SIZE_K(30)>;
+		reg = <0x0 DT_SIZE_K(64)>;
 	};
 
-	image_sdram: memory@8000 {
+	image_sdram: memory@10000 {
 		compatible = "mmio-sram";
-		reg = <0x8000 DT_SIZE_M(3)>;
+		reg = <0x10000 DT_SIZE_M(3)>;
 	};
 };


### PR DESCRIPTION
In case of DT overlay for RAM loading MCUboot image RAM size portion for MCUboot wasn't enough. This commit increases the size from 30 kB to 64 kB.